### PR TITLE
Fix a bug on identifying that a feed already exists.

### DIFF
--- a/GoogleReader.m
+++ b/GoogleReader.m
@@ -486,7 +486,7 @@ enum GoogleReaderStatus {
 		{
 			LOG_EXPR(feed);
 			NSString * feedID = [feed objectForKey:@"id"];
-			NSString * feedURL = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@""];
+			NSString * feedURL = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:NULL range:NSMakeRange(0, 5)];
 			
 			NSString * folderName = nil;
 			


### PR DESCRIPTION
Google ID for feeds is the string "feed/" followed by the URL of the feed.
Don't be fooled by URLs having "feed/" inside them (like most Wordpress feeds)...
