### PR TITLE
Date format conversion error

### DIFF
--- a/RefreshManager.m
+++ b/RefreshManager.m
@@ -575,6 +575,7 @@ typedef enum {
 		[myRequest setUserInfo:[NSDictionary dictionaryWithObjectsAndKeys:folder, @"folder", aItem, @"log", nil]];
 		[myRequest setDelegate:self];
 		[myRequest setDidFinishSelector:@selector(folderRefreshCompleted:)];
+		[myRequest setTimeOutSeconds:20];
 	} else if (IsGoogleReaderFolder(folder)) {
 		myRequest = [[GoogleReader sharedManager] refreshFeed:folder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:force];
 	}


### PR DESCRIPTION
I'm running a build from the current code, and when I update my RSS feed from Atlassian FishEye I get a bunch of errors in my console:

```
27/03/12 11:48:31.095 AM ViennaBeta: connessione = NO
27/03/12 11:48:31.108 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.108 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.109 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.109 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.110 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.110 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.145 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.275 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.356 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.515 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.563 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.566 AM ViennaBeta: Conversion error: 2011-10-17T08:16:22-07:00
27/03/12 11:48:31.566 AM ViennaBeta: Conversion error: 2011-10-17T08:16:22-07:00
27/03/12 11:48:31.566 AM ViennaBeta: Conversion error: 2011-01-10T01:04:56-08:00
27/03/12 11:48:31.567 AM ViennaBeta: Conversion error: 2010-10-25T03:08:37-07:00
27/03/12 11:48:31.567 AM ViennaBeta: Conversion error: 2010-06-02T01:19:12-07:00
27/03/12 11:48:31.567 AM ViennaBeta: Conversion error: 2010-06-01T18:04:14-07:00
27/03/12 11:48:31.568 AM ViennaBeta: Conversion error: 2010-06-01T17:59:55-07:00
27/03/12 11:48:31.568 AM ViennaBeta: Conversion error: 2010-04-12T17:49:57-07:00
27/03/12 11:48:31.568 AM ViennaBeta: Conversion error: 2010-04-12T17:49:57-07:00
27/03/12 11:48:31.568 AM ViennaBeta: Conversion error: 2010-04-12T17:43:57-07:00
27/03/12 11:48:31.569 AM ViennaBeta: Conversion error: 2010-04-12T17:43:42-07:00
27/03/12 11:48:31.569 AM ViennaBeta: Conversion error: 2010-04-02T19:36:34-07:00
27/03/12 11:48:31.569 AM ViennaBeta: Conversion error: 2010-02-18T10:49:35-08:00
27/03/12 11:48:31.570 AM ViennaBeta: Conversion error: 2010-02-17T20:43:04-08:00
27/03/12 11:48:31.570 AM ViennaBeta: Conversion error: 2010-01-25T18:15:00-08:00
27/03/12 11:48:31.570 AM ViennaBeta: Conversion error: 2010-01-18T14:50:39-08:00
27/03/12 11:48:31.571 AM ViennaBeta: Conversion error: 2009-12-02T16:10:21-08:00
27/03/12 11:48:31.571 AM ViennaBeta: Conversion error: 2009-12-02T16:02:29-08:00
27/03/12 11:48:31.571 AM ViennaBeta: Conversion error: 2009-12-02T15:52:58-08:00
27/03/12 11:48:31.572 AM ViennaBeta: Conversion error: 2009-12-02T15:52:04-08:00
27/03/12 11:48:31.572 AM ViennaBeta: Conversion error: 2009-12-02T15:47:39-08:00
27/03/12 11:48:31.572 AM ViennaBeta: Conversion error: 2009-12-02T15:31:13-08:00
27/03/12 11:48:31.572 AM ViennaBeta: Conversion error: 2009-12-02T15:20:54-08:00
27/03/12 11:48:31.599 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.603 AM ViennaBeta: connessione = YES
27/03/12 11:48:31.872 AM ViennaBeta: connessione = YES
```

Running directly from source there are a few extra console messages from -[RefreshManager nqRequestStarted:] which implies the "connessione" messages are just my other feeds updating.'

This feed works fine in the 2.6.0 release.
