### PR TITLE
Remove unused notification observer with non-existent selector

### DIFF
--- a/FoldersTree.m
+++ b/FoldersTree.m
@@ -151,7 +151,6 @@
 	[nc addObserver:self selector:@selector(handleFolderNameChange:) name:@"MA_Notify_FolderNameChanged" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderAdded:) name:@"MA_Notify_FolderAdded" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderDeleted:) name:@"MA_Notify_FolderDeleted" object:nil];
-	[nc addObserver:self selector:@selector(autoCollapseFolder:) name:@"MA_Notify_AutoCollapseFolder" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderFontChange:) name:@"MA_Notify_FolderFontChange" object:nil];
 	[nc addObserver:self selector:@selector(handleShowFolderImagesChange:) name:@"MA_Notify_ShowFolderImages" object:nil];
 	[nc addObserver:self selector:@selector(handleAutoSortFoldersTreeChange:) name:@"MA_Notify_AutoSortFoldersTreeChange" object:nil];


### PR DESCRIPTION
I'm a graduate student developing a research prototype plugin for the clang static analyzer that looks for problems with reflection in Objective-C. We ran our prototype on Vienna and found a minor but interesting (from our perspective) issue:

-[FoldersTree initialiseFoldersTree] registers itself as an observer for a bunch of notifications from the default notification center. For one of those notifications ("MA_Notify_AutoCollapseFolder") it specifies a call-back selector that doesn't exist on FoldersTree: (autoCollapseFolder:). This is kind of like a dangling pointer: if anyone were to post a "MA_Notify_AutoCollapseFolder" notification, this would throw an unrecognized selector exception.

Fortunately, it doesn't look like "MA_Notify_AutoCollapseFolder" is ever used, so it is safe to just remove the line that adds the observer. The commit in this pull request does just this.
