### PR TITLE
Fix issue #90 : replace newlines with spaces in title

### DIFF
--- a/RichXMLParser.m
+++ b/RichXMLParser.m
@@ -1148,7 +1148,7 @@
  */
 -(NSString *)stripHTMLTags:(NSString *)htmlString
 {
-	NSMutableString * rawString = [[NSMutableString alloc] initWithString:htmlString];
+	NSMutableString * rawString = [[NSMutableString alloc] initWithString:[[htmlString componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]] componentsJoinedByString:@" "]];
 	NSUInteger openTagStartIndex = 0;
 	
 	while ((openTagStartIndex = [rawString indexOfCharacterInString:'<' afterIndex:openTagStartIndex]) != NSNotFound)


### PR DESCRIPTION
Titles containing newlines were truncated when displayed in the "Report" layout.

This completes commit 5a0661e7377aab18aaac47b0ad5ef7c6d9536ad5
