### PR TITLE
Refreshes should not perturb the user

### DIFF
--- a/ArticleController.m
+++ b/ArticleController.m
@@ -125,7 +125,6 @@
 		[nc addObserver:self selector:@selector(handleFolderNameChange:) name:@"MA_Notify_FolderNameChanged" object:nil];
 		[nc addObserver:self selector:@selector(handleFolderUpdate:) name:@"MA_Notify_FoldersUpdated" object:nil];
 		[nc addObserver:self selector:@selector(handleRefreshArticle:) name:@"MA_Notify_ArticleViewChange" object:nil];
-        [nc addObserver:self selector:@selector(handleArticleListStateChange:) name:@"MA_Notify_ArticleListStateChange" object:nil];
         
         operationQueue = [[NSOperationQueue alloc] init];
     }
@@ -884,15 +883,6 @@
 -(void)handleRefreshArticle:(NSNotification *)nc
 {
 	[mainArticleView handleRefreshArticle:nc];
-}
-
-// TODO this is being called too often by sync operations. We should try to avoid
-// querying the database so often. Need to look into having the sync operations know
-// when everything has been completed and only query the database once.
--(void)handleArticleListStateChange:(NSNotification *)nc
-{
-    [mainArticleView refreshFolder:MA_Refresh_ReloadFromDatabase];
-    //[mainArticleView refreshFolder:MA_Refresh_RedrawList];
 }
 
 /* handleFolderUpdate

--- a/ArticleListView.m
+++ b/ArticleListView.m
@@ -103,7 +103,6 @@ static const CGFloat MA_Minimum_Article_Pane_Width = 80;
 	[nc addObserver:self selector:@selector(handleArticleListFontChange:) name:@"MA_Notify_ArticleListFontChange" object:nil];
 	[nc addObserver:self selector:@selector(handleReadingPaneChange:) name:@"MA_Notify_ReadingPaneChange" object:nil];
 	[nc addObserver:self selector:@selector(handleLoadFullHTMLChange:) name:@"MA_Notify_LoadFullHTMLChange" object:nil];
-    [nc addObserver:self selector:@selector(handleArticleListStateChange:) name:@"MA_Notify_ArticleListStateChange" object:nil];
 
 	// Make us the frame load and UI delegate for the web view
 	[articleText setUIDelegate:self];
@@ -864,14 +863,6 @@ static const CGFloat MA_Minimum_Article_Pane_Width = 80;
 {
 	[self setTableViewFont];
 	if (self == [articleController mainArticleView])
-	{
-		[articleList reloadData];
-	}
-}
-
--(void)handleArticleListStateChange:(NSNotification *)note
-{
-    if (self == [articleController mainArticleView])
 	{
 		[articleList reloadData];
 	}


### PR DESCRIPTION
Refreshes should be performed in the background of user's activity and must not disturb his reading.

Issue raised at http://www.cocoaforge.com/viewtopic.php?f=18&t=24658. Revert some of the changes since Vienna 2.5
