### PR TITLE
Fix username/passwords feeds

### DIFF
--- a/RefreshManager.m
+++ b/RefreshManager.m
@@ -478,6 +478,8 @@ static NSRecursiveLock * articlesUpdate_lock;
             [myRequest addRequestHeader:@"If-Modified-Since" value:theLastUpdateString];
         }
 		[myRequest setUserInfo:[NSDictionary dictionaryWithObjectsAndKeys:folder, @"folder", aItem, @"log", [NSNumber numberWithInt:MA_Refresh_Feed], @"type", nil]];
+		[myRequest setUsername:[folder username]];
+		[myRequest setPassword:[folder password]];
 		[myRequest setDelegate:self];
 		[myRequest setDidFinishSelector:@selector(folderRefreshCompleted:)];
 		[myRequest setDidFailSelector:@selector(folderRefreshFailed:)];


### PR DESCRIPTION
Fix feeds requiring username/passwords (reminder : for local feeds only, as Google Reader does not support authenticated feeds)
