### PR TITLE
Treat https:// links the same way we treat http:// links.

### DIFF
--- a/src/BrowserPane.m
+++ b/src/BrowserPane.m
@@ -449,7 +449,7 @@
 		{
 			[rssPageURL release];
 			rssPageURL = [arrayOfLinks objectAtIndex:0];
-			if (![rssPageURL hasPrefix:@"http:"])
+			if (![rssPageURL hasPrefix:@"http:"] && ![rssPageURL hasPrefix:@"https:"])
 				rssPageURL = [[self viewLink] stringByAppendingString:rssPageURL];
 			[rssPageURL retain];
 			[self showRssPageButton:YES];

--- a/src/GoogleReader.m
+++ b/src/GoogleReader.m
@@ -570,7 +570,7 @@ JSONDecoder * jsonDecoder;
 		if (feedID == nil)
 			break;
 		NSString * feedURL = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
-		if (![feedURL hasPrefix:@"http"])
+		if (![feedURL hasPrefix:@"http:"] && ![feedURL hasPrefix:@"https:"])
             feedURL = [NSString stringWithFormat:@"http://www.google.com/reader/public/atom/%@", feedURL];
 		
 		NSString * folderName = nil;

--- a/src/NewSubscription.m
+++ b/src/NewSubscription.m
@@ -386,7 +386,7 @@
 	if ([RichXMLParser extractFeeds:urlContent toArray:linkArray])
 	{
 		NSString * feedPart = [linkArray objectAtIndex:0];
-		if (![feedPart hasPrefix:@"http:"])
+		if (![feedPart hasPrefix:@"http:"] && ![feedPart hasPrefix:@"https:"])
 		{
 			if (![urlString hasSuffix:@"/"])
 				urlString = [urlString stringByAppendingString:@"/"];

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -775,7 +775,7 @@ static NSRecursiveLock * articlesUpdate_lock;
 			// Synthesize feed link if it is missing
 			if (feedLink == nil || [feedLink isBlank])
 				feedLink = [[folder feedURL] baseURL];
-			if (feedLink != nil && ![feedLink hasPrefix:@"http"])
+			if (feedLink != nil && ![feedLink hasPrefix:@"http:"] && ![feedLink hasPrefix:@"https:"])
 				feedLink = [[NSURL URLWithString:feedLink relativeToURL:url] absoluteString];
 
 			
@@ -830,7 +830,7 @@ static NSRecursiveLock * articlesUpdate_lock;
 				[article setBody:[newsItem description]];
 				[article setTitle:[newsItem title]];
 				NSString * articleLink = [newsItem link];
-				if (![articleLink hasPrefix:@"http"])
+				if (![articleLink hasPrefix:@"http:"] && ![articleLink hasPrefix:@"https:"])
 					articleLink = [[NSURL URLWithString:articleLink relativeToURL:url] absoluteString];
 				if (articleLink == nil)
 					articleLink = feedLink;

--- a/src/RichXMLParser.m
+++ b/src/RichXMLParser.m
@@ -846,7 +846,7 @@
 				NSString * theLink = [[subTree valueOfAttribute:@"href"] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 				if (theLink != nil)
 				{
-					if ((linkBaseURL != nil) && ![theLink hasPrefix:@"http://"])
+					if ((linkBaseURL != nil) && ![theLink hasPrefix:@"http://"] && ![theLink hasPrefix:@"https://"])
 					{
 						NSURL * theLinkURL = [NSURL URLWithString:theLink relativeToURL:linkBaseURL];
 						[self setLink:(theLinkURL != nil) ? [theLinkURL absoluteString] : theLink];

--- a/src/StringExtensions.m
+++ b/src/StringExtensions.m
@@ -67,7 +67,7 @@
 			
 			// Now extract the source parameter
 			NSString * srcPath = [self substringWithRange:srcRange];
-			if (![srcPath hasPrefix:@"http://"])
+			if (![srcPath hasPrefix:@"http://"] && ![srcPath hasPrefix:@"https://"])
 			{
 				NSString * escapedSrcPath = [srcPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 				if (escapedSrcPath != nil)
@@ -125,7 +125,7 @@
 
 			// Now extract the source parameter
 			NSString * srcPath = [self substringWithRange:srcRange];
-			if (![srcPath hasPrefix:@"http://"])
+			if (![srcPath hasPrefix:@"http://"] && ![srcPath hasPrefix:@"https://"])
 			{
 				NSString * escapedSrcPath = [srcPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 				if (escapedSrcPath != nil)
@@ -366,6 +366,8 @@ static NSMutableDictionary * entityMap = nil;
 
 	if ([self hasPrefix:@"http://"])
 		beginning = 6;
+	if ([self hasPrefix:@"https://"])
+		beginning = 7;
 	if (index > beginning && [self characterAtIndex:index] == '/')
 		--index;
 	while (index >= beginning && [self characterAtIndex:index] != '/')


### PR DESCRIPTION
Problem spotted at http://forums.cocoaforge.com/viewtopic.php?t=25229&p=135113 was due to the fact that https:// links weren't recognized as absolute, and were unduly escaped.
