### PR TITLE
Handle private RSS/Atom feeds whose authentication mechanism would require a cookie.…

### DIFF
--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -468,9 +468,12 @@ static RefreshManager * _refreshManager = nil;
             [myRequest addRequestHeader:@"If-Modified-Since" value:theLastUpdateString];
         }
 		[myRequest setUserInfo:[NSDictionary dictionaryWithObjectsAndKeys:folder, @"folder", aItem, @"log", [NSNumber numberWithInt:MA_Refresh_Feed], @"type", nil]];
-		[myRequest setUsername:[folder username]];
-		[myRequest setPassword:[folder password]];
-		[myRequest setUseCookiePersistence:NO];
+		if ([folder username] != nil)
+		{
+			[myRequest setUsername:[folder username]];
+			[myRequest setPassword:[folder password]];
+			[myRequest setUseCookiePersistence:NO];
+		}
 		[myRequest setDelegate:self];
 		[myRequest setDidFinishSelector:@selector(folderRefreshCompleted:)];
 		[myRequest setDidFailSelector:@selector(folderRefreshFailed:)];


### PR DESCRIPTION
, rather than via HTTP authentication.

Note : I haven't encountered one of these feeds yet, but apparently they exist. Might solve issue #126 , but I got not enough info to confirm...
