### PR TITLE
Update Localizable.strings

### DIFF
--- a/lproj/de.lproj/Localizable.strings
+++ b/lproj/de.lproj/Localizable.strings
@@ -322,9 +322,9 @@
 "Get Info..." = "Information...";
 "Open Web Location..." = "Web-Adresse öffnen...";
 "Refresh Folder Images" = "Ordner-Icons aktualisieren";
-"Report" = "Überschriften & Text separat";
-"Condensed" = "Kompakt";
-"Unified" = "Kompakt mit Zusammenfassung";
+"Report" = "Horizontal";
+"Condensed" = "Vertikal";
+"Unified" = "Widescreen";
 "Summary" = "Zusammenfassung";
 "Blog With..." = "Bloggen mit...";
 "Blog with %@" = "Bloggen mit %@";


### PR DESCRIPTION
Changed the German translation for the screen layouts to „Horizontal“ (Report), „Vertikal“ (Condensed) and „Widescreen“ (Unified) because I think the current names can be misleading. Not 100% sure about Widescreen. Fullscreen could be misleading too but it's closer to what I think would fit. Maybe something like „No Headline“/„No Headline Column“?

Maybe it would make sense to change the names in the English version as well? I don't really understand what they're supposed to mean either but then again I'm not a native speaker.

And I have no idea where to do that.
