### PR TITLE
Support for directories containing spaces

### DIFF
--- a/configs/scripts/Sparkle-setup.sh
+++ b/configs/scripts/Sparkle-setup.sh
@@ -19,6 +19,6 @@ esac
 
 INFO="${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/../Info.plist"
 
-/usr/libexec/PlistBuddy $INFO -c "add SUFeedURL string $SU_FEED_URL"
-/usr/libexec/PlistBuddy $INFO -c "set :SUFeedURL $SU_FEED_URL"
+/usr/libexec/PlistBuddy "$INFO" -c "add SUFeedURL string $SU_FEED_URL"
+/usr/libexec/PlistBuddy "$INFO" -c "set :SUFeedURL $SU_FEED_URL"
 exit ${?}


### PR DESCRIPTION
You need to put $INFO variables between " to support script execution on directory with spaces.
