### PR TITLE
Adapt the browser tabs to OS X Yosemite (fix issue #330)

### DIFF
--- a/src/BrowserView.m
+++ b/src/BrowserView.m
@@ -47,13 +47,12 @@
 	[[tabView tabViewItemAtIndex:0] setLabel:NSLocalizedString(@"Articles", nil)];
 	
 	//Metal is the default
-	[tabBarControl setStyleNamed:@"Unified"];
+	[tabBarControl setStyleNamed:@"Card"];
 	
 	[tabBarControl setHideForSingleTab:YES];
 	[tabBarControl setUseOverflowMenu:YES];
 	[tabBarControl setAllowsBackgroundTabClosing:YES];
 	[tabBarControl setAutomaticallyAnimates:NO];
-	[tabBarControl setSizeCellsToFit:YES];
 	[tabBarControl setCellMinWidth:60];
 	[tabBarControl setCellMaxWidth:350];
 


### PR DESCRIPTION
Setting to YES the sizeCellsToFit property made the ‘Articles’ pane to shrink to be invisible when many panes were loaded.
The ‘Card’ style is an acceptable compromise for OS X Mavericks and Yosemite.
