### PR TITLE
Switched some NSAutoreleasePool calls to @autoreleasepool 

### DIFF
--- a/3rdparty/JSONKit/JSONKit.m
+++ b/3rdparty/JSONKit/JSONKit.m
@@ -117,7 +117,7 @@
 
 //#import <Foundation/Foundation.h>
 #import <Foundation/NSArray.h>
-#import <Foundation/NSAutoreleasePool.h>
+//#import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSData.h>
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSException.h>
@@ -635,25 +635,24 @@ static NSNumberInitWithUnsignedLongLongImp _jk_NSNumberInitWithUnsignedLongLongI
 extern void jk_collectionClassLoadTimeInitialization(void) __attribute__ ((constructor));
 
 void jk_collectionClassLoadTimeInitialization(void) {
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; // Though technically not required, the run time environment at load time initialization may be less than ideal.
-  
-  _JKArrayClass             = objc_getClass("JKArray");
-  _JKArrayInstanceSize      = jk_max(16UL, class_getInstanceSize(_JKArrayClass));
-  
-  _JKDictionaryClass        = objc_getClass("JKDictionary");
-  _JKDictionaryInstanceSize = jk_max(16UL, class_getInstanceSize(_JKDictionaryClass));
-  
-  // For JSONDecoder...
-  _jk_NSNumberClass = [NSNumber class];
-  _jk_NSNumberAllocImp = (NSNumberAllocImp)[NSNumber methodForSelector:@selector(alloc)];
-  
-  // Hacktacular.  Need to do it this way due to the nature of class clusters.
-  id temp_NSNumber = [NSNumber alloc];
-  _jk_NSNumberInitWithUnsignedLongLongImp = (NSNumberInitWithUnsignedLongLongImp)[temp_NSNumber methodForSelector:@selector(initWithUnsignedLongLong:)];
-  [[temp_NSNumber init] release];
-  temp_NSNumber = NULL;
-  
-  [pool release]; pool = NULL;
+    // Though technically not required, the run time environment at load time initialization may be less than ideal.
+    @autoreleasepool {
+      _JKArrayClass             = objc_getClass("JKArray");
+      _JKArrayInstanceSize      = jk_max(16UL, class_getInstanceSize(_JKArrayClass));
+      
+      _JKDictionaryClass        = objc_getClass("JKDictionary");
+      _JKDictionaryInstanceSize = jk_max(16UL, class_getInstanceSize(_JKDictionaryClass));
+      
+      // For JSONDecoder...
+      _jk_NSNumberClass = [NSNumber class];
+      _jk_NSNumberAllocImp = (NSNumberAllocImp)[NSNumber methodForSelector:@selector(alloc)];
+      
+      // Hacktacular.  Need to do it this way due to the nature of class clusters.
+      id temp_NSNumber = [NSNumber alloc];
+      _jk_NSNumberInitWithUnsignedLongLongImp = (NSNumberInitWithUnsignedLongLongImp)[temp_NSNumber methodForSelector:@selector(initWithUnsignedLongLong:)];
+      [[temp_NSNumber init] release];
+      temp_NSNumber = NULL;
+    }
 }
 
 

--- a/src/BrowserPane.m
+++ b/src/BrowserPane.m
@@ -72,15 +72,13 @@
 
 + (void)load
 {
-	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
-	if (self == [BrowserPane class]) {
-		//These are synonyms
-		[self exposeBinding:@"isLoading"];
-		[self exposeBinding:@"isProcessing"];
-	}
-	
-	[pool drain];
+    @autoreleasepool {
+        if (self == [BrowserPane class]) {
+            //These are synonyms
+            [self exposeBinding:@"isLoading"];
+            [self exposeBinding:@"isProcessing"];
+        }
+    }
 }
 
 + (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key


### PR DESCRIPTION
Increased efficiency as per https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSAutoreleasePool_Class/Reference/Reference.html#//apple_ref/doc/uid/20000051-1722

I realise I have made a change to JSONKit but as the original code hasn't been modified in a couple of years I figured this was fairly safe...
