### PR TITLE
Adapt the browser tabs to OS X Yosemite

### DIFF
--- a/src/BrowserView.m
+++ b/src/BrowserView.m
@@ -53,7 +53,6 @@
 	[tabBarControl setUseOverflowMenu:YES];
 	[tabBarControl setAllowsBackgroundTabClosing:YES];
 	[tabBarControl setAutomaticallyAnimates:NO];
-	[tabBarControl setSizeCellsToFit:YES];
 	[tabBarControl setCellMinWidth:60];
 	[tabBarControl setCellMaxWidth:350];
 


### PR DESCRIPTION
Setting to YES the sizeCellsToFit property made the ‘Articles’ pane to shrink to be invisible where many panes were loaded.

Fix issue #330 ; replaces pull request #331
