### PR TITLE
disabled assertions for deployment config

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -8983,6 +8983,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -9044,6 +9045,7 @@
 				035B703F19E0E4AE00197334 /* StaticAnalyzer */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Deployment;
 		};
 		430C4AD6166172C70079C9FC /* Build configuration list for PBXAggregateTarget "Autorevision" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Fixes crash reported in issue #348.

Assertions should generally be disabled in release/deployment configs. 
The call to `[spinner stopAnimation:self]` with no matching startAnimation is safe as so doesn't need the assertion to block it in release.

[Some more info about why assertions shouldn't be present in release code](http://myok12.wordpress.com/2010/10/10/to-use-or-not-to-use-assertions/).
