### PR TITLE
Ensures that notifications order remain unchanged

### DIFF
--- a/src/NSNotificationAdditions.m
+++ b/src/NSNotificationAdditions.m
@@ -2,11 +2,15 @@
 
 @implementation NSNotificationCenter (NSNotificationCenterAdditions)
 - (void) postNotificationOnMainThread:(NSNotification *) notification {
-	[self performSelectorOnMainThread:@selector(postNotification:) withObject:notification waitUntilDone:NO];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self postNotification:notification];
+	});
 }
 
 - (void) postNotificationOnMainThreadWithName:(NSString *) name object:(id) object {
-	[self postNotificationOnMainThreadWithName:name object:object userInfo:nil];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self postNotificationName:name object:object];
+	});
 }
 
 - (void) postNotificationOnMainThreadWithName:(NSString *) name object:(id) object userInfo:(NSDictionary *) userInfo {


### PR DESCRIPTION
Follow up on issue #348 
One should not mix performSelectorOnMainThread and dispatch_async, as explained here : http://blackpixel.com/blog/2013/11/performselectoronmainthread-vs-dispatch-async.html
