### PR TITLE
Fix repeating articles issue with the Netflix feed

### DIFF
--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -815,6 +815,10 @@ static RefreshManager * _refreshManager = nil;
 			NSMutableArray * articleArray = [NSMutableArray array];
 			NSMutableArray * articleGuidArray = [NSMutableArray array];
 			
+			NSDate * itemAlternativeDate = [newFeed lastModified];
+			if (itemAlternativeDate == nil)
+				itemAlternativeDate = [NSDate date];
+
 			// Parse off items.
 			
 			for (FeedItem * newsItem in [newFeed items])
@@ -838,16 +842,22 @@ static RefreshManager * _refreshManager = nil;
 				NSUInteger articleIndex = [articleGuidArray indexOfObject:articleGuid];
 				if (articleIndex != NSNotFound)
 				{
-					if (articleDate == nil)
-						continue; // Skip this duplicate article
-					
 					// rebuild a complex guid which should eliminate most duplicates
-					articleGuid = [NSString stringWithFormat:@"%ld-%@-%@-%@", folderId, [NSString stringWithFormat:@"%1.3f", [articleDate timeIntervalSince1970]], [newsItem link], [newsItem title]];
+					if (articleDate == nil)
+						articleGuid = [NSString stringWithFormat:@"%ld-%@-%@", folderId, [newsItem link], [newsItem title]];
+					else
+						articleGuid = [NSString stringWithFormat:@"%ld-%@-%@-%@", folderId, [NSString stringWithFormat:@"%1.3f", [articleDate timeIntervalSince1970]], [newsItem link], [newsItem title]];
 				}
 				[articleGuidArray addObject:articleGuid];
 				
+				// set the article date if it is missing. We'll use the
+				// last modified date of the feed and set each article to be 1 second older than the
+				// previous one. So the array is effectively newest first.
 				if (articleDate == nil)
-					articleDate = [NSDate date];
+				{
+					articleDate = itemAlternativeDate;
+					itemAlternativeDate = [itemAlternativeDate dateByAddingTimeInterval:-1.0];
+				}
 				
 				Article * article = [[[Article alloc] initWithGuid:articleGuid] autorelease];
 				[article setFolderId:folderId];

--- a/src/RichXMLParser.m
+++ b/src/RichXMLParser.m
@@ -808,18 +808,6 @@
 		}
 	}
 
-	// Now scan the array and set the article date if it is missing. We'll use the
-	// last modified date of the feed and set each article to be 1 second older than the
-	// previous one. So the array is effectively newest first.
-	NSDate * itemDate = [self lastModified];
-	if (itemDate == nil)
-		itemDate = [NSDate date];
-	for (FeedItem * anItem in items)
-	{
-		if ([anItem date] == nil)
-			[anItem setDate:itemDate];
-		itemDate = [itemDate dateByAddingTimeInterval:-1.0];
-	}
 	return success;
 }
 


### PR DESCRIPTION
As discussed at <http://forums.cocoaforge.com/viewtopic.php?t=26612 : the Netflix feed does not include dates, and has the last movie repeated in the feed. So a guid value is duplicated within the feed, which is invalid.
Other problematic feed, like this one http://depeches.orange.mg/fluxrss.xml, have duplicate guids and ambiguous titles and links ; but the date can be usefully used to discriminate between different articles.
