### PR TITLE
Fix issue #348

### DIFF
--- a/src/RefreshManager.h
+++ b/src/RefreshManager.h
@@ -30,7 +30,7 @@
 	NSMutableArray * authQueue;
 	NSTimer * pumpTimer;
 	FeedCredentials * credentialsController;
-	//BOOL hasStarted;
+	BOOL hasStarted;
 	NSString * statusMessageDuringRefresh;
     SyncTypes syncType;
 	ASINetworkQueue *networkQueue;


### PR DESCRIPTION
Make sure that we are really handling a refresh of feeds (and not another kind of network activity) before posting a MA_Notify_RefreshStatus notification

This accurately fix issue #348
