### PR TITLE
fix for issue #351 aggressive URL encoding

### DIFF
--- a/src/StringExtensions.m
+++ b/src/StringExtensions.m
@@ -69,17 +69,13 @@
 			NSString * srcPath = [self substringWithRange:srcRange];
 			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"] && ![srcPath hasPrefix:@"data:"])
 			{
-				NSString * escapedSrcPath = [srcPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-				if (escapedSrcPath != nil)
-				{
-					NSURL * imgURL = [NSURL URLWithString:escapedSrcPath relativeToURL:imgBaseURL];
-					if (imgURL != nil)
-					{
-						srcPath = [imgURL absoluteString];
-						[self replaceCharactersInRange:srcRange withString:srcPath];
-						textLength = [self length];
-					}
-				}
+                NSURL * imgURL = [NSURL URLWithString:srcPath relativeToURL:imgBaseURL];
+                if (imgURL != nil)
+                {
+                    srcPath = [imgURL absoluteString];
+                    [self replaceCharactersInRange:srcRange withString:srcPath];
+                    textLength = [self length];
+                }
 			}
 			
 			// Start searching again from beyond the URL
@@ -127,13 +123,13 @@
 			NSString * srcPath = [self substringWithRange:srcRange];
 			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"] && ![srcPath hasPrefix:@"#"])
 			{
-					NSURL * anchorURL = [NSURL URLWithString:srcPath relativeToURL:anchorBaseURL];
-					if (anchorURL != nil)
-					{
-						srcPath = [anchorURL absoluteString];
-						[self replaceCharactersInRange:srcRange withString:srcPath];
-						textLength = [self length];
-					}
+                NSURL * anchorURL = [NSURL URLWithString:srcPath relativeToURL:anchorBaseURL];
+                if (anchorURL != nil)
+                {
+                    srcPath = [anchorURL absoluteString];
+                    [self replaceCharactersInRange:srcRange withString:srcPath];
+                    textLength = [self length];
+                }
 			}
 
 			// Start searching again from beyond the URL
@@ -181,17 +177,13 @@
 			NSString * srcPath = [self substringWithRange:srcRange];
 			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"])
 			{
-				NSString * escapedSrcPath = [srcPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-				if (escapedSrcPath != nil)
-				{
-					NSURL * iframeURL = [NSURL URLWithString:escapedSrcPath relativeToURL:imgBaseURL];
-					if (iframeURL != nil)
-					{
-						srcPath = [iframeURL absoluteString];
-						[self replaceCharactersInRange:srcRange withString:srcPath];
-						textLength = [self length];
-					}
-				}
+                NSURL * iframeURL = [NSURL URLWithString:srcPath relativeToURL:imgBaseURL];
+                if (iframeURL != nil)
+                {
+                    srcPath = [iframeURL absoluteString];
+                    [self replaceCharactersInRange:srcRange withString:srcPath];
+                    textLength = [self length];
+                }
 			}
 
 			// Start searching again from beyond the URL


### PR DESCRIPTION
Fixed issue #351 by removing stringByAppendingPercentEscapesUsingEncoding as the purpose of this method is to encode strings that are going to be part of a URL, e.g. a search query string of `xcode is funny # encoding` results in `https://duckduckgo.com/?q=xcode+is+funny+%23+encoding`.
