### PR TITLE
Fixes #418 - Moved viewDidLoad code into viewWillAppear

### DIFF
--- a/src/Preferences/AdvancedPreferencesViewController.m
+++ b/src/Preferences/AdvancedPreferencesViewController.m
@@ -29,15 +29,18 @@
 @implementation AdvancedPreferencesViewController
 
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
+- (instancetype)init {
+    return [super initWithNibName:@"AdvancedPreferencesView" bundle:nil];
+}
+
+- (void)viewWillAppear {
+    if([NSViewController instancesRespondToSelector:@selector(viewWillAppear)]) {
+        [super viewWillAppear];
+    }
     // Do view setup here.
     [self initializePreferences];
 }
 
-- (instancetype)init {
-    return [super initWithNibName:@"AdvancedPreferencesView" bundle:nil];
-}
 
 #pragma mark - MASPreferencesViewController
 

--- a/src/Preferences/AppearancePreferencesViewController.m
+++ b/src/Preferences/AppearancePreferencesViewController.m
@@ -42,8 +42,16 @@ int availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24 };
 
 @implementation AppearancePreferencesViewController
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
+
+- (instancetype)init {
+    return [super initWithNibName:@"AppearancePreferencesView" bundle:nil];
+}
+
+
+- (void)viewWillAppear {
+    if([NSViewController instancesRespondToSelector:@selector(viewWillAppear)]) {
+        [super viewWillAppear];
+    }
     // Do view setup here.
     [self initializePreferences];
     
@@ -53,11 +61,7 @@ int availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24 };
     [nc addObserver:self selector:@selector(handleReloadPreferences:) name:@"MA_Notify_ArticleListFontChange" object:nil];
     [nc addObserver:self selector:@selector(handleReloadPreferences:) name:@"MA_Notify_MinimumFontSizeChange" object:nil];
     [nc addObserver:self selector:@selector(handleReloadPreferences:) name:@"MA_Notify_PreferenceChange" object:nil];
-
-}
-
-- (instancetype)init {
-    return [super initWithNibName:@"AppearancePreferencesView" bundle:nil];
+    
 }
 
 #pragma mark - MASPreferencesViewController

--- a/src/Preferences/GeneralPreferencesViewController.m
+++ b/src/Preferences/GeneralPreferencesViewController.m
@@ -37,8 +37,16 @@
 
 @implementation GeneralPreferencesViewController
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
+
+- (instancetype)init {
+    return [super initWithNibName:@"GeneralPreferencesView" bundle:nil];
+}
+
+
+- (void)viewWillAppear {
+    if([NSViewController instancesRespondToSelector:@selector(viewWillAppear)]) {
+        [super viewWillAppear];
+    }
     
     [self initializePreferences];
     
@@ -46,11 +54,8 @@
     NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(handleReloadPreferences:) name:@"MA_Notify_CheckFrequencyChange" object:nil];
     [nc addObserver:self selector:@selector(handleReloadPreferences:) name:@"MA_Notify_PreferenceChange" object:nil];
-} 
-
-- (instancetype)init {
-    return [super initWithNibName:@"GeneralPreferencesView" bundle:nil];
 }
+
 
 #pragma mark - MASPreferencesViewController
 

--- a/src/Preferences/SyncingPreferencesViewController.m
+++ b/src/Preferences/SyncingPreferencesViewController.m
@@ -34,8 +34,14 @@ static BOOL _credentialsChanged;
 @synthesize syncButton;
 
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
+- (instancetype)init {
+    return [super initWithNibName:@"SyncingPreferencesView" bundle:nil];
+}
+
+- (void)viewWillAppear {
+    if([NSViewController instancesRespondToSelector:@selector(viewWillAppear)]) {
+        [super viewWillAppear];
+    }
     // Do view setup here.
     sourcesDict = nil;
     // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
@@ -110,9 +116,7 @@ static BOOL _credentialsChanged;
     
 }
 
-- (instancetype)init {
-    return [super initWithNibName:@"SyncingPreferencesView" bundle:nil];
-}
+
 
 #pragma mark - MASPreferencesViewController
 


### PR DESCRIPTION
Investigated issue #418 and discovered preferences were not initialising on OS X < 10.10 due to the
initialisation code being placed in viewDidLoad which wasn't being called after the transition to MASPreferences.

MASPreferences calls viewWillAppear so the initialisation code has been
moved into that. NSViewController has viewWillAppear in 10.10 and so a
check has been added before calling it on super.