### PR TITLE
Fix an AppController’s assertion

### DIFF
--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -96,10 +96,10 @@ static RefreshManager * _refreshManager = nil;
 }
 
 - (void)nqQueueDidFinishSelector:(ASIHTTPRequest *)request {
-	[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_ArticleListStateChange" object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ArticleListStateChange" object:nil];
 	if (hasStarted)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_RefreshStatus" object:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_RefreshStatus" object:nil];
 		hasStarted = NO;
 	}
 	LLog(@"Queue empty!!!");
@@ -112,6 +112,12 @@ static RefreshManager * _refreshManager = nil;
 }
 
 - (void)nqRequestStarted:(ASIHTTPRequest *)request {
+	if (!hasStarted)
+	{
+			hasStarted = YES;
+			[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_RefreshStatus" object:nil];
+	}
+
 	statusMessageDuringRefresh = [NSString stringWithFormat:@"%@: (%i) - %@",NSLocalizedString(@"Queue",nil),[networkQueue requestsCount],NSLocalizedString(@"Refreshing subscriptions...", nil)];
 	[APPCONTROLLER setStatusMessage:[self statusMessageDuringRefresh] persist:YES];
 	LLog(@"Added queue: %d", [networkQueue requestsCount]);
@@ -471,12 +477,6 @@ static RefreshManager * _refreshManager = nil;
  */
 -(void)refreshFeed:(Folder *)folder fromURL:(NSURL *)url withLog:(ActivityItem *)aItem shouldForceRefresh:(BOOL)force
 {	
-	if (!hasStarted)
-	{
-			[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_RefreshStatus" object:nil];
-			hasStarted = YES;
-	}
-
 	ASIHTTPRequest *myRequest;
 	
 	if (IsRSSFolder(folder)) {
@@ -1078,8 +1078,7 @@ static RefreshManager * _refreshManager = nil;
 
 -(BOOL)isConnecting
 {
-	LOG_NS(@"Connected : %@", [networkQueue requestsCount] > 0 ? @"yes" : @"no" );
-	return [networkQueue requestsCount] > 0;
+	return hasStarted;
 }
 
 

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -1078,7 +1078,7 @@ static RefreshManager * _refreshManager = nil;
 
 -(BOOL)isConnecting
 {
-	return hasStarted;
+	return [networkQueue requestsCount] > 0;
 }
 
 


### PR DESCRIPTION
Fix AppController’s assertion on stopProgressIndicator being called without a matching startProgressIndicator (could occur on a network error condition)
The detection of a feed refresh being processed has also been simplified, as a consequence.