### PR TITLE
Improved handling of HTTP 301 response

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -78,6 +78,7 @@ extern NSString * MAPref_SyncServer;
 extern NSString * MAPref_SyncingUser;
 extern NSString * MAPref_SendSystemProfileInfo;
 extern NSString * MAPref_AlwaysAcceptBetas;
+extern NSString * MAPref_IgnoreHTTP301Redirect;
 
 extern NSInteger MA_Default_BackTrackQueueSize;
 extern NSInteger MA_Default_RefreshThreads;

--- a/src/Constants.m
+++ b/src/Constants.m
@@ -77,6 +77,7 @@ NSString * MAPref_SyncServer = @"SyncServer";
 NSString * MAPref_SyncingUser = @"SyncingUser";
 NSString * MAPref_SendSystemProfileInfo = @"SUSendProfileInfo";
 NSString * MAPref_AlwaysAcceptBetas = @"AlwayAcceptBetas";
+NSString * MAPref_IgnoreHTTP301Redirect = @"IgnoreHTTP301Redirect";
 
 const NSInteger MA_Default_BackTrackQueueSize = 20;
 const NSInteger MA_Default_RefreshThreads = 20;

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -52,6 +52,7 @@
     BOOL prefersGoogleNewSubscription;
     BOOL markUpdatedAsNew;
     BOOL sendSystemSpecs;
+    BOOL ignoreHTTP301Redirect;
 	NSString * downloadFolder;
 	NSString * displayStyle;
 	float textSizeMultiplier;
@@ -74,6 +75,7 @@
 extern NSString * const kMA_Notify_MinimumFontSizeChange;
 extern NSString * const kMA_Notify_UseJavaScriptChange;
 extern NSString * const kMA_Notify_UseWebPluginsChange;
+extern NSString * const kMA_Notify_IgnoreHTTP301RedirectChange;
 
 // Accessor functions
 +(Preferences *)standardPreferences;
@@ -255,4 +257,8 @@ extern NSString * const kMA_Notify_UseWebPluginsChange;
 // username used for syncing
 -(NSString *)syncingUser;
 -(void)setSyncingUser:(NSString *)newUser;
+
+#pragma mark - Advanced Preferences
+- (BOOL)ignoreHTTP301Redirect;
+- (void)setIgnoreHTTP301Redirect:(BOOL)flag;
 @end

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -620,14 +620,17 @@ static RefreshManager * _refreshManager = nil;
 
 	if (responseStatusCode == 301)
 	{
-		// We got a permanent redirect from the feed so change the feed URL to the new location.
-		Folder * folder = (Folder *)[[connector userInfo] objectForKey:@"folder"];
-		ActivityItem *connectorItem = [[connector userInfo] objectForKey:@"log"];
+        if ([[Preferences standardPreferences] ignoreHTTP301Redirect] == false)
+        {
+            // We got a permanent redirect from the feed so update the feed URL
+            Folder * folder = (Folder *)[[connector userInfo] objectForKey:@"folder"];
+            ActivityItem *connectorItem = [[connector userInfo] objectForKey:@"log"];
 
-        [[Database sharedManager] setFeedURL:newURL.absoluteString
-                                   forFolder:folder.itemId];
-        
-		[connectorItem appendDetail:[NSString stringWithFormat:NSLocalizedString(@"Feed URL updated to %@", nil), [newURL absoluteString]]];
+            [[Database sharedManager] setFeedURL:newURL.absoluteString
+                                       forFolder:folder.itemId];
+            
+            [connectorItem appendDetail:[NSString stringWithFormat:NSLocalizedString(@"Feed URL updated to %@", nil), [newURL absoluteString]]];
+        }
 	}
 
 	[connector redirectToURL:newURL];


### PR DESCRIPTION
Refer to issue #380 for history.
This PR currently only has the following changes and does not have any UI changes:

1. Uses the preferences model to store the preference for ignoring HTTP 301 requests or not
2. Updated `RefreshManager` to check for the new preference before deciding whether to update the feed's URL or not
