### PR TITLE
Fix to issue #380

### DIFF
--- a/lproj/cs.lproj/Localizable.strings
+++ b/lproj/cs.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/da.lproj/Localizable.strings
+++ b/lproj/da.lproj/Localizable.strings
@@ -448,3 +448,6 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";
+

--- a/lproj/de.lproj/Localizable.strings
+++ b/lproj/de.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/en.lproj/Localizable.strings
+++ b/lproj/en.lproj/Localizable.strings
@@ -447,3 +447,6 @@
 "Got HTTP status 304 - No news from last check" = "Got HTTP status 304 - No news from last check";
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
+
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/es.lproj/Localizable.strings
+++ b/lproj/es.lproj/Localizable.strings
@@ -448,3 +448,6 @@
 "Got HTTP status 304 - No news from last check" = "Recibido estado HTTP 304 - No hay noticias desde la última búsqueda";
 "Error retrieving RSS Icon:" = "Error recuperando icono de la suscripción:";
 "RSS Icon not found!" = "¡Icono de la suscripción no encontrado!";
+
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/eus.lproj/Localizable.strings
+++ b/lproj/eus.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/fr.lproj/Localizable.strings
+++ b/lproj/fr.lproj/Localizable.strings
@@ -447,3 +447,6 @@
 "Got HTTP status 304 - No news from last check" = "Code retour HTTP 304 - Pas de nouvel article depuis la dernière recherche";
 "Error retrieving RSS Icon:" = "Erreur lors de la recherche de l'icône RSS";
 "RSS Icon not found!" = "Icône RSS non trouvée !";
+
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Tentative de redirection traitée de façon temporaire par souci de prudence";

--- a/lproj/it.lproj/Localizable.strings
+++ b/lproj/it.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/ja.lproj/Localizable.strings
+++ b/lproj/ja.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/ko.lproj/Localizable.strings
+++ b/lproj/ko.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/nl.lproj/Localizable.strings
+++ b/lproj/nl.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/pt.lproj/Localizable.strings
+++ b/lproj/pt.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/pt_BR.lproj/Localizable.strings
+++ b/lproj/pt_BR.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/ru.lproj/Localizable.strings
+++ b/lproj/ru.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/sv.lproj/Localizable.strings
+++ b/lproj/sv.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/tr.lproj/Localizable.strings
+++ b/lproj/tr.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/uk.lproj/Localizable.strings
+++ b/lproj/uk.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/zh_CN.lproj/Localizable.strings
+++ b/lproj/zh_CN.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/lproj/zh_TW.lproj/Localizable.strings
+++ b/lproj/zh_TW.lproj/Localizable.strings
@@ -448,3 +448,5 @@
 "Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
 "RSS Icon not found!" = "RSS Icon not found!";
 
+/*Added in 3.0.5 */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";

--- a/src/RefreshManager.h
+++ b/src/RefreshManager.h
@@ -36,6 +36,7 @@
 	ASINetworkQueue *networkQueue;
 	dispatch_queue_t _queue;
 	NSTimer * unsafe301RedirectionTimer;
+	NSString * riskyIPAddress;
 }
 
 +(RefreshManager *)sharedManager;

--- a/src/RefreshManager.h
+++ b/src/RefreshManager.h
@@ -35,6 +35,7 @@
     SyncTypes syncType;
 	ASINetworkQueue *networkQueue;
 	dispatch_queue_t _queue;
+	NSTimer * unsafe301RedirectionTimer;
 }
 
 +(RefreshManager *)sharedManager;

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -649,7 +649,7 @@ static RefreshManager * _refreshManager = nil;
 			[connectorItem appendDetail:[NSString stringWithFormat:NSLocalizedString(@"Feed URL updated to %@", nil), [newURL absoluteString]]];
 		}
 		else
-			[connectorItem appendDetail:NSLocalizedString(@"Redirection attempt treated as temporary for safety reasons", nil)];
+			[connectorItem appendDetail:NSLocalizedString(@"Redirection attempt treated as temporary for safety concern", nil)];
 	}
 
 	[connector redirectToURL:newURL];


### PR DESCRIPTION
When we encounter a 301 redirection, we test if a well known website is also permanently redirected.

If so, there probably is a network misconfiguration problem. So we consider all 301 redirections as temporary, until 24 hours have elapsed or our machine wakes up with a new IP address. Then, we will retest at the next 301 redirection.