### PR TITLE
Fiddling with browser user agent

### DIFF
--- a/src/BrowserPane.m
+++ b/src/BrowserPane.m
@@ -21,7 +21,6 @@
 #import "ViennaApp.h"
 #import "BrowserPane.h"
 #import "TabbedWebView.h"
-#import "Constants.h"
 #import "AppController.h"
 #import "Preferences.h"
 #import "HelperFunctions.h"
@@ -124,12 +123,6 @@
 	[webPane initTabbedWebView];
 	[webPane setUIDelegate:self];
 	[webPane setFrameLoadDelegate:self];
-	NSString * safariVersion = [[[NSBundle bundleWithPath:@"/Applications/Safari.app"] infoDictionary] objectForKey:@"CFBundleVersion"];
-	if (safariVersion)
-		safariVersion = [safariVersion substringFromIndex:1];
-	else
-		safariVersion = @"532.22";
-	[webPane setApplicationNameForUserAgent:[NSString stringWithFormat:MA_BrowserUserAgentString, [[((ViennaApp *)NSApp) applicationVersion] firstWord], safariVersion]];
 	
 	// Make web preferences 16pt Arial to match Safari
 	[[webPane preferences] setStandardFontFamily:@"Arial"];

--- a/src/TabbedWebView.h
+++ b/src/TabbedWebView.h
@@ -32,6 +32,7 @@
 }
 
 // Public functions
++(NSString *)userAgent;
 -(void)initTabbedWebView;
 -(void)setController:(AppController *)theController;
 -(void)setOpenLinksInNewBrowser:(BOOL)flag;

--- a/src/TabbedWebView.m
+++ b/src/TabbedWebView.m
@@ -23,6 +23,8 @@
 #import "Preferences.h"
 #import "DownloadManager.h"
 #import "StringExtensions.h"
+#import "ViennaApp.h"
+#import "Constants.h"
 
 @interface NSObject (TabbedWebViewDelegate)
 	-(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags;
@@ -35,6 +37,16 @@
 @end
 
 @implementation TabbedWebView
+
++(NSString *)userAgent
+{
+	NSString * safariVersion = [[[NSBundle bundleWithPath:@"/Applications/Safari.app"] infoDictionary] objectForKey:@"CFBundleVersion"];
+	if (safariVersion)
+		safariVersion = [safariVersion substringFromIndex:2];
+	else
+		safariVersion = @"532.22";
+	return [NSString stringWithFormat:MA_BrowserUserAgentString, [[((ViennaApp *)NSApp) applicationVersion] firstWord], safariVersion];
+}
 
 /* initWithFrame
  * The designated instance initialiser.
@@ -80,6 +92,8 @@
 	[defaultWebPrefs setPrivateBrowsingEnabled:NO];
 	[defaultWebPrefs setJavaScriptEnabled:NO];
     [defaultWebPrefs setPlugInsEnabled:NO];
+    // handle UserAgent
+    [self setApplicationNameForUserAgent:[TabbedWebView userAgent]];
 	[self loadMinimumFontSize];
 	[self loadUseJavaScript];
     [self loadUseWebPlugins];


### PR DESCRIPTION
- UserAgent initialization is performed for every TabbedWebView instance. This makes the article view in the main tab use the same UserAgent as browser panes in other tabs.
- Mimics Safari better.

These may solve issues like the one shown at http://m.yhub.us/image/3z0H3o2a3W3X , especially with horizontal or vertical layout and the option to “Use Web Page for Articles” set.