### PR TITLE
Hiutil fixes

### DIFF
--- a/lproj/cs.lproj/Vienna Help/advanced.html
+++ b/lproj/cs.lproj/Vienna Help/advanced.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
 <p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
 not essential for normal use but may resolve some issues as advised by the support forum. This page details the
 advanced settings and their function.

--- a/lproj/cs.lproj/Vienna Help/faq.html
+++ b/lproj/cs.lproj/Vienna Help/faq.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">How Do I?</span>
 <p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
 See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
 and the latest hints and tips for using Vienna.
@@ -107,18 +108,18 @@ located at ~/Library/Application Support/Vienna. You can move this to
 another folder if you wish. The following steps show how:</p>
 <ol>
 <li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
+<li>Open a console window and enter:<br />
+<br />
 <font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
+&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br />
 
-<br>
+<br />
 where &lt;path to new messages.db&gt; is the name of the folder that 
 contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
+messages.db filename at the end. For example:<br />
+<br />
 <font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
+&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br />
 </li>
 
 <li>Restart Vienna.</li>

--- a/lproj/cs.lproj/Vienna Help/index.html
+++ b/lproj/cs.lproj/Vienna Help/index.html
@@ -1,9 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+  <meta name="AppleTitle" content="Vienna Help"/>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
   <title>Vienna Help</title>
 </head>
 <body>
@@ -11,11 +12,11 @@
   <tbody>
     <tr>
       <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
+		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""/></p>
 		<p class="title" align="center">Vienna Help</p>
       </td>
       <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
+		<img src="images/Vertical-Line.jpg" height="270" width="36" alt=""/>
       </td>
       <td width="300">
 		<p class="header">Introduction to Vienna</p>

--- a/lproj/cs.lproj/Vienna Help/intro.html
+++ b/lproj/cs.lproj/Vienna Help/intro.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span>
 <span class="header">Introduction to Vienna</span>
 <p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
 job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
@@ -21,7 +22,7 @@ just a few controls are needed to perform the most common actions in the user in
 and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
 from the File menu to grab the latest articles from those subscriptions.</p>
 <p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
+the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"/> or XML icons indicating that the page has a feed associated
 with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
 an alternative to reading the postings online.</p>
 <p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier

--- a/lproj/cs.lproj/Vienna Help/keyboard.html
+++ b/lproj/cs.lproj/Vienna Help/keyboard.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
 <p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
 (or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
 menus. To see a contextual menu, press the Control key and click the item.</p>

--- a/lproj/da.lproj/Vienna Help/advanced.html
+++ b/lproj/da.lproj/Vienna Help/advanced.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title>Avancerede indstillinger</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Avancerede indstillinger</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Avancerede indstillinger</span>
 <p>Sektionen for avancerede instillinerg giver mulighed for at ændre meget specifikke indstillinger i Vienna som ikke er essentielle for normal brug, men som kan klare nogle problemer som kan være bragt op på support-forummet. Denne sider detajlerer de avancerede indstillinger og deres funktioner.
 </p>
 <h2><b>Aktiver JavaScript i den interne browser</b></h2>

--- a/lproj/da.lproj/Vienna Help/faq.html
+++ b/lproj/da.lproj/Vienna Help/faq.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">How Do I?</span>
 <p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
 See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
 and the latest hints and tips for using Vienna.
@@ -107,18 +108,18 @@ located at ~/Library/Application Support/Vienna. You can move this to
 another folder if you wish. The following steps show how:</p>
 <ol>
 <li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
+<li>Open a console window and enter:<br />
+<br />
 <font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
+&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br />
 
-<br>
+<br />
 where &lt;path to new messages.db&gt; is the name of the folder that 
 contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
+messages.db filename at the end. For example:<br />
+<br />
 <font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
+&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br />
 </li>
 
 <li>Restart Vienna.</li>

--- a/lproj/da.lproj/Vienna Help/index.html
+++ b/lproj/da.lproj/Vienna Help/index.html
@@ -1,9 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta name="AppleTitle" content="Vienna Help"/>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
   <title>Vienna hjælp</title>
 </head>
 <body>
@@ -11,11 +12,11 @@
   <tbody>
     <tr>
       <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
+		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""/></p>
 		<p class="title" align="center">Vienna hjælp</p>
       </td>
       <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
+		<img src="images/Vertical-Line.jpg" height="270" width="36" alt=""/>
       </td>
       <td width="300">
 		<p class="header">Introduktion til Vienna</p>

--- a/lproj/da.lproj/Vienna Help/intro.html
+++ b/lproj/da.lproj/Vienna Help/intro.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span>
 <span class="header">Introduction to Vienna</span>
 <p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
 job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
@@ -21,7 +22,7 @@ just a few controls are needed to perform the most common actions in the user in
 and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
 from the File menu to grab the latest articles from those subscriptions.</p>
 <p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
+the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"/> or XML icons indicating that the page has a feed associated
 with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
 an alternative to reading the postings online.</p>
 <p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier

--- a/lproj/da.lproj/Vienna Help/keyboard.html
+++ b/lproj/da.lproj/Vienna Help/keyboard.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title>Tastaturgenveje</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Tastaturgenveje</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Tastaturgenveje</span>
 <p>Du kan bruge dit tastatur til hurtigt at klare mange funktioner i Vienna. For at finde genveje for ofte brugte kommandoer, kig da i menuerne (eller se listen i bunden af denne side). Mange emner i Vienna, såsom mappefanen og artikellistefanen, har også contextual menuer. For at se en contextualmenu, hold Kontrol-tasten nede og klik på et emne.</p>
 <p>For at gøre en handling, tryk genvejstasterne indikeret nedenfor.</p>
 <table width="662.0" cellspacing="0" cellpadding="0">

--- a/lproj/de.lproj/Vienna Help/advanced.html
+++ b/lproj/de.lproj/Vienna Help/advanced.html
@@ -8,12 +8,12 @@
 </head>
 <body>
 <span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Erweiterte Einstellungen</span>
-<p>Der "Erweitert"-Abschnitt der Einstellungen ermšglicht das Anpassen von spezifischen Optione die fŸr den normalen Gebrauch nicht notwendig sind,
-aber eventuelle Probleme beheben helfen kšnnen. Dieser Abschnitt beschreibt die Optionen und ihre Funktion.</p>
+<p>Der "Erweitert"-Abschnitt der Einstellungen ermÂšglicht das Anpassen von spezifischen Optione die fÂŸr den normalen Gebrauch nicht notwendig sind,
+aber eventuelle Probleme beheben helfen kÂšnnen. Dieser Abschnitt beschreibt die Optionen und ihre Funktion.</p>
 <h2><b>JavaScript im integrierten Browser aktivieren</b></h2>
-<p>Aktiviert oder deaktiviert die JavaScript UnterstŸtzung in Viennas integriertem Web-Browser. Dieser Optione ist standardmŠ§ig aktiviert.
-Durch das Abschalten der UnterstŸtzung wird das AusfŸhren JavaScript vollstŠnding unterbunden. Dies kann zum Beispiel dabei helfen, Probleme mit 
-Seiten zu beheben Dieser durch Skripte Pop-Up Fenster šffnen oder sich sonst unerwartet Verhalten. Allerdings kšnnen auch die Funktion und Anzeige 
-einiger Webseiten teilweise oder vollstŠndig gestšrt werden.</p>
+<p>Aktiviert oder deaktiviert die JavaScript UnterstÂŸtzung in Viennas integriertem Web-Browser. Dieser Optione ist standardmÂŠÂ§ig aktiviert.
+Durch das Abschalten der UnterstÂŸtzung wird das AusfÂŸhren JavaScript vollstÂŠnding unterbunden. Dies kann zum Beispiel dabei helfen, Probleme mit 
+Seiten zu beheben Dieser durch Skripte Pop-Up Fenster Âšffnen oder sich sonst unerwartet Verhalten. Allerdings kÂšnnen auch die Funktion und Anzeige 
+einiger Webseiten teilweise oder vollstÂŠndig gestÂšrt werden.</p>
 </body>
 </html>

--- a/lproj/de.lproj/Vienna Help/advanced.html
+++ b/lproj/de.lproj/Vienna Help/advanced.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 	<title>Erweiterte Einstellingen</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Erweiterte Einstellungen</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Erweiterte Einstellungen</span>
 <p>Der "Erweitert"-Abschnitt der Einstellungen ermöglicht das Anpassen von spezifischen Optione die für den normalen Gebrauch nicht notwendig sind,
 aber eventuelle Probleme beheben helfen können. Dieser Abschnitt beschreibt die Optionen und ihre Funktion.</p>
 <h2><b>JavaScript im integrierten Browser aktivieren</b></h2>

--- a/lproj/de.lproj/Vienna Help/index.html
+++ b/lproj/de.lproj/Vienna Help/index.html
@@ -1,9 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta name="AppleTitle" content="Vienna Help"/>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
   <title>Vienna Hilfe</title>
 </head>
 <body>
@@ -11,11 +12,11 @@
   <tbody>
     <tr>
       <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
+		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""/></p>
 		<p class="title" align="center">Vienna Hilfe</p>
       </td>
       <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
+		<img src="images/Vertical-Line.jpg" height="270" width="36" alt=""/>
       </td>
       <td width="300">
 		<p class="header">Einleitung zu Vienna</p>

--- a/lproj/de.lproj/Vienna Help/intro.html
+++ b/lproj/de.lproj/Vienna Help/intro.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>Einleitung zu Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Einleitung zu Vienna</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Einleitung zu Vienna</span>
 <p>Vienna ist ein Programm zum lesen und verwalten von RSS und Atom Feeds auf Mac OSX Computern. Es automatisiert Aufgaben
 zum verwalten von Atikeln der abonnierten Feeds und speichert sie in einer lokalen Datenbank um die Artikel auch Offline 
 lesen zu können. Unterstützte Merkmale sind das Durchsuchen der Feeds nach Schlüsselwörtern und Phrasen, makieren ineressanter

--- a/lproj/de.lproj/Vienna Help/keyboard.html
+++ b/lproj/de.lproj/Vienna Help/keyboard.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title>Tastatur-Kürzel</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Tastatur-Kürzel</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Tastatur-Kürzel</span>
 <p>Ein Großteil der Funktionen in Vienna können über die Tastatur ausgeführt werden. Die notwendigen Tastatür-Kürzel werden im
 Menü neben dem jeweiligen Befehl angezeigt und werden im Folgenden beschrieben. Viele Bedienelemente in Vienna verfügen ausserdem 
 über Kontext-Menüs, die durch einen Rechtsklick beziehungsweise durch Klicken und halten von Steuerung aktiviert werden können.

--- a/lproj/en.lproj/Vienna Help/advanced.html
+++ b/lproj/en.lproj/Vienna Help/advanced.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
 <p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
 not essential for normal use but may resolve some issues as advised by the support forum. This page details the
 advanced settings and their function.

--- a/lproj/en.lproj/Vienna Help/faq.html
+++ b/lproj/en.lproj/Vienna Help/faq.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">How Do I?</span>
 <p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
 See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
 and the latest hints and tips for using Vienna.
@@ -94,17 +95,17 @@ method they require.</p>
 
 <p>Requiring a username and a password is the most frequent method. It is also the most
 transparent for the user. On first refresh, Vienna will present you with a dialog box
-where you can enter the username and the password that has been provided to you.<br>
+where you can enter the username and the password that has been provided to you.<br />
 You can check that you have provided these credentials to Vienna (and update them if
 necessary) through the 'Info' window associated to the feed (which you can access through
 the 'Folder → Get Info…' menu or through the contextual menu you get when you right-click
-on the feed in Vienna's left pane).<br>
+on the feed in Vienna's left pane).<br />
 Note that the password is securely stored in Apple's Keychain.</p>
 
 <p>For servers which require a cookie, the username and password must NOT be set in the
-'Info' window. Both fields MUST be left blank.<br>
+'Info' window. Both fields MUST be left blank.<br />
 Instead, you will need to log in to the website through Safari or through a web browser
-tab in Vienna.<br>
+tab in Vienna.<br />
 A problem is that you may need, from time to time, to re-log in again, because cookies can
 expire.
 </p>
@@ -117,18 +118,18 @@ located at ~/Library/Application Support/Vienna. You can move this to
 another folder if you wish. The following steps show how:</p>
 <ol>
 <li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
+<li>Open a console window and enter:<br />
+<br />
 <font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
+&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br />
 
-<br>
+<br />
 where &lt;path to new messages.db&gt; is the name of the folder that 
 contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
+messages.db filename at the end. For example:<br />
+<br />
 <font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
+&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br />
 </li>
 
 <li>Restart Vienna.</li>

--- a/lproj/en.lproj/Vienna Help/index.html
+++ b/lproj/en.lproj/Vienna Help/index.html
@@ -1,9 +1,10 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+  <meta name="AppleTitle" content="Vienna Help"/>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
   <title>Vienna Help</title>
 </head>
 <body>
@@ -11,11 +12,11 @@
   <tbody>
     <tr>
       <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
+		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""/></p>
 		<p class="title" align="center">Vienna Help</p>
       </td>
       <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
+		<img src="images/Vertical-Line.jpg" height="270" width="36" alt=""/>
       </td>
       <td width="300">
 		<p class="header">Introduction to Vienna</p>

--- a/lproj/en.lproj/Vienna Help/intro.html
+++ b/lproj/en.lproj/Vienna Help/intro.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span>
 <span class="header">Introduction to Vienna</span>
 <p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
 job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
@@ -21,7 +22,7 @@ just a few controls are needed to perform the most common actions in the user in
 and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
 from the File menu to grab the latest articles from those subscriptions.</p>
 <p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
+the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"/> or XML icons indicating that the page has a feed associated
 with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
 an alternative to reading the postings online.</p>
 <p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
@@ -30,12 +31,12 @@ In the "Create a new RSS subscription" panel, pick the blogging service from the
 user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
 you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
 <p>You can also use Vienna in relation with an account in an Open Reader server. Go into Preferences... / Syncing and tick the
-"Sync with an Open Reader server" checkbox.<br>
+"Sync with an Open Reader server" checkbox.<br />
 Beforehand, think about which feeds you prefer reading through Open Reader and which you'll get through direct access.
 Vienna will avoid creating duplicates between the two categories, but if you have feeds inside Open Reader
 which Vienna already fetches directly, you will have discrepancies between your reading lists.
-So, organize your feeds accordingly.<br>
-You should take into account these elements :
+So, organize your feeds accordingly.<br />
+You should take into account these elements :</p>
 <ul>
 <li>Open Reader feeds can be synchronized across multiple devices/applications supporting it</li>
 <li>Open Reader does not support feeds requiring username/password</li>
@@ -43,7 +44,7 @@ You should take into account these elements :
 for less "popular" feeds, you'll get articles sooner.</li>
 <li>Generally, directly fetching feeds from their original website generates less network traffic. When the server signals there
 is no new articles since last fetch, Vienna avoids an useless download.</li>
-</ul></p>
+</ul>
 <p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
 to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
 from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh

--- a/lproj/en.lproj/Vienna Help/keyboard.html
+++ b/lproj/en.lproj/Vienna Help/keyboard.html
@@ -1,12 +1,13 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+	<link rel="stylesheet" href="helpstyle.css" type="text/css"/>
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
+<span><img src="images/Small-Vienna-Logo.jpg" alt=""/>&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
 <p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
 (or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
 menus. To see a contextual menu, press the Control key and click the item.</p>

--- a/lproj/es.lproj/Vienna Help/advanced.html
+++ b/lproj/es.lproj/Vienna Help/advanced.html
@@ -1,19 +1,35 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Preferencias avanzadas</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Preferencias avanzadas</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Preferencias avanzadas</span>
-<p>La sección Avanzado de las preferencias da al usuario la posibilidad de cambiar algunos ajustes muy específicos de Vienna que no son esenciales para
-el uso normal de la aplicación pero que podrían resolver algunas incidencias tal y como se sugiere en el foro de ayuda. Esta página detalla las
-preferencias avanzadas y su función.
-</p>
-<h2><b>Habilitar el uso de JavaScript en el navegador interno</b></h2>
-<p>Activa o desactiva el soporte para JavaScript en el navegador integrado de Vienna. Javascript está activado por defecto. Desactivándolo
-el código programado por JavaScript no funcionará. Este hecho podría ayudar a resolver algunas incidencias con páginas que utilizan este tipo de código -por ejemplo, ventanas emergentes-. Sin embargo, también podría causar comportamientos inesperados. Desactivar JavasScript también podría provocar que algunas páginas
-apareciesen incompletas o no se mostrasen y/o funcionasen tal y como se prevee.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Preferencias
+  avanzadas</span>
+  <p>La sección Avanzado de las preferencias da al usuario la
+  posibilidad de cambiar algunos ajustes muy específicos de Vienna
+  que no son esenciales para el uso normal de la aplicación pero
+  que podrían resolver algunas incidencias tal y como se sugiere en
+  el foro de ayuda. Esta página detalla las preferencias avanzadas
+  y su función.</p>
+  <h2><b>Habilitar el uso de JavaScript en el navegador
+  interno</b></h2>
+  <p>Activa o desactiva el soporte para JavaScript en el navegador
+  integrado de Vienna. Javascript está activado por defecto.
+  Desactivándolo el código programado por JavaScript no funcionará.
+  Este hecho podría ayudar a resolver algunas incidencias con
+  páginas que utilizan este tipo de código -por ejemplo, ventanas
+  emergentes-. Sin embargo, también podría causar comportamientos
+  inesperados. Desactivar JavasScript también podría provocar que
+  algunas páginas apareciesen incompletas o no se mostrasen y/o
+  funcionasen tal y como se prevee.</p>
 </body>
 </html>

--- a/lproj/es.lproj/Vienna Help/faq.html
+++ b/lproj/es.lproj/Vienna Help/faq.html
@@ -1,130 +1,224 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>¿Cómo puedo...?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>¿Cómo puedo...?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">¿Cómo puedo...?</span>
-<p>Le presentamos algunas de las preguntas más frecuentes acerca de Vienna.
-Consulte el <a href="http://www.vienna-rss.org/vienna_faq.html">F.A.Q. oficial</a> para obtener respuestas más concretas y, obviamente, también los últimos consejos prácticos para el uso de Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">¿Dónde puedo conseguir el código de Vienna?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">He apreciado un problema en Vienna. ¿Cómo informo de ello?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">¿Cómo puedo crear mis propios estilos?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">¿Cómo puedo crear mis propios scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-¿Cómo puedo comprobar si mis suscripciones se han actualizado?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">¿Cómo puedo mover la base de datos de Vienna a otra carpeta?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Una de mis suscripciones muestra el mensaje «Se ha producido un error al procesar los datos XML de la fuente». 
-¿Qué significa?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-¿Hay alguna función rápida de teclado para pasar al siguiente artículo, marcar como leído, 
-etc?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">¿Cómo puedo utilizar la auto-eliminación de artículos y qué hace?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">¿Cómo puedo sugerir una mejora para Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">¿Dónde puedo conseguir el código de Vienna?</a></h2>
-<p>Consulte la <a href="http://www.vienna-rss.org/vienna_dev.php">página de desarrollo</a> para 
-conocer la manera de obtener el código de Vienna. El código está a libre disposición de todo aquel que quiera conocer cómo funciona 
-Vienna. También está disponible para quien desee construir su propia copia de Vienna desde cero en su propio ordenador o bien quiera incluir partes del código en su propio
-proyecto. El código se distribuye bajo licencia <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">He apreciado un problema en Vienna. ¿Cómo informo de ello?</a></h2>
-<p>Escriba en el foro de soporte y alguien investigará sobre ello. Entregue tanta información como pueda acerca del problema. No olvide especificar
-la versión de Vienna utilizada (se obtiene en el menú Acerca de Vienna), los pasos previos al error y lo que esperaba que ocurriera.</p>
-
-<p>Asegúrese de que utiliza siempre la última versión de Vienna. El menú Comprobar si hay actualizaciones le informará en el caso que existan versiones
-más recientes que la que usted posee.</p>
-<p>Tenga presente que solventar errores goza de mayor prioridad que incluir nuevas características. En el que caso de que se confirme que su problema es un error reconocido y generalizado se intentará dar una solución en un plazo razonable de tiempo.</p>
-<h2><a name="How_do_I_create_my_own_styles">¿Cómo puedo crear mis propios estilos?</a></h2>
-<p>Consulte la <a href="http://www.vienna-rss.org/vienna_styles.html">página de personalización de estilos</a> para obtener las correspondientes
-instrucciones.</p>
-<h2><a name="How_do_I_create_my_own_scripts">¿Cómo puedo crear mis propios scripts?</a></h2>
-
-<p>Los scripts de Vienna se escriben utilizando AppleScript. Consulte la
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-página de recursos de Apple</a> para obtener más detalles acerca de él y de su uso.</p>
-<p>Una manera de comenzar es descargar uno de los scripts ya existentes en 
-la <a href="http://www.vienna-rss.org/vienna_files.html">página de descargas de Vienna</a> y abrirlo con el editor de AppleScripts. Consulte también la 
-<a href="http://www.vienna-rss.org/vienna_scripting.html">página de scripts</a> para obtener más detalles de los scripts para Vienna y ejemplos de lo que se puede conseguir.</p>
-
-<p>Si desea presentar su propio script a la comunidad de usuarios de la aplicación, envíelo a <a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-y una vez haya sido probado, se pondrá a disposición de todos en la página de descargas.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-¿Cómo puedo comprobar si mis suscripciones se han actualizado?</a></h2>
-<p>Abra la página de actividad del menú Ventana. La ventana de actividad 
-muestra todas las suscripciones y la situación que tenían la última vez que fueron actualizadas durante la presente sesión.
-La parte inferior de la ventana de actividad muestra más detalles. Entre éstos se incluyen los encabezados HTTP, que podrían ser 
-útiles para detectar y eliminar fallos. Si el panel de actividades no está visible, 
-puede hacerlo aparecer arrastrando hacia la parte superior la barra inferior de la ventana.</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">¿Cómo puedo mover la base de datos de Vienna a otra carpeta?</a></h2>
-
-<p>Por defecto, la base de datos de Vienna es el archivo messages.db que se encuentra en 
-~/Library/Application Support/Vienna. Usted puede moverlo a la carpeta que desee. Los pasos a realizar son los siguientes:</p>
-<ol>
-<li>Salga de Vienna.</li>
-<li>Abra una ventana de la consola e introduzca el siguiente texto:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-donde pone &lt;path to new messages.db&gt; es el nombre de la nueva carpeta que contiene 
-el archivo messages.db. La ruta debe incluir el archivo messages.db al final. Un ejemplo:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Reinicie Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Una de mis suscripciones muestra el mensaje «Se ha producido un error al procesar los datos XML de la fuente». 
-¿Qué significa?</a></h2>
-<p>Significa que Vienna ha obtenido una respuesta de la suscripción que no ha podido interpretar. Hay varias razones para ello:</p>
-
-<ol>
-<li>La URL de la suscripción podría no redirigir a una fuente RSS o Atom sino a una página web. 
-Compruebe la dirección URL.</li>
-<li>La fuente de noticias podría contener XML incorrecto. Algunas suscripciones 
-cometen un error al unir el XML que compone la fuente 
-y por ello Vienna no puede interpretarlo. Utilice el comando Validar la fuente para comprobar si es el caso. Desafortunadamente
-no se puede hacer gran cosa más que esperar que se corrija desde la propia página.</li>
-<li>La fuente de noticias podría estar incompleta. Si la actualización ha sido interrumpida, probablemente el archivo XML esté incompleto y aparece como incorrecto para Vienna. Una segunda actualización podría resolver el problema.</li>
-</ol>
-<p>Si ninguna de las posibilidades arriba mencionadas explica el mensaje de error, escriba un mensaje en el foro de soporte, incluyendo la dirección URL de la suscripción que muestra el problema. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-¿Hay alguna función rápida de teclado para pasar al siguiente artículo, marcar como leído, 
-etc?</a></h2>
-<p>Probablemente. Existen algunas funciones rápidas de teclado para algunos comandos del menú. Algunos de ellos son:</p>
-<p>Barra espaciadora - Dirige al siguiente artículo no leído. Si el artículo seleccionado tiene varias páginas,
-se desplazará primero por el artículo. Sin embargo, el comando Siguiente artículo no leído (Comando-U) siempre se dirige directamente al siguiente artículo no leído.</p>
-<p>R - Marca el artículo seleccionado como leído si no lo está todavía, o bien como no leído si es que ya ha sido leído.</p>
-<p>F - Marca con indicador el artículo seleccionado si no ha sido marcado previamente, o bien elimina la marca si lo ha sido.</p>
-<p>Consulte la ayuda de Vienna para obtener más funciones rápidas de teclado.</p>
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">¿Cómo puedo utilizar la auto-eliminación de artículos y qué hace exactamente?</a></h2>
-<p>La auto-eliminación de artículos mueve a la papelera los artículos que superan una determinada antigüedad.
-Esto le permite mantener de manera manejable las carpetas guardando únicamente los artículos recientes. 
-La auto-eliminación de artículos funciona tanto cuando se inicia Vienna como cuando se ha actualizado cualquier suscripción. Para especificar una nueva fecha máxima de los artículos sujetos a la auto-eliminación, cambie la opción Mover los artículos a la papelera en las preferencias de la aplicación.</p>
-<p>La auto-eliminación no eliminará artículos no leídos o con indicador. Vienna entiende que ya que no ha leído estos artículos no desea eliminarlos todavía .</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">¿Cómo puedo sugerir una mejora para Vienna?</a></h2>
-<p>Escriba un mensaje en el
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">foro de soporte</a>. Todas las mejoras son incluidas en un archivo «To-Do» que se incluye en el código como guía para futuros desarrollos.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">¿Cómo
+  puedo...?</span>
+  <p>Le presentamos algunas de las preguntas más frecuentes acerca
+  de Vienna. Consulte el <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">F.A.Q. oficial</a>
+  para obtener respuestas más concretas y, obviamente, también los
+  últimos consejos prácticos para el uso de Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">¿Dónde
+    puedo conseguir el código de Vienna?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">He
+    apreciado un problema en Vienna. ¿Cómo informo de
+    ello?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">¿Cómo puedo crear
+    mis propios estilos?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">¿Cómo puedo crear
+    mis propios scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    ¿Cómo puedo comprobar si mis suscripciones se han
+    actualizado?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">¿Cómo
+    puedo mover la base de datos de Vienna a otra carpeta?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    Una de mis suscripciones muestra el mensaje «Se ha producido un
+    error al procesar los datos XML de la fuente». ¿Qué
+    significa?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    ¿Hay alguna función rápida de teclado para pasar al siguiente
+    artículo, marcar como leído, etc?</a></li>
+    <li><a href=
+    "#How_do_I_use_Auto_Expire_and_what_does_it_do">¿Cómo puedo
+    utilizar la auto-eliminación de artículos y qué hace?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">¿Cómo
+    puedo sugerir una mejora para Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">¿Dónde puedo conseguir el
+  código de Vienna?</a></h2>
+  <p>Consulte la <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">página de
+  desarrollo</a> para conocer la manera de obtener el código de
+  Vienna. El código está a libre disposición de todo aquel que
+  quiera conocer cómo funciona Vienna. También está disponible para
+  quien desee construir su propia copia de Vienna desde cero en su
+  propio ordenador o bien quiera incluir partes del código en su
+  propio proyecto. El código se distribuye bajo licencia <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache
+  2.0</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">He
+  apreciado un problema en Vienna. ¿Cómo informo de ello?</a></h2>
+  <p>Escriba en el foro de soporte y alguien investigará sobre
+  ello. Entregue tanta información como pueda acerca del problema.
+  No olvide especificar la versión de Vienna utilizada (se obtiene
+  en el menú Acerca de Vienna), los pasos previos al error y lo que
+  esperaba que ocurriera.</p>
+  <p>Asegúrese de que utiliza siempre la última versión de Vienna.
+  El menú Comprobar si hay actualizaciones le informará en el caso
+  que existan versiones más recientes que la que usted posee.</p>
+  <p>Tenga presente que solventar errores goza de mayor prioridad
+  que incluir nuevas características. En el que caso de que se
+  confirme que su problema es un error reconocido y generalizado se
+  intentará dar una solución en un plazo razonable de tiempo.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">¿Cómo puedo crear mis propios
+  estilos?</a></h2>
+  <p>Consulte la <a href=
+  "http://www.vienna-rss.org/vienna_styles.html">página de
+  personalización de estilos</a> para obtener las correspondientes
+  instrucciones.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">¿Cómo puedo crear mis propios
+  scripts?</a></h2>
+  <p>Los scripts de Vienna se escriben utilizando AppleScript.
+  Consulte la <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  página de recursos de Apple</a> para obtener más detalles acerca
+  de él y de su uso.</p>
+  <p>Una manera de comenzar es descargar uno de los scripts ya
+  existentes en la <a href=
+  "http://www.vienna-rss.org/vienna_files.html">página de descargas
+  de Vienna</a> y abrirlo con el editor de AppleScripts. Consulte
+  también la <a href=
+  "http://www.vienna-rss.org/vienna_scripting.html">página de
+  scripts</a> para obtener más detalles de los scripts para Vienna
+  y ejemplos de lo que se puede conseguir.</p>
+  <p>Si desea presentar su propio script a la comunidad de usuarios
+  de la aplicación, envíelo a <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  y una vez haya sido probado, se pondrá a disposición de todos en
+  la página de descargas.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  ¿Cómo puedo comprobar si mis suscripciones se han
+  actualizado?</a></h2>
+  <p>Abra la página de actividad del menú Ventana. La ventana de
+  actividad muestra todas las suscripciones y la situación que
+  tenían la última vez que fueron actualizadas durante la presente
+  sesión. La parte inferior de la ventana de actividad muestra más
+  detalles. Entre éstos se incluyen los encabezados HTTP, que
+  podrían ser útiles para detectar y eliminar fallos. Si el panel
+  de actividades no está visible, puede hacerlo aparecer
+  arrastrando hacia la parte superior la barra inferior de la
+  ventana.</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">¿Cómo
+  puedo mover la base de datos de Vienna a otra carpeta?</a></h2>
+  <p>Por defecto, la base de datos de Vienna es el archivo
+  messages.db que se encuentra en ~/Library/Application
+  Support/Vienna. Usted puede moverlo a la carpeta que desee. Los
+  pasos a realizar son los siguientes:</p>
+  <ol>
+    <li>Salga de Vienna.</li>
+    <li>Abra una ventana de la consola e introduzca el siguiente
+    texto:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    donde pone &lt;path to new messages.db&gt; es el nombre de la
+    nueva carpeta que contiene el archivo messages.db. La ruta debe
+    incluir el archivo messages.db al final. Un ejemplo:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Reinicie Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  Una de mis suscripciones muestra el mensaje «Se ha producido un
+  error al procesar los datos XML de la fuente». ¿Qué
+  significa?</a></h2>
+  <p>Significa que Vienna ha obtenido una respuesta de la
+  suscripción que no ha podido interpretar. Hay varias razones para
+  ello:</p>
+  <ol>
+    <li>La URL de la suscripción podría no redirigir a una fuente
+    RSS o Atom sino a una página web. Compruebe la dirección
+    URL.</li>
+    <li>La fuente de noticias podría contener XML incorrecto.
+    Algunas suscripciones cometen un error al unir el XML que
+    compone la fuente y por ello Vienna no puede interpretarlo.
+    Utilice el comando Validar la fuente para comprobar si es el
+    caso. Desafortunadamente no se puede hacer gran cosa más que
+    esperar que se corrija desde la propia página.</li>
+    <li>La fuente de noticias podría estar incompleta. Si la
+    actualización ha sido interrumpida, probablemente el archivo
+    XML esté incompleto y aparece como incorrecto para Vienna. Una
+    segunda actualización podría resolver el problema.</li>
+  </ol>
+  <p>Si ninguna de las posibilidades arriba mencionadas explica el
+  mensaje de error, escriba un mensaje en el foro de soporte,
+  incluyendo la dirección URL de la suscripción que muestra el
+  problema.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  ¿Hay alguna función rápida de teclado para pasar al siguiente
+  artículo, marcar como leído, etc?</a></h2>
+  <p>Probablemente. Existen algunas funciones rápidas de teclado
+  para algunos comandos del menú. Algunos de ellos son:</p>
+  <p>Barra espaciadora - Dirige al siguiente artículo no leído. Si
+  el artículo seleccionado tiene varias páginas, se desplazará
+  primero por el artículo. Sin embargo, el comando Siguiente
+  artículo no leído (Comando-U) siempre se dirige directamente al
+  siguiente artículo no leído.</p>
+  <p>R - Marca el artículo seleccionado como leído si no lo está
+  todavía, o bien como no leído si es que ya ha sido leído.</p>
+  <p>F - Marca con indicador el artículo seleccionado si no ha sido
+  marcado previamente, o bien elimina la marca si lo ha sido.</p>
+  <p>Consulte la ayuda de Vienna para obtener más funciones rápidas
+  de teclado.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">¿Cómo puedo
+  utilizar la auto-eliminación de artículos y qué hace
+  exactamente?</a></h2>
+  <p>La auto-eliminación de artículos mueve a la papelera los
+  artículos que superan una determinada antigüedad. Esto le permite
+  mantener de manera manejable las carpetas guardando únicamente
+  los artículos recientes. La auto-eliminación de artículos
+  funciona tanto cuando se inicia Vienna como cuando se ha
+  actualizado cualquier suscripción. Para especificar una nueva
+  fecha máxima de los artículos sujetos a la auto-eliminación,
+  cambie la opción Mover los artículos a la papelera en las
+  preferencias de la aplicación.</p>
+  <p>La auto-eliminación no eliminará artículos no leídos o con
+  indicador. Vienna entiende que ya que no ha leído estos artículos
+  no desea eliminarlos todavía .</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">¿Cómo puedo sugerir
+  una mejora para Vienna?</a></h2>
+  <p>Escriba un mensaje en el <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">foro de
+  soporte</a>. Todas las mejoras son incluidas en un archivo
+  «To-Do» que se incluye en el código como guía para futuros
+  desarrollos.</p>
 </body>
 </html>

--- a/lproj/es.lproj/Vienna Help/index.html
+++ b/lproj/es.lproj/Vienna Help/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Ayuda de Vienna</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Ayuda de Vienna</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introducci&oacute;n a Vienna</p>
-		<p><a href="intro.html">Aprenda como empezar con Vienna.</a></p>
-
-		<p class="header">Atajos de teclado</p>
-		<p><a href="keyboard.html">Descubra los atajos de teclado para los comandos frecuentes.</a></p>
-
-		<p class="header">¿Cómo hacer?</p>
-		<p><a href="faq.html">Preguntas frecuentes, obtener soporte y pasos de resolución de problemas.</a></p>
-        
-        <p class="header">Configuraci&oacute;n avanzada</p>
-		<p><a href="advanced.html">Explica la configuraci&oacute;n en las preferencias avanzadas.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Ayuda de Vienna</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introducción a Vienna</p>
+          <p><a href="intro.html">Aprenda como empezar con
+          Vienna.</a></p>
+          <p class="header">Atajos de teclado</p>
+          <p><a href="keyboard.html">Descubra los atajos de teclado
+          para los comandos frecuentes.</a></p>
+          <p class="header">¿Cómo hacer?</p>
+          <p><a href="faq.html">Preguntas frecuentes, obtener
+          soporte y pasos de resolución de problemas.</a></p>
+          <p class="header">Configuración avanzada</p>
+          <p><a href="advanced.html">Explica la configuración en
+          las preferencias avanzadas.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/es.lproj/Vienna Help/intro.html
+++ b/lproj/es.lproj/Vienna Help/intro.html
@@ -1,51 +1,108 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introducción a Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introducción a Vienna</span>
-<p>Vienna es una aplicación que le permite leer las fuentes de noticias RSS o Atom en su ordenador con Mac OS X. Automatiza
-el trabajo de conseguir artículos de noticias de todas las fuentes suscritas y las guarda en una base de datos local, lo que permite
-que los artículos también puedan ser leídos cuando no hay disponible una conexión a la red.
-Asimismo incluye opciones de búsqueda que le permiten buscar palabras o frases clave en los artículos, marcar artículos con un indicador
-para tener referencias u organizar las fuentes de artículos relacionadas en grupos. También puede crear carpetas inteligentes que obtienen y muestran de manera fácil y dinámica
-los artículos en función de un determinado criterio de búsqueda. El navegador integrado - dotado con un sistema de pestañas - le permite ver los artículos o enlaces de
-las páginas web
-desde el mismo Vienna.</p>
-<p>Vienna está diseñado para ofrecer una gran facilidad de uso. Posee una interfaz limpia y sencilla que maximiza el espacio para los artículos. Y apenas
-se necesitan unos pocos controles para llevar a cabo las acciones más frecuentes.</p>
-<b>Primeros pasos</b>
-<p>Si ésta es la primera vez que utiliza Vienna se habrá creado automáticamente una base de datos y añadido a ella
-algunas suscripciones. Para actualizarlas pulse Comando-T o bien escoja la opción Actualizar todas las suscripciones que se encuentra en el menú Archivo.</p>
-<p>Obviamente, puede suscribirse a todas las fuentes de noticias que usted desee. Hay varias maneras de encontrar fuentes. Cuando navegue por la 
-web busque el <img src="images/rssfeed.gif" alt=""> o el icono XML que indica que la página tiene una fuente de noticias asociada a ella.
-Por lo general, prácticamente todos los servicios de publicación de blogs, por ejemplo LiveJournal o Blogger/Blogspot, incluyen las fuentes RSS 
-como altenativa a la lectura de contenidos en la propia página.</p>
-<p>Si conoce el nombre de un usuario de LiveJournal, Blogger/Blogspot, MSN Spaces or Xanga, Vienna le proporciona una 
-fácil manera de suscribirse a esa fuente. Empiece pulsando Comando-N o bien seleccionando la opción Crear una nueva suscripción en el menú Archivo.
-En el cuadro de diálogo Crear una nueva suscripción escoja el servicio de publicación de blogs que hay en la lista desplegable e introduzca el nombre de usuario en el campo inferior. Pulse Suscribirse y Vienna añadirá la suscripción a la lista de fuentes. Si en ese momento está conectado a internet automáticamente
-se iniciará la descarga de los artículos disponibles en la fuente.</p>
-<p>Es muy común actualizar las suscripciones de manera manual. Sin embargo, puede optar por la posibilidad de que Vienna lo haga automáticamente tras un determinado periodo de tiempo. Para ello, diríjase a Preferencias y escoja el intervalo de tiempo deseado en la opción Comprobar si hay nuevos artículos. Tenga en cuenta que Vienna necesita estar ejecutándose -ya sea en segundo plano- para
-actualizar automáticamente las suscripciones.</p>
-<p>Al leer los artículos pulse la barra espaciadora y así saltará al siguiente artículo no leído de cualquier suscripción. Cada artículo recibe
-el estado de Leído tras un breve lapso de tiempo. Si prefiere esperar a leer un nuevo artículo para que que se produzca este hecho diríjase a Preferencias.
-Para marcar de nuevo como no leído un artículo, simplemente pulse la tecla R o seleccione la opción Marcar como no leído disponible en el menú Archivo.</p>
-<p>Usted puede ver cualquier artículo o enlace con el propio Vienna. Por defecto al seleccionar un enlace hará que se abra una nueva pestaña con el
-nuevo contenido. Vienna proporciona una navegación similar a los actuales navegadores, pero habrá ocasiones en las que prefiera hacerlo con su navegador preferido. 
-Si desea ver siempre en su navegador las páginas web, active en Preferencias la opción Abrir enlaces en un navegador externo.
-No obstante, si únicamente desea visualizar el artículo seleccionado en ese momento en un navegador externo, haga clic en el botón derecho del ratón
-o pulse Comando a la vez que hace clic con el mencionado ratón y elija la opción Abrir página con XXX (XXX es el nombre de su navegador por defecto).</p>
-<p>Una vez se haya familiarizado a las características y uso de Vienna puede explorar opciones más avanzadas. Por ejemplo, puede cambiar el estilo en el que
-se muestran los artículos gracias a las diferentes posibilidades que se ofrecen en la lista desplegable que encontrará en el menú Ver. 
-Tiene a su disposición más estilos en la página de descargas de Vienna. Allí también encontrará scripts que le permitirán ampliar las posibilidades de uso de la aplicación: podrá hacer que Vienna se 
-relacione de manera más directa con otras aplicaciones de su sistema. Otras posibilidad de uso avanzado es la creación de carpetas inteligentes
-en función del contenido de los artículos. Una muestra de ello podría ser el crear fácilmente una carpeta que guarde todos los artículos que hagan 
-referencia por ejemplo a U2 y Bono. De este modo encontrará rápidamente información acerca de la actividad del grupo o las campañas de sensibilización en las que participa el cantante irlandés.</p>
-<p>Si tiene cualquier pregunta acerca de Vienna o no logra resolver algún problema, diríjase al <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-foro de soporte</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introducción a
+  Vienna</span>
+  <p>Vienna es una aplicación que le permite leer las fuentes de
+  noticias RSS o Atom en su ordenador con Mac OS X. Automatiza el
+  trabajo de conseguir artículos de noticias de todas las fuentes
+  suscritas y las guarda en una base de datos local, lo que permite
+  que los artículos también puedan ser leídos cuando no hay
+  disponible una conexión a la red. Asimismo incluye opciones de
+  búsqueda que le permiten buscar palabras o frases clave en los
+  artículos, marcar artículos con un indicador para tener
+  referencias u organizar las fuentes de artículos relacionadas en
+  grupos. También puede crear carpetas inteligentes que obtienen y
+  muestran de manera fácil y dinámica los artículos en función de
+  un determinado criterio de búsqueda. El navegador integrado -
+  dotado con un sistema de pestañas - le permite ver los artículos
+  o enlaces de las páginas web desde el mismo Vienna.</p>
+  <p>Vienna está diseñado para ofrecer una gran facilidad de uso.
+  Posee una interfaz limpia y sencilla que maximiza el espacio para
+  los artículos. Y apenas se necesitan unos pocos controles para
+  llevar a cabo las acciones más frecuentes.</p><b>Primeros
+  pasos</b>
+  <p>Si ésta es la primera vez que utiliza Vienna se habrá creado
+  automáticamente una base de datos y añadido a ella algunas
+  suscripciones. Para actualizarlas pulse Comando-T o bien escoja
+  la opción Actualizar todas las suscripciones que se encuentra en
+  el menú Archivo.</p>
+  <p>Obviamente, puede suscribirse a todas las fuentes de noticias
+  que usted desee. Hay varias maneras de encontrar fuentes. Cuando
+  navegue por la web busque el <img src="images/rssfeed.gif" alt=
+  "" /> o el icono XML que indica que la página tiene una fuente de
+  noticias asociada a ella. Por lo general, prácticamente todos los
+  servicios de publicación de blogs, por ejemplo LiveJournal o
+  Blogger/Blogspot, incluyen las fuentes RSS como altenativa a la
+  lectura de contenidos en la propia página.</p>
+  <p>Si conoce el nombre de un usuario de LiveJournal,
+  Blogger/Blogspot, MSN Spaces or Xanga, Vienna le proporciona una
+  fácil manera de suscribirse a esa fuente. Empiece pulsando
+  Comando-N o bien seleccionando la opción Crear una nueva
+  suscripción en el menú Archivo. En el cuadro de diálogo Crear una
+  nueva suscripción escoja el servicio de publicación de blogs que
+  hay en la lista desplegable e introduzca el nombre de usuario en
+  el campo inferior. Pulse Suscribirse y Vienna añadirá la
+  suscripción a la lista de fuentes. Si en ese momento está
+  conectado a internet automáticamente se iniciará la descarga de
+  los artículos disponibles en la fuente.</p>
+  <p>Es muy común actualizar las suscripciones de manera manual.
+  Sin embargo, puede optar por la posibilidad de que Vienna lo haga
+  automáticamente tras un determinado periodo de tiempo. Para ello,
+  diríjase a Preferencias y escoja el intervalo de tiempo deseado
+  en la opción Comprobar si hay nuevos artículos. Tenga en cuenta
+  que Vienna necesita estar ejecutándose -ya sea en segundo plano-
+  para actualizar automáticamente las suscripciones.</p>
+  <p>Al leer los artículos pulse la barra espaciadora y así saltará
+  al siguiente artículo no leído de cualquier suscripción. Cada
+  artículo recibe el estado de Leído tras un breve lapso de tiempo.
+  Si prefiere esperar a leer un nuevo artículo para que que se
+  produzca este hecho diríjase a Preferencias. Para marcar de nuevo
+  como no leído un artículo, simplemente pulse la tecla R o
+  seleccione la opción Marcar como no leído disponible en el menú
+  Archivo.</p>
+  <p>Usted puede ver cualquier artículo o enlace con el propio
+  Vienna. Por defecto al seleccionar un enlace hará que se abra una
+  nueva pestaña con el nuevo contenido. Vienna proporciona una
+  navegación similar a los actuales navegadores, pero habrá
+  ocasiones en las que prefiera hacerlo con su navegador preferido.
+  Si desea ver siempre en su navegador las páginas web, active en
+  Preferencias la opción Abrir enlaces en un navegador externo. No
+  obstante, si únicamente desea visualizar el artículo seleccionado
+  en ese momento en un navegador externo, haga clic en el botón
+  derecho del ratón o pulse Comando a la vez que hace clic con el
+  mencionado ratón y elija la opción Abrir página con XXX (XXX es
+  el nombre de su navegador por defecto).</p>
+  <p>Una vez se haya familiarizado a las características y uso de
+  Vienna puede explorar opciones más avanzadas. Por ejemplo, puede
+  cambiar el estilo en el que se muestran los artículos gracias a
+  las diferentes posibilidades que se ofrecen en la lista
+  desplegable que encontrará en el menú Ver. Tiene a su disposición
+  más estilos en la página de descargas de Vienna. Allí también
+  encontrará scripts que le permitirán ampliar las posibilidades de
+  uso de la aplicación: podrá hacer que Vienna se relacione de
+  manera más directa con otras aplicaciones de su sistema. Otras
+  posibilidad de uso avanzado es la creación de carpetas
+  inteligentes en función del contenido de los artículos. Una
+  muestra de ello podría ser el crear fácilmente una carpeta que
+  guarde todos los artículos que hagan referencia por ejemplo a U2
+  y Bono. De este modo encontrará rápidamente información acerca de
+  la actividad del grupo o las campañas de sensibilización en las
+  que participa el cantante irlandés.</p>
+  <p>Si tiene cualquier pregunta acerca de Vienna o no logra
+  resolver algún problema, diríjase al <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">foro de
+  soporte</a>.</p>
 </body>
 </html>

--- a/lproj/es.lproj/Vienna Help/keyboard.html
+++ b/lproj/es.lproj/Vienna Help/keyboard.html
@@ -1,221 +1,256 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Funciones rápidas de teclado</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Funciones rápidas de teclado</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Funciones rápidas de teclado</span>
-<p>Puede utilizar su teclado para llevar a cabo rápidamente muchas acciones en Vienna. Para encontrar las combinaciones de teclas para las acciones más frecuentes,
-consulte en los menús o bien desplácese hacia el final de esta página. Recuerde que
-muchos ítems en Vienna disponen de menú contextual. Para acceder a ellos, pulse la tecla Control y haga clic sobre el ítem seleccionado.</p>
-<p>Para llevar a cabo una acción, pulse las siguientes combinaciones de teclado.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Tecla</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Acción</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Funciones rápidas de teclado</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Desplaza el cursor al cajón de búsqueda.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marca el artículo seleccionado como leído.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marca todo el contenido de la carpeta seleccionada como leído y salta a la siguiente carpeta con artículos no leídos.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marca la carpeta seleccionada como leída.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Marca con indicador el artículo seleccionado.</td>
-  </tr>
-  <tr
-    <td>&lt;</td>
-    <td>Muestra el artículo o página web previa.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Muestra el siguiente artículo o página web.</td>
-  </tr>
-  <tr>
-    <td>Barra espaciadora</td>
-    <td>Muestra el siguiente artículo no leído. En el caso de que el artículo seleccionado disponga de más de una página, se mostrará la siguiente página del artículo.</td>
-  </tr>
-  <tr>
-    <td>Comando-U</td>
-    <td>Muestra el siguiente artículo no leído.</td>
-  </tr>
-  <tr>
-    <td>Aceptar</td>
-    <td>Abre la página original del artículo seleccionado.</td>
-  </tr>
-  <tr>
-    <td>Suprimir</td>
-    <td>Envía el artículo seleccionado a la papelera. Si esta función se utiliza dentro de la papelera, el artículo se eliminará de manera permantente.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>Funciones rápidas de teclado generales</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Comando-N</td>
-    <td>Crea una nueva suscripción.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-F</td>
-    <td>Crea una nueva carpeta inteligente.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-E</td>
-    <td>Edita la dirección URL de la suscripción seleccionada o los criterios de una carpeta inteligente.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-D</td>
-    <td>Elimina la carpeta seleccionada.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-N</td>
-    <td>Renombra la carpeta seleccionada.</td>
-  </tr>
-  <tr>
-    <td>Comando-R</td>
-    <td>Actualiza todas las suscripciones.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-R</td>
-    <td>Actualiza únicamente las suscripciones seleccionadas.</td>
-  </tr>
-  <tr>
-    <td>Comando-Minus</td>
-    <td>Cancela cualquier actualización que se esté produciendo.</td>
-  </tr>
-  <tr>
-    <td>Comando-P</td>
-    <td>Imprime el artículo seleccionado.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-P</td>
-    <td>Muestra la configuración de página.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-V</td>
-    <td>Valida la fuente de noticias.</td>
-  </tr>
-  <tr>
-    <td>Comando-?</td>
-    <td>Muestra la ayuda de Vienna.</td>
-  </tr>
-  <tr>
-    <td><b>Funciones rápidas de teclado para artículos</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-M</td>
-    <td>Marca con indicador los artículos seleccionados.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-U</td>
-    <td>Marca como leídos los artículos seleccionados.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-S</td>
-    <td>Marca como leída la carpeta seleccionada y se desplaza a la siguiente carpeta con artículos no leídos.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-O</td>
-    <td>Restaura un artículo desde la papelera a su carpeta original.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-K</td>
-    <td>Marca como leídos todos los artículos de las carpetas seleccionadas.</td>
-  </tr>
-  <tr>
-    <td>Alt-Comando-K</td>
-    <td>Marca como leídos todos los artículos de todas las carpetas.</td>
-  </tr>
-  <tr>
-    <td><b>Funciones rápidas de teclado para ventanas</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Comando-W</td>
-    <td>Cierra la página activa en el caso de que haya alguna. De no haber ninguna, cierra la propia ventana principal de Vienna.</td>
-  </tr>
-  <tr>
-    <td>Alt-Comando-W</td>
-    <td>Cierra todas las pestañas. Tenga en cuenta que que esta acción sustituye al comamndo Cerrar pestaña del menú Archivo.</td>
-  </tr>
-  <tr>
-    <td>Control-Comando-Izquierda</td>
-    <td>Muestra la pestaña anterior.</td>
-  </tr>
-  <tr>
-    <td>Control-Comando-Derecha</td>
-    <td>Muestra la pestaña siguiente.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-W</td>
-    <td>Cierra la pantalla principal de Vienna pero deja a la aplicación ejecutándose en segundo plano. 
-	Puede acceder de nuevo a la ventana principal haciendo clic en el icono de Vienna o pulsando Comando-1.</td>
-  </tr>
-  <tr>
-    <td>Comando-M</td>
-    <td>Minimiza la ventana de Vienna en el dock.</td>
-  </tr>
-  <tr>
-    <td>Comando-0</td>
-    <td>Muestra la ventana de actividad.</td>
-  </tr>
-  <tr>
-    <td>Comando-1</td>
-    <td>Muestra la ventana principal de Vienna.</td>
-  </tr>
-  <tr>
-    <td>Comando-2</td>
-    <td>Muestra la ventana de descargas.</td>
-  </tr>
-  <tr>
-    <td><b>Funciones rápidas de teclas de ventana</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Actualiza la página web seleccionada.</td>
-  </tr>
-  <tr>
-    <td>Comando-Period</td>
-    <td>Cancela la carga de la página web seleccionada.</td>
-  </tr>
-  <tr>
-    <td>Comando-[/Comando-Izquierda</td>
-    <td>Muestra la anterior página web seleccionada.</td>
-  </tr>
-  <tr>
-    <td>Comando-]/Comando-Derecha</td>
-    <td>Muestra la siguiente página web seleccionada.</td>
-  </tr>
-  <tr>
-    <td>Comando-F</td>
-    <td>Desplaza el cursor al cajón de búsqueda. Escriba alguna palabra y/o texto, pulse la tecla Aceptar y Vienna buscará en la página web seleccionada su solicitud.</td>
-  </tr>
-  <tr>
-    <td>Comando-G</td>
-    <td>Busca la siguiente acepción del cajón de búsqueda en la página web.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Funciones rápidas de
+  teclado</span>
+  <p>Puede utilizar su teclado para llevar a cabo rápidamente
+  muchas acciones en Vienna. Para encontrar las combinaciones de
+  teclas para las acciones más frecuentes, consulte en los menús o
+  bien desplácese hacia el final de esta página. Recuerde que
+  muchos ítems en Vienna disponen de menú contextual. Para acceder
+  a ellos, pulse la tecla Control y haga clic sobre el ítem
+  seleccionado.</p>
+  <p>Para llevar a cabo una acción, pulse las siguientes
+  combinaciones de teclado.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Tecla</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Acción</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Funciones rápidas de teclado</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Desplaza el cursor al cajón de búsqueda.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marca el artículo seleccionado como leído.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marca todo el contenido de la carpeta seleccionada como
+      leído y salta a la siguiente carpeta con artículos no
+      leídos.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marca la carpeta seleccionada como leída.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Marca con indicador el artículo seleccionado.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Muestra el artículo o página web previa.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Muestra el siguiente artículo o página web.</td>
+    </tr>
+    <tr>
+      <td>Barra espaciadora</td>
+      <td>Muestra el siguiente artículo no leído. En el caso de que
+      el artículo seleccionado disponga de más de una página, se
+      mostrará la siguiente página del artículo.</td>
+    </tr>
+    <tr>
+      <td>Comando-U</td>
+      <td>Muestra el siguiente artículo no leído.</td>
+    </tr>
+    <tr>
+      <td>Aceptar</td>
+      <td>Abre la página original del artículo seleccionado.</td>
+    </tr>
+    <tr>
+      <td>Suprimir</td>
+      <td>Envía el artículo seleccionado a la papelera. Si esta
+      función se utiliza dentro de la papelera, el artículo se
+      eliminará de manera permantente.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>Funciones rápidas de teclado
+      generales</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Comando-N</td>
+      <td>Crea una nueva suscripción.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-F</td>
+      <td>Crea una nueva carpeta inteligente.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-E</td>
+      <td>Edita la dirección URL de la suscripción seleccionada o
+      los criterios de una carpeta inteligente.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-D</td>
+      <td>Elimina la carpeta seleccionada.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-N</td>
+      <td>Renombra la carpeta seleccionada.</td>
+    </tr>
+    <tr>
+      <td>Comando-R</td>
+      <td>Actualiza todas las suscripciones.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-R</td>
+      <td>Actualiza únicamente las suscripciones
+      seleccionadas.</td>
+    </tr>
+    <tr>
+      <td>Comando-Minus</td>
+      <td>Cancela cualquier actualización que se esté
+      produciendo.</td>
+    </tr>
+    <tr>
+      <td>Comando-P</td>
+      <td>Imprime el artículo seleccionado.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-P</td>
+      <td>Muestra la configuración de página.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-V</td>
+      <td>Valida la fuente de noticias.</td>
+    </tr>
+    <tr>
+      <td>Comando-?</td>
+      <td>Muestra la ayuda de Vienna.</td>
+    </tr>
+    <tr>
+      <td><b>Funciones rápidas de teclado para artículos</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-M</td>
+      <td>Marca con indicador los artículos seleccionados.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-U</td>
+      <td>Marca como leídos los artículos seleccionados.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-S</td>
+      <td>Marca como leída la carpeta seleccionada y se desplaza a
+      la siguiente carpeta con artículos no leídos.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-O</td>
+      <td>Restaura un artículo desde la papelera a su carpeta
+      original.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-K</td>
+      <td>Marca como leídos todos los artículos de las carpetas
+      seleccionadas.</td>
+    </tr>
+    <tr>
+      <td>Alt-Comando-K</td>
+      <td>Marca como leídos todos los artículos de todas las
+      carpetas.</td>
+    </tr>
+    <tr>
+      <td><b>Funciones rápidas de teclado para ventanas</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Comando-W</td>
+      <td>Cierra la página activa en el caso de que haya alguna. De
+      no haber ninguna, cierra la propia ventana principal de
+      Vienna.</td>
+    </tr>
+    <tr>
+      <td>Alt-Comando-W</td>
+      <td>Cierra todas las pestañas. Tenga en cuenta que que esta
+      acción sustituye al comamndo Cerrar pestaña del menú
+      Archivo.</td>
+    </tr>
+    <tr>
+      <td>Control-Comando-Izquierda</td>
+      <td>Muestra la pestaña anterior.</td>
+    </tr>
+    <tr>
+      <td>Control-Comando-Derecha</td>
+      <td>Muestra la pestaña siguiente.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-W</td>
+      <td>Cierra la pantalla principal de Vienna pero deja a la
+      aplicación ejecutándose en segundo plano. Puede acceder de
+      nuevo a la ventana principal haciendo clic en el icono de
+      Vienna o pulsando Comando-1.</td>
+    </tr>
+    <tr>
+      <td>Comando-M</td>
+      <td>Minimiza la ventana de Vienna en el dock.</td>
+    </tr>
+    <tr>
+      <td>Comando-0</td>
+      <td>Muestra la ventana de actividad.</td>
+    </tr>
+    <tr>
+      <td>Comando-1</td>
+      <td>Muestra la ventana principal de Vienna.</td>
+    </tr>
+    <tr>
+      <td>Comando-2</td>
+      <td>Muestra la ventana de descargas.</td>
+    </tr>
+    <tr>
+      <td><b>Funciones rápidas de teclas de ventana</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Actualiza la página web seleccionada.</td>
+    </tr>
+    <tr>
+      <td>Comando-Period</td>
+      <td>Cancela la carga de la página web seleccionada.</td>
+    </tr>
+    <tr>
+      <td>Comando-[/Comando-Izquierda</td>
+      <td>Muestra la anterior página web seleccionada.</td>
+    </tr>
+    <tr>
+      <td>Comando-]/Comando-Derecha</td>
+      <td>Muestra la siguiente página web seleccionada.</td>
+    </tr>
+    <tr>
+      <td>Comando-F</td>
+      <td>Desplaza el cursor al cajón de búsqueda. Escriba alguna
+      palabra y/o texto, pulse la tecla Aceptar y Vienna buscará en
+      la página web seleccionada su solicitud.</td>
+    </tr>
+    <tr>
+      <td>Comando-G</td>
+      <td>Busca la siguiente acepción del cajón de búsqueda en la
+      página web.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/eus.lproj/Vienna Help/advanced.html
+++ b/lproj/eus.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/eus.lproj/Vienna Help/faq.html
+++ b/lproj/eus.lproj/Vienna Help/faq.html
@@ -1,190 +1,216 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-What do the green dots mean in the list of articles?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.php">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a> and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen. There is a sticky note in
-the forum with tips on how to write a good bug report.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.php">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.php">Vienna Downloads page</a> and view 
-it in the AppleScript editor.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">What do
-the green dots mean in the list of articles?</a></h2>
-<p>The blue dots are for new articles, and the green dots are for updated articles:
-articles whose text has changed since they were last downloaded.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the
-&quot;Move articles to Trash&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> and somebody will investigate. Provide as much
+  information about the problem as you can including: the build of
+  Vienna (obtained from the About Vienna panel), repro steps and
+  what you expected to happen. There is a sticky note in the forum
+  with tips on how to write a good bug report.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.php">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Vienna Downloads
+  page</a> and view it in the AppleScript editor.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">What do
+  the green dots mean in the list of articles?</a></h2>
+  <p>The blue dots are for new articles, and the green dots are for
+  updated articles: articles whose text has changed since they were
+  last downloaded.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Move articles to Trash" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/eus.lproj/Vienna Help/index.html
+++ b/lproj/eus.lproj/Vienna Help/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-
-		<p class="header">Advanced Settings</p>
-		<p><a href="advanced.html">Explains the settings in the Advanced Preferences.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+          <p class="header">Advanced Settings</p>
+          <p><a href="advanced.html">Explains the settings in the
+          Advanced Preferences.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/eus.lproj/Vienna Help/intro.html
+++ b/lproj/eus.lproj/Vienna Help/intro.html
@@ -1,55 +1,96 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the <a href="http://www.vienna-rss.org/vienna_files.php">Downloads</a> page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OS X computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+R or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Downloads</a> page
+  on the Vienna web site along with custom scripts that allow you
+  to integrate Vienna with other applications on your machine. Or
+  experiment with smart folders to organise articles according to
+  criteria based on the contents of each article. For example, you
+  can easily set up a smart folder to group together all articles
+  that mention "Joss Whedon" and "Firefly" to find references to
+  the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/eus.lproj/Vienna Help/keyboard.html
+++ b/lproj/eus.lproj/Vienna Help/keyboard.html
@@ -1,227 +1,253 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-S</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-S</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/fr.lproj/Vienna Help/advanced.html
+++ b/lproj/fr.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Réglages Avancés</span>
-<p>Le panneau Advancé des Préférences proposes des options pour changer des réglages très spécifiques de Vienna qui ne sont pas 
-essentiels pour une utilisation classique, mais qui peuvent résoudre des problèmes comme ceux traités par le forum de Support. 
-Cette page détaille les réglages avancés et les fonction.
-</p>
-<h2><b>Activer JavaScript dans le navigateur interne</b></h2>
-<p>Active ou désactive le support de script JavaScript dans le navigateur interne de Vienna internal. Est activé par défaut. En
-décochant ce réglage, le code JavaScript des pages Web ne sera pas éxécuté. Cela peut résoudre des problèmes avec les pages qui 
-utilisent des scripts pour afficher des fenêtres ou d'autre comportement inattendus, mais cela peut aussi rendre l'affichage de 
-page incomplet ou créer des disfonctionnement.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Réglages
+  Avancés</span>
+  <p>Le panneau Advancé des Préférences proposes des options pour
+  changer des réglages très spécifiques de Vienna qui ne sont pas
+  essentiels pour une utilisation classique, mais qui peuvent
+  résoudre des problèmes comme ceux traités par le forum de
+  Support. Cette page détaille les réglages avancés et les
+  fonction.</p>
+  <h2><b>Activer JavaScript dans le navigateur interne</b></h2>
+  <p>Active ou désactive le support de script JavaScript dans le
+  navigateur interne de Vienna internal. Est activé par défaut. En
+  décochant ce réglage, le code JavaScript des pages Web ne sera
+  pas éxécuté. Cela peut résoudre des problèmes avec les pages qui
+  utilisent des scripts pour afficher des fenêtres ou d'autre
+  comportement inattendus, mais cela peut aussi rendre l'affichage
+  de page incomplet ou créer des disfonctionnement.</p>
 </body>
 </html>

--- a/lproj/fr.lproj/Vienna Help/faq.html
+++ b/lproj/fr.lproj/Vienna Help/faq.html
@@ -1,218 +1,281 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-	<title>Comment faire ?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <title>Comment faire ?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Comment faire ?</span>
-<p>Ci-dessous vous trouverez les questions les plus courantes à propos de Vienna lors de sa phase de beta-test.
-Reportez-vous à la page <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ</a> (en anglais) pour les dernières astuces pour utiliser Vienna.
-</p>
-<ul>
-<li>
-<a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">J'ai rencontré un problème avec Vienna. Comment faire un rapport ?</a></li>
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-Comment puis-je voir ce qui se passe quand les abonnements sont rafraîchis ?</a></li>
-<li>
-<a href="#How_do_I_subscribe_to_a_feed_requiring_user_authentication">
-Comment puis je m'abonner à un flux exigeant une authentification de l'utilisateur ?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">Comment 
-déplacer la base de données Vienna dans un autre dossier ?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Un de mes abonnements renvoie le message &quot;Erreur de traitement 
-des données XML dans le flux&quot;. Qu'est ce que cela signifie ?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Quels sont les raccourcis clavier pour passer à l'article suivant, le 
-marquer comme étant lu, etc. ?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-Que signifie le point vert dans la liste des articles ?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">Comment utiliser
-Auto Expire, et qu'est que cela fait ?</a></li>
-<li>
-<a href="#How_do_I_create_my_own_styles">Comment créer mes propres styles ?</a></li>
-<li>
-<a href="#How_do_I_create_my_own_scripts">Comment créer mes propres scripts ?</a></li>
-
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">Comment demander des 
-améliorations dans Vienna ?</a></li>
-<li>
-<a href="#Where_do_I_get_the_Vienna_source_code">Où obtenir le code source de Vienna ?</a></li>
-
-</ul>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">J'ai rencontré un problème 
-avec Vienna. Comment faire un rapport ?</a></h2>
-<p>Postez un message dans le <a href="http://forums.cocoaforge.com/viewforum.php?f=18">forum de support</a>
-ou dans la <a href="https://github.com/ViennaRSS/vienna-rss/issues">liste des problèmes</a>
-et quelqu'un analysera le problème. Fournissez
-autant d'information que vous pouvez sur le problème, dont notamment : la version du logiciel 
-(disponible dans la fenêtre "À propos"), les actions réalisées et ce à quoi vous vous attendiez. Il 
-y a une note dans le forum avec des instructions pour rédiger un bon rapport de problème.</p>
-
-<p>Assurez-vous que vous utilisez la version la plus récente de Vienna. La commande de vérification 
-de mise à jour vous informera si une version plus récente que la votre existe.</p>
-<p>La résolution des boggues est prioritaire sur l'ajout de fonctionnalités, aussi si votre problème 
-est bien un boggue ayant un impact important et pas une simple amélioration, alors une résolution du 
-problème sera mise à disposition dès que possible.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-Comment puis-je voir ce qui se passe quand les abonnements sont rafraîchis ?</a></h2>
-<p>Ouvrez la fenêtre d'activité à partir du menu Fenêtre. la fenêtre d'activité montre 
-tous les abonnements et le statut de leur dernière rafraîchissement dans la session. Le bas de
-la fenêtre d'activité montre plus de détails et inclut les entêtes HTTP qui peuvent être utiles
-pour débogguer. (Si le panneau de détails n'est pas visible, découvrez-le en faisant glisser la barre 
-située en bas de la fenêtre).</p>
-
-<h2>
-<a name="How_do_I_subscribe_to_a_feed_requiring_user_authentication">
-Comment puis je m'abonner à un flux exigeant une authentification de l'utilisateur ?</a></h2>
-
-<p>Il est important de comprendre que les services de type Open Reader ne permettent pas
-de s'authentifier auprès d'un service tiers. Vienna devra accéder directement au serveur
-qui exige une identification et une authentification de l'utilisateur.<br>
-Quand vous vous abonnez, assurez vous que la case "S'abonner à travers le serveur Open
-Reader" n'est PAS cochée.</p>
-
-<p>Ensuite, il est utile de savoir qu'il y a deux principales méthodes d'authentification
-des utilisateurs qui demandent un flux, et ce selon les serveurs que l'on rencontre :</p>
-<ul>
-<li>certains serveurs exigent un nom d'utilisateur et le mot de passe associé ;</li>
-<li>d'autres serveurs exigent un cookie spécifique.</li>
-</ul>
-<p>Le problème, c'est que beaucoup de serveurs n'indiquent pas clairement quelle méthode
-ils mettent en oeuvre pour les flux nécessitant une authentification.</p>
-
-<p>La demande d'un nom d'utilisateur et du mot de passe associé est la méthode la plus
-courante. C'est aussi celle qui est la plus explicite vis-à-vis de l'utilisateur.
-Lors du premier rafraîchissement du flux, Vienna vous présentera une boite de dialogue
-où vous pourrez entrer le nom d'utilisateur et le mot de passe.<br>
-Vous pouvez vérifier que vous avez fourni un nom d'utilisateur et un mot de passe – et les
-mettre à jour si nécessaire – à travers la boite de dialogue "Infos" du flux.
-Vous accédez à cette boite de dialogue à travers le menu "Dossier → Obtenir les
-infos…" ou via le menu contextuel (clic droit) dans la liste des flux.<br>
-Le mot de passe est stocké de manière sécurisée dans le Trousseau d'accès.</p>
-
-<p>Par contre, pour les serveurs qui exigent un cookie, le nom d'utilisateur et le mot
-de passe ne doivent PAS apparaître dans la boite de dialogue "Infos" du flux. Les deux
-champs DOIVENT être laissés à blanc.<br>
-Par contre, vous devrez être authentifiés auprès du site en vous connectant via le web
-à travers le navigateur Safari ou à travers un onglet de navigation dans Vienna.<br>
-Comme les cookies peuvent expirer après un certain temps, vous serez peut-être obligés
-de vous reconnecter de temps à autres.
-</p>
-
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">Comment 
-déplacer la base de données Vienna dans un autre dossier ?</a></h2>
-
-<p>Par défaut, votre base de données Vienna est le fichier messages.db placé dans 
- ~/Library/Application Support/Vienna. vous pouvez déplacer ce fichier dans le dossier de votre choix.
- Pour cela, suivez les étapes ci-dessous :</p>
-<ol>
-<li>Quitter Vienna.</li>
-<li>Ouvrir une fenêtre de Terminal et taper :<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;chemin_vers_messages.db&gt;'</font><br>
-
-<br>
-où &lt;chemin_vers_messages.db&gt; est le nom complet du fichier messages.db. Le chemin 
-lui-même devrait contenir le nom messages.db à la fin. Par exemple :<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Relancer Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Un de mes abonnements renvoie le message &quot;Erreur de traitement 
-des données XML dans le flux&quot;. Qu'est ce que cela signifie ?</a></h2>
-<p>Cela signifie que Vienna a reçu un retour de l'abonnement qu'il ne sait pas interpréter. 
-Il peut y avoir plusieurs raisons à cela :</p>
-
-<ol>
-<li>L'adresse URL du flux n'indique peut-être pas un flux RSS ou Atom, mais une page Web. Vérifiez 
-attentivement l'URL de l'abonnement en question.</li>
-<li>Le flux lui-même peut contenir un format XML incorrect. Certains abonnements font des erreurs lors 
-de l'assemblage des données XML qui constituent le flux et Vienna ne sait pas interpréter des flux
-XML incorrects. Utilisez la commande de validation des flux à partir du menu Fichier pour identifier un 
-tel cas. Malheureusement, vous ne pourrez rien faire de plus avec Vienna pour recevoir ce flux, si ce
-n'est attendre que le flux soit corrigé par le site émetteur.</li>
-<li>Le flux peut être incomplet. Si le rafraîchissement a été interrompu, alors les données XML seront 
-incomplètes et apparaîtront malformées dans Vienna. Un nouveau rafraîchissement devrait corriger ce 
-problème.</li>
-</ol>
-<p>Si le problème n'est couvert par aucun des cas ci-dessus, alors postez un message sur le forum de support en 
-indiquant l'URL concernée. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Quels sont les raccourcis clavier pour passer à l'article suivant, le marquer comme 
-étant lu, etc. ?</a></h2>
-<p>Il existe des raccourcis à une touche pour quelques unes des commandes des menus, par exemple :</p>
-<p>Barre d'espace - affiche l'article suivant non lu. Si l'article actuellement affiché est long de 
-plusieurs pages, cette commande affichera en priorité les pages suivantes. Elle n'affichera l'article 
-suivant que si la fin de l'article en cours est déjà à l'écran. A l'inverse, la commande Cmd+U affichera 
-diretement l'article non lu suivant, même si l'article en cours n'est pas lu entièrement.</p>
-<p>R - Permute l'état lu / non lu pour l'article en cours.</p>
-<p>F - Permute l'état du drapeau affiché / masqué pour l'article en cours.</p>
-
-<p>Lisez la page dédiées aux raccourcis pour une liste complète.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">Que 
-signifie le point vert dans la liste des articles ?</a></h2>
-<p>Les points bleus signalent les nouveaux articles, et les points verts signalent les articles mis à jour :
-les articles dont le contenu a changé depuis leur dernier téléchargement.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">Comment utiliser
-Auto Expire, et qu'est ce que cela fait ?</a></h2>
-<p>Auto-expire déplace les articles plus vieux qu'un certain nombre de jours 
-dans la corbeille. Cela permet d'obtenir des dossiers gérables en 
-conservant uniquement les articles les plus récents. Cette fonction s'exécute 
-à la fois au démarrage de Vienna et après le rafraîchissement des abonnements. 
-Dans les préférences, modifiez le paramètre &quot;Expirer les articles vieux de&quot;
-pour déterminer les articles à expurger.</p>
-<p>Auto-expire n'effacera pas les articles non lus ou marqués d'un drapeau.</p>
-
-<h2><a name="How_do_I_create_my_own_styles">Comment créer mes propres styles ?</a></h2>
-<p>Voir la page <a href="http://www.vienna-rss.org/?page_id=65">Styles personnalisés</a> pour les instructions.</p>
-
-<h2><a name="How_do_I_create_my_own_scripts">Comment créer mes propres scripts ?</a></h2>
-
-<p>Le pilotage de Vienna par des scripts est possible en utilisant AppleScript. Voir la page de 
-<a href="http://developer.apple.com/applescript/">
-ressources Apple</a> pour plus de détails.</p>
-<p>Un moyen de débuter est de télécharger un des scripts existants comme celui du
-<a href="http://www.cortig.net/files/ShareWithPapers.zip">plugin de partage avec Papers</a>
-écrit par Cortig ou le script de partage de
-<a href="https://github.com/reefdog/Vienna-to-Yojimbo-AppleScripts">Vienna vers Yojimbo</a> écrit par reefdog
-et de les visualiser dans l'éditeur d'AppleScript.
-
-<p>Pour soumettre vos propres scripts, envoyez-les dans le forum de support, et après qu'ils sont revus, ils seront diffusés sur la page de
-téléchargement.</p>
-
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">Comment demander des 
-améliorations dans Vienna ?</a></h2>
-
-<p>Laisser un message sur la
-<a href="https://github.com/ViennaRSS/vienna-rss/issues">liste de problèmes ou demandes</a> (en anglais).</p>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">
-Où obtenir le code source de Vienna ?</a></h2>
-<p>Voir la <a href="https://github.com/ViennaRSS/vienna-rss/">page de développement</a> contenant les instructions 
-pour obtenir le code source de Vienna. Le code source est disponible librement 
-si vous vous intéressez au fonctionnement de Vienna, si vous souhaitez compiler votre propre 
-copie de Vienna sur votre ordinateur ou si vous souhaitez emprunter des portions de codes 
-pour les inclures dans votre propre projet. Le code source est diffusé sous la  
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">licence Apache 2.0</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Comment faire
+  ?</span>
+  <p>Ci-dessous vous trouverez les questions les plus courantes à
+  propos de Vienna lors de sa phase de beta-test. Reportez-vous à
+  la page <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna
+  FAQ</a> (en anglais) pour les dernières astuces pour utiliser
+  Vienna.</p>
+  <ul>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">J'ai
+    rencontré un problème avec Vienna. Comment faire un rapport
+    ?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    Comment puis-je voir ce qui se passe quand les abonnements sont
+    rafraîchis ?</a></li>
+    <li><a href=
+    "#How_do_I_subscribe_to_a_feed_requiring_user_authentication">Comment
+    puis je m'abonner à un flux exigeant une authentification de
+    l'utilisateur ?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">Comment
+    déplacer la base de données Vienna dans un autre dossier
+    ?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    Un de mes abonnements renvoie le message "Erreur de traitement
+    des données XML dans le flux". Qu'est ce que cela signifie
+    ?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Quels sont les raccourcis clavier pour passer à l'article
+    suivant, le marquer comme étant lu, etc. ?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">Que
+    signifie le point vert dans la liste des articles ?</a></li>
+    <li><a href=
+    "#How_do_I_use_Auto_Expire_and_what_does_it_do">Comment
+    utiliser Auto Expire, et qu'est que cela fait ?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">Comment créer mes
+    propres styles ?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">Comment créer mes
+    propres scripts ?</a></li>
+    <li><a href=
+    "#How_do_I_request_an_enhancement_in_Vienna">Comment demander
+    des améliorations dans Vienna ?</a></li>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Où obtenir
+    le code source de Vienna ?</a></li>
+  </ul>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">J'ai
+  rencontré un problème avec Vienna. Comment faire un rapport
+  ?</a></h2>
+  <p>Postez un message dans le <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">forum de
+  support</a> ou dans la <a href=
+  "https://github.com/ViennaRSS/vienna-rss/issues">liste des
+  problèmes</a> et quelqu'un analysera le problème. Fournissez
+  autant d'information que vous pouvez sur le problème, dont
+  notamment : la version du logiciel (disponible dans la fenêtre "À
+  propos"), les actions réalisées et ce à quoi vous vous attendiez.
+  Il y a une note dans le forum avec des instructions pour rédiger
+  un bon rapport de problème.</p>
+  <p>Assurez-vous que vous utilisez la version la plus récente de
+  Vienna. La commande de vérification de mise à jour vous informera
+  si une version plus récente que la votre existe.</p>
+  <p>La résolution des boggues est prioritaire sur l'ajout de
+  fonctionnalités, aussi si votre problème est bien un boggue ayant
+  un impact important et pas une simple amélioration, alors une
+  résolution du problème sera mise à disposition dès que
+  possible.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  Comment puis-je voir ce qui se passe quand les abonnements sont
+  rafraîchis ?</a></h2>
+  <p>Ouvrez la fenêtre d'activité à partir du menu Fenêtre. la
+  fenêtre d'activité montre tous les abonnements et le statut de
+  leur dernière rafraîchissement dans la session. Le bas de la
+  fenêtre d'activité montre plus de détails et inclut les entêtes
+  HTTP qui peuvent être utiles pour débogguer. (Si le panneau de
+  détails n'est pas visible, découvrez-le en faisant glisser la
+  barre située en bas de la fenêtre).</p>
+  <h2><a name=
+  "How_do_I_subscribe_to_a_feed_requiring_user_authentication" id=
+  "How_do_I_subscribe_to_a_feed_requiring_user_authentication">Comment
+  puis je m'abonner à un flux exigeant une authentification de
+  l'utilisateur ?</a></h2>
+  <p>Il est important de comprendre que les services de type Open
+  Reader ne permettent pas de s'authentifier auprès d'un service
+  tiers. Vienna devra accéder directement au serveur qui exige une
+  identification et une authentification de l'utilisateur.<br />
+  Quand vous vous abonnez, assurez vous que la case "S'abonner à
+  travers le serveur Open Reader" n'est PAS cochée.</p>
+  <p>Ensuite, il est utile de savoir qu'il y a deux principales
+  méthodes d'authentification des utilisateurs qui demandent un
+  flux, et ce selon les serveurs que l'on rencontre :</p>
+  <ul>
+    <li>certains serveurs exigent un nom d'utilisateur et le mot de
+    passe associé ;</li>
+    <li>d'autres serveurs exigent un cookie spécifique.</li>
+  </ul>
+  <p>Le problème, c'est que beaucoup de serveurs n'indiquent pas
+  clairement quelle méthode ils mettent en oeuvre pour les flux
+  nécessitant une authentification.</p>
+  <p>La demande d'un nom d'utilisateur et du mot de passe associé
+  est la méthode la plus courante. C'est aussi celle qui est la
+  plus explicite vis-à-vis de l'utilisateur. Lors du premier
+  rafraîchissement du flux, Vienna vous présentera une boite de
+  dialogue où vous pourrez entrer le nom d'utilisateur et le mot de
+  passe.<br />
+  Vous pouvez vérifier que vous avez fourni un nom d'utilisateur et
+  un mot de passe – et les mettre à jour si nécessaire – à travers
+  la boite de dialogue "Infos" du flux. Vous accédez à cette boite
+  de dialogue à travers le menu "Dossier → Obtenir les infos…" ou
+  via le menu contextuel (clic droit) dans la liste des flux.<br />
+  Le mot de passe est stocké de manière sécurisée dans le Trousseau
+  d'accès.</p>
+  <p>Par contre, pour les serveurs qui exigent un cookie, le nom
+  d'utilisateur et le mot de passe ne doivent PAS apparaître dans
+  la boite de dialogue "Infos" du flux. Les deux champs DOIVENT
+  être laissés à blanc.<br />
+  Par contre, vous devrez être authentifiés auprès du site en vous
+  connectant via le web à travers le navigateur Safari ou à travers
+  un onglet de navigation dans Vienna.<br />
+  Comme les cookies peuvent expirer après un certain temps, vous
+  serez peut-être obligés de vous reconnecter de temps à
+  autres.</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">Comment
+  déplacer la base de données Vienna dans un autre dossier
+  ?</a></h2>
+  <p>Par défaut, votre base de données Vienna est le fichier
+  messages.db placé dans ~/Library/Application Support/Vienna. vous
+  pouvez déplacer ce fichier dans le dossier de votre choix. Pour
+  cela, suivez les étapes ci-dessous :</p>
+  <ol>
+    <li>Quitter Vienna.</li>
+    <li>Ouvrir une fenêtre de Terminal et taper :<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '&lt;chemin_vers_messages.db&gt;'</font><br />
+    <br />
+    où &lt;chemin_vers_messages.db&gt; est le nom complet du
+    fichier messages.db. Le chemin lui-même devrait contenir le nom
+    messages.db à la fin. Par exemple :<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Relancer Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  Un de mes abonnements renvoie le message "Erreur de traitement
+  des données XML dans le flux". Qu'est ce que cela signifie
+  ?</a></h2>
+  <p>Cela signifie que Vienna a reçu un retour de l'abonnement
+  qu'il ne sait pas interpréter. Il peut y avoir plusieurs raisons
+  à cela :</p>
+  <ol>
+    <li>L'adresse URL du flux n'indique peut-être pas un flux RSS
+    ou Atom, mais une page Web. Vérifiez attentivement l'URL de
+    l'abonnement en question.</li>
+    <li>Le flux lui-même peut contenir un format XML incorrect.
+    Certains abonnements font des erreurs lors de l'assemblage des
+    données XML qui constituent le flux et Vienna ne sait pas
+    interpréter des flux XML incorrects. Utilisez la commande de
+    validation des flux à partir du menu Fichier pour identifier un
+    tel cas. Malheureusement, vous ne pourrez rien faire de plus
+    avec Vienna pour recevoir ce flux, si ce n'est attendre que le
+    flux soit corrigé par le site émetteur.</li>
+    <li>Le flux peut être incomplet. Si le rafraîchissement a été
+    interrompu, alors les données XML seront incomplètes et
+    apparaîtront malformées dans Vienna. Un nouveau
+    rafraîchissement devrait corriger ce problème.</li>
+  </ol>
+  <p>Si le problème n'est couvert par aucun des cas ci-dessus,
+  alors postez un message sur le forum de support en indiquant
+  l'URL concernée.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Quels sont les raccourcis clavier pour passer à l'article
+  suivant, le marquer comme étant lu, etc. ?</a></h2>
+  <p>Il existe des raccourcis à une touche pour quelques unes des
+  commandes des menus, par exemple :</p>
+  <p>Barre d'espace - affiche l'article suivant non lu. Si
+  l'article actuellement affiché est long de plusieurs pages, cette
+  commande affichera en priorité les pages suivantes. Elle
+  n'affichera l'article suivant que si la fin de l'article en cours
+  est déjà à l'écran. A l'inverse, la commande Cmd+U affichera
+  diretement l'article non lu suivant, même si l'article en cours
+  n'est pas lu entièrement.</p>
+  <p>R - Permute l'état lu / non lu pour l'article en cours.</p>
+  <p>F - Permute l'état du drapeau affiché / masqué pour l'article
+  en cours.</p>
+  <p>Lisez la page dédiées aux raccourcis pour une liste
+  complète.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">Que
+  signifie le point vert dans la liste des articles ?</a></h2>
+  <p>Les points bleus signalent les nouveaux articles, et les
+  points verts signalent les articles mis à jour : les articles
+  dont le contenu a changé depuis leur dernier téléchargement.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">Comment utiliser
+  Auto Expire, et qu'est ce que cela fait ?</a></h2>
+  <p>Auto-expire déplace les articles plus vieux qu'un certain
+  nombre de jours dans la corbeille. Cela permet d'obtenir des
+  dossiers gérables en conservant uniquement les articles les plus
+  récents. Cette fonction s'exécute à la fois au démarrage de
+  Vienna et après le rafraîchissement des abonnements. Dans les
+  préférences, modifiez le paramètre "Expirer les articles vieux
+  de" pour déterminer les articles à expurger.</p>
+  <p>Auto-expire n'effacera pas les articles non lus ou marqués
+  d'un drapeau.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">Comment créer mes propres styles
+  ?</a></h2>
+  <p>Voir la page <a href=
+  "http://www.vienna-rss.org/?page_id=65">Styles personnalisés</a>
+  pour les instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">Comment créer mes propres
+  scripts ?</a></h2>
+  <p>Le pilotage de Vienna par des scripts est possible en
+  utilisant AppleScript. Voir la page de <a href=
+  "http://developer.apple.com/applescript/">ressources Apple</a>
+  pour plus de détails.</p>
+  <p>Un moyen de débuter est de télécharger un des scripts
+  existants comme celui du <a href=
+  "http://www.cortig.net/files/ShareWithPapers.zip">plugin de
+  partage avec Papers</a> écrit par Cortig ou le script de partage
+  de <a href=
+  "https://github.com/reefdog/Vienna-to-Yojimbo-AppleScripts">Vienna
+  vers Yojimbo</a> écrit par reefdog et de les visualiser dans
+  l'éditeur d'AppleScript.</p>
+  <p>Pour soumettre vos propres scripts, envoyez-les dans le forum
+  de support, et après qu'ils sont revus, ils seront diffusés sur
+  la page de téléchargement.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">Comment demander des
+  améliorations dans Vienna ?</a></h2>
+  <p>Laisser un message sur la <a href=
+  "https://github.com/ViennaRSS/vienna-rss/issues">liste de
+  problèmes ou demandes</a> (en anglais).</p>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Où obtenir le code source
+  de Vienna ?</a></h2>
+  <p>Voir la <a href=
+  "https://github.com/ViennaRSS/vienna-rss/">page de
+  développement</a> contenant les instructions pour obtenir le code
+  source de Vienna. Le code source est disponible librement si vous
+  vous intéressez au fonctionnement de Vienna, si vous souhaitez
+  compiler votre propre copie de Vienna sur votre ordinateur ou si
+  vous souhaitez emprunter des portions de codes pour les inclures
+  dans votre propre projet. Le code source est diffusé sous la
+  <a href="http://www.apache.org/licenses/LICENSE-2.0.html">licence
+  Apache 2.0</a>.</p>
 </body>
 </html>

--- a/lproj/fr.lproj/Vienna Help/index.html
+++ b/lproj/fr.lproj/Vienna Help/index.html
@@ -1,37 +1,42 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Aide Vienna</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Aide Vienna</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction à Vienna</p>
-		<p><a href="intro.html">Apprendre comment débuter avec Vienna.</a></p>
-
-		<p class="header">Raccourcis clavier</p>
-		<p><a href="keyboard.html">Découvrir les raccourcis clavier pour les commandes courantes</a></p>
-
-		<p class="header">Comment faire ?</p>
-		<p><a href="faq.html">Questions fréquemment posées, obtenir du support, étapes de dépannage.</a></p>
-
-		<p class="header">Réglages avancés</p>
-		<p><a href="advanced.html">Explications des réglages de l'onglet Advancés des Préférences.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Aide Vienna</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction à Vienna</p>
+          <p><a href="intro.html">Apprendre comment débuter avec
+          Vienna.</a></p>
+          <p class="header">Raccourcis clavier</p>
+          <p><a href="keyboard.html">Découvrir les raccourcis
+          clavier pour les commandes courantes</a></p>
+          <p class="header">Comment faire ?</p>
+          <p><a href="faq.html">Questions fréquemment posées,
+          obtenir du support, étapes de dépannage.</a></p>
+          <p class="header">Réglages avancés</p>
+          <p><a href="advanced.html">Explications des réglages de
+          l'onglet Advancés des Préférences.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/fr.lproj/Vienna Help/intro.html
+++ b/lproj/fr.lproj/Vienna Help/intro.html
@@ -1,77 +1,130 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
   <title>Introduction à Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction à Vienna</span>
-<p>Vienna est une application qui permet de lire des flux RSS ou Atom sur les systèmes Mac OS X. Il automatise la 
-récupération des nouveaux articles pour tous les abonnements auxquels vous aurez souscrit et les stocke dans une base de 
-données locale pour une lecture hors-ligne. Il fournit des fonctions permettant de rechercher parmi les flux via des 
-mots-clés ou des phrases, de marquer des articles pour un référencement ultérieur et d'organiser des flux ensemble à 
-travers des groupes. Vous pouvez créer des dossiers intelligents qui rendent aisé de retrouver et consulter dynamiquement 
-tous les articles de la base qui satisfont des critères de sélection. Le navigateur internet intégré permet d'afficher 
-dans un onglet séparé, la page web des articles ou les liens présents dans les articles.</p>
-<p>Vienna est conçu pour être simple et facile à utiliser. Une interface propre et dépouillée maximise l'espace pour les 
-articles, et seules quelques commandes sont nécessaires pour effectuer les actions les plus courantes dans l'interface 
-utilisateur.</p>
-<b>Pour démarrer</b>
-<p>Lors de la première utilisation de Vienna, il crée une base de données et ajoute quelques abonnements d'exemple. 
-Continuez ainsi et pressez Commande+T ou choisissez "Rafraîchir les abonnements" à partir du menu Fichier pour récupérer les 
-derniers articles pour ces abonnements.</p>
-<p>Sinon, souscrivez à vos propres nouveaux flux. Il y a différents moyens de trouver ces flux. En surfant sut le net, 
-repérez les icônes <img src="images/rssfeed.gif" alt="RSS feed icon"> ou XML indiquant qu'un flux est associé à la page.  De 
-plus, presque tous les services de blogs tels que LiveJournal ou Blogger fournissent des flux RSS comme alternative 
-à une lecture des publications en ligne.</p>
-<p>Si vous connaissez le nom d'utilisateur d'un bloggueur inscrit sur LiveJournal, Blogger, MSN Spaces ou Xanga alors 
-Vienna fournit un moyen aisé de souscrire à son flux. Pressez Commande+N ou choisissez la commande "Nouvel abonnement..." à 
-partir du menu Fichier. Dans le panneau qui s'affiche, sélectionnez le service de Blog dans la liste déroulante, et 
-saisissez enfin le nom de l'utilisateur dans le champ de texte en dessous. Confirmer par le bouton "S'abonner" et Vienna 
-ajoutera l'abonnement dans la liste des dossiers. Si vous êtes connectés à Internet au même moment, il commencera tout de 
-suite à collecter les articles pour ce flux.</p>
-<p>Vous pouvez aussi utiliser Vienna en lien avec un compte de serveur Open Reader. Allez dans Préférences... / Syncing et activez
-la case "Synchroniser avec un serveur Open Reader".<br>
-Au préalable, interrogez vous sur les flux que vous lirez à travers Open Reader et ceux pour lesquels vous choisirez un
-accès direct.
-Vienna évitera de créer des doublons entre les deux catégories, mais si vous vous abonnez dans Open Reader à des flux
-auxquels Vienna accède directement, vous aurez des incohérences dans vos listes de lectures. Tenez en compte.<br>
-Certains éléments sont à prendre en compte dans votre organisation :
-<ul>
-<li>Les flux Open Reader peuvent être synchronisés entre différents appareils et différentes applications qui supportent
-la synchronisation Open Reader</li>
-<li>Open Reader ne permet pas d'accéder aux flux nécessitant un nom d'utilisateur et un mot de passe</li>
-<li>Accéder directement aux sites évite l'intermédiaire que constitue un service Open Reader. Vous récupérerez souvent
-l'information plus vite, notamment en ce qui concerne les sites un peu moins "populaires".</li>
-<li>Généralement, l'accès direct aux sites d'origine entraîne moins de trafic réseau. Lorsque le serveur signale qu'il n'y a
-pas de nouveaux articles depuis la dernière collecte, Vienna évite un téléchargement inutile.</li>
-</ul></p>
-<p>Normalement vous devez indiquer manuellement à Vienna de rafraîchir les abonnements. Cependant, cela peut être
-automatisé à intervalles réguliers. Pour cela, ouvrez la section "Générale" du panneau de Préférences, sélectionnez 
-l'intervalle de rafraîchissement dans la liste déroulante en face du paramètre 'Relever les nouveaux articles'. Vienna doit 
-être lancé pour pouvoir exécuter le rafraîchissement automatique.</p>
-<p>Lors de la lecture des articles, pressez la barre d'espace pour passer au prochain article non lu. Chaque article est 
-marqué comme étant lu automatiquement après un court délai. Si vous préférez attendre de passer à l'article suivant pour 
-marquer l'article actuel comme étant lu, alors modifiez ce réglage dans la section "Générale" des Préférences. Pour marquer 
-à nouveau un article comme étant non lu, choisissez la commande "Marquer comme non lu" à partir du menu Message ou pressez 
-simplement la touche 'R'.</p>
-<p>Finalement, vous pouvez visualiser dans Vienna la page web de l'article ou n'importe quelle page dont le lien est 
-contenu dans un article. Vienna supporte beaucoup des fonctions élémentaires d'un navigation internet. Par défaut, cliquer 
-sur un lien dans Vienna ouvrira la page web dans un nouvel onglet. Si vous préférez visualiser toutes les pages web 
-avec une autre navigateur, alors dans la section "Générale" du panneau de Préférences, activez l'option 'Ouvrir les liens 
-dans un autre navigateur'. Pour visualiser au cas par cas les liens pour les pages dans un autre navigateur, choisissez 
-dans le menu contextuel de la page (bouton droit ou Crontrol-clic) la commande "Ouvrir le lien dans XXX" ou "Ouvrir la page 
-dans XXX" où XXX est le nom de votre navigateur internet par défaut.</p>
-<p>Dès que vous vous sentirez à l'aise avec Vienna, poursuivez et explorez the différentes options. Vous pouvez changer 
-l'apparence d'affichage des articles en sélectionnant un Style dans la liste du menu Affichage/Style. Vous trouverez 
-beaucoup plus de styles personnalisés sur la page de <a href="http://www.vienna-rss.org/?page_id=76">téléchargement</a> 
-du site web de Vienna, ainsi que des scripts qui permettent d'intégrer Vienna aux autres applications de votre ordinateur. 
-Vous pouvez expérimenter les dossiers intelligents pour organiser les articles selon des critères fondés sur le contenu de 
-chaque article.</p>
-<p>Si vous avez des questions au sujet de Vienna ou si vous rencontrez des problèmes, envoyez un e-mail à <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> 
-ou reportez-vous au <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-forum de support</a> (en anglais).</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction à
+  Vienna</span>
+  <p>Vienna est une application qui permet de lire des flux RSS ou
+  Atom sur les systèmes Mac OS X. Il automatise la récupération des
+  nouveaux articles pour tous les abonnements auxquels vous aurez
+  souscrit et les stocke dans une base de données locale pour une
+  lecture hors-ligne. Il fournit des fonctions permettant de
+  rechercher parmi les flux via des mots-clés ou des phrases, de
+  marquer des articles pour un référencement ultérieur et
+  d'organiser des flux ensemble à travers des groupes. Vous pouvez
+  créer des dossiers intelligents qui rendent aisé de retrouver et
+  consulter dynamiquement tous les articles de la base qui
+  satisfont des critères de sélection. Le navigateur internet
+  intégré permet d'afficher dans un onglet séparé, la page web des
+  articles ou les liens présents dans les articles.</p>
+  <p>Vienna est conçu pour être simple et facile à utiliser. Une
+  interface propre et dépouillée maximise l'espace pour les
+  articles, et seules quelques commandes sont nécessaires pour
+  effectuer les actions les plus courantes dans l'interface
+  utilisateur.</p><b>Pour démarrer</b>
+  <p>Lors de la première utilisation de Vienna, il crée une base de
+  données et ajoute quelques abonnements d'exemple. Continuez ainsi
+  et pressez Commande+T ou choisissez "Rafraîchir les abonnements"
+  à partir du menu Fichier pour récupérer les derniers articles
+  pour ces abonnements.</p>
+  <p>Sinon, souscrivez à vos propres nouveaux flux. Il y a
+  différents moyens de trouver ces flux. En surfant sut le net,
+  repérez les icônes <img src="images/rssfeed.gif" alt=
+  "RSS feed icon" /> ou XML indiquant qu'un flux est associé à la
+  page. De plus, presque tous les services de blogs tels que
+  LiveJournal ou Blogger fournissent des flux RSS comme alternative
+  à une lecture des publications en ligne.</p>
+  <p>Si vous connaissez le nom d'utilisateur d'un bloggueur inscrit
+  sur LiveJournal, Blogger, MSN Spaces ou Xanga alors Vienna
+  fournit un moyen aisé de souscrire à son flux. Pressez Commande+N
+  ou choisissez la commande "Nouvel abonnement..." à partir du menu
+  Fichier. Dans le panneau qui s'affiche, sélectionnez le service
+  de Blog dans la liste déroulante, et saisissez enfin le nom de
+  l'utilisateur dans le champ de texte en dessous. Confirmer par le
+  bouton "S'abonner" et Vienna ajoutera l'abonnement dans la liste
+  des dossiers. Si vous êtes connectés à Internet au même moment,
+  il commencera tout de suite à collecter les articles pour ce
+  flux.</p>
+  <p>Vous pouvez aussi utiliser Vienna en lien avec un compte de
+  serveur Open Reader. Allez dans Préférences... / Syncing et
+  activez la case "Synchroniser avec un serveur Open Reader".<br />
+  Au préalable, interrogez vous sur les flux que vous lirez à
+  travers Open Reader et ceux pour lesquels vous choisirez un accès
+  direct. Vienna évitera de créer des doublons entre les deux
+  catégories, mais si vous vous abonnez dans Open Reader à des flux
+  auxquels Vienna accède directement, vous aurez des incohérences
+  dans vos listes de lectures. Tenez en compte.<br />
+  Certains éléments sont à prendre en compte dans votre
+  organisation :</p>
+  <ul>
+    <li>Les flux Open Reader peuvent être synchronisés entre
+    différents appareils et différentes applications qui supportent
+    la synchronisation Open Reader</li>
+    <li>Open Reader ne permet pas d'accéder aux flux nécessitant un
+    nom d'utilisateur et un mot de passe</li>
+    <li>Accéder directement aux sites évite l'intermédiaire que
+    constitue un service Open Reader. Vous récupérerez souvent
+    l'information plus vite, notamment en ce qui concerne les sites
+    un peu moins "populaires".</li>
+    <li>Généralement, l'accès direct aux sites d'origine entraîne
+    moins de trafic réseau. Lorsque le serveur signale qu'il n'y a
+    pas de nouveaux articles depuis la dernière collecte, Vienna
+    évite un téléchargement inutile.</li>
+  </ul>
+  <p>Normalement vous devez indiquer manuellement à Vienna de
+  rafraîchir les abonnements. Cependant, cela peut être automatisé
+  à intervalles réguliers. Pour cela, ouvrez la section "Générale"
+  du panneau de Préférences, sélectionnez l'intervalle de
+  rafraîchissement dans la liste déroulante en face du paramètre
+  'Relever les nouveaux articles'. Vienna doit être lancé pour
+  pouvoir exécuter le rafraîchissement automatique.</p>
+  <p>Lors de la lecture des articles, pressez la barre d'espace
+  pour passer au prochain article non lu. Chaque article est marqué
+  comme étant lu automatiquement après un court délai. Si vous
+  préférez attendre de passer à l'article suivant pour marquer
+  l'article actuel comme étant lu, alors modifiez ce réglage dans
+  la section "Générale" des Préférences. Pour marquer à nouveau un
+  article comme étant non lu, choisissez la commande "Marquer comme
+  non lu" à partir du menu Message ou pressez simplement la touche
+  'R'.</p>
+  <p>Finalement, vous pouvez visualiser dans Vienna la page web de
+  l'article ou n'importe quelle page dont le lien est contenu dans
+  un article. Vienna supporte beaucoup des fonctions élémentaires
+  d'un navigation internet. Par défaut, cliquer sur un lien dans
+  Vienna ouvrira la page web dans un nouvel onglet. Si vous
+  préférez visualiser toutes les pages web avec une autre
+  navigateur, alors dans la section "Générale" du panneau de
+  Préférences, activez l'option 'Ouvrir les liens dans un autre
+  navigateur'. Pour visualiser au cas par cas les liens pour les
+  pages dans un autre navigateur, choisissez dans le menu
+  contextuel de la page (bouton droit ou Crontrol-clic) la commande
+  "Ouvrir le lien dans XXX" ou "Ouvrir la page dans XXX" où XXX est
+  le nom de votre navigateur internet par défaut.</p>
+  <p>Dès que vous vous sentirez à l'aise avec Vienna, poursuivez et
+  explorez the différentes options. Vous pouvez changer l'apparence
+  d'affichage des articles en sélectionnant un Style dans la liste
+  du menu Affichage/Style. Vous trouverez beaucoup plus de styles
+  personnalisés sur la page de <a href=
+  "http://www.vienna-rss.org/?page_id=76">téléchargement</a> du
+  site web de Vienna, ainsi que des scripts qui permettent
+  d'intégrer Vienna aux autres applications de votre ordinateur.
+  Vous pouvez expérimenter les dossiers intelligents pour organiser
+  les articles selon des critères fondés sur le contenu de chaque
+  article.</p>
+  <p>Si vous avez des questions au sujet de Vienna ou si vous
+  rencontrez des problèmes, envoyez un e-mail à <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> ou
+  reportez-vous au <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">forum de
+  support</a> (en anglais).</p>
 </body>
 </html>

--- a/lproj/fr.lproj/Vienna Help/keyboard.html
+++ b/lproj/fr.lproj/Vienna Help/keyboard.html
@@ -1,316 +1,364 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-	<title>Raccourcis clavier</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <title>Raccourcis clavier</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Raccourcis clavier</span>
-<p>Dans Vienna vous pouvez utiliser votre clavier pour exécuter rapidement beaucoup d'actions. Pour trouver les 
-raccourcis clavier pour les commandes courantes, regardez dans les menus (ou parcourrez la liste en bas de cette 
-page). Beaucoup d'objets dans Vienna, tels que la liste des dossiers ou celle des articles possèdent aussi un 
-menu contextuel. Pour afficher un menu contextuel, pressez la touche "Ctrl" et cliquez sur l'objet.</p>
-<p>Pour réaliser une action, pressez les raccourcis indiqués ci-dessous.</p>
-<table width="100%" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Combinaison de touches</b></td>
-    <td  bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="250"><b>Raccourci à une touche</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="150">f</td>
-    <td>Ouvrir la barre de recherche et sélectionne le champ de recherche.</td>
-  </tr>
-  <tr>
-    <td>h</td>
-    <td>Sélectionne le champ de recherche.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marque tous les articles du dossier courant comme étant lus.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Permute l'état affiché/masqué du drapeau pour les articles sélectionnés.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Va à l'article non lu suivant.</td>
-  </tr>
-  <tr>
-    <td>r <i>ou</i> u</td>
-    <td>Permute l'état lu/non lu pour les articles sélectionnés.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marque tous les articles du dossier courant comme étant lus et passe au prochain dossier contenant des articles non lus.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Affiche l'article ou la page web précédent.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Affiche l'article ou la page web suivant.</td>
-  </tr>
-  <tr>
-    <td>Gauche</td>
-    <td>Sélectionne  la liste des dossiers lorsque on se trouve dans la liste des articles</td>
-  </tr>
-  <tr>
-    <td>Barre d'espace</td>
-    <td>Passe au prochain article non lu, à moins qu'il reste du texte à afficher pour l'article en cours ; dans ce cas, on affiche la page de texte suivante.</td>
-  </tr>
-  <tr>
-    <td>Entrée <i>ou</i> Return</td>
-    <td>Ouvre la page web source de l'article sélectionné.</td>
-  </tr>
-  <tr>
-    <td>Suppr <i>ou</i> Backspace</td>
-    <td>Déplace les articles sélectionnés dans la corbeille. Lorsque cette commande est utilisée à partir de la corbeille, les articles sélectionnés sont définitivement détruits.</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="250"><b>Raccourcis généraux</b></td>
-    <td>&nbsp;</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="150">Alt-Click</td>
-    <td>Ouvre la page originelle de l'article dans un onglet sans tenir compte des préférences pour ouvrir les liens dans un navigateur externe.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-B</td>
-    <td>Affiche la barre de filtre.</td>
-  </tr>
-  <tr>
-    <td>⌘-N</td>
-    <td>Crée un nouvel abonnement.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-G</td>
-    <td>Crée un nouveau groupe.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-F</td>
-    <td>Crée un nouveau groupe intelligent.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-E</td>
-    <td>Modifie l'adresse URL du dossier sélectionné ou modifie les critères du dossier intelligent sélectionné.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-D</td>
-    <td>Supprime le groupe sélectionné.</td>
-  </tr>
-  <tr>
-    <td>⌘-C</td>
-    <td>Copie le texte sélectionné dans le presse-papier. Si la zone active est la liste des articles, copie l'intégralité de l'article sélectionné.</td>
-  </tr>
-  <tr>
-    <td>⌘-H</td>
-    <td>Masque Vienna.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-H</td>
-    <td>Masque toutes les applications sauf Vienna.</td>
-  </tr>
-  <tr>
-    <td>⌘-I</td>
-    <td>Affiche la fenêtre d'information pour le dossier sélectionné.</td>
-  </tr>
-  <tr>
-    <td>⌘-L</td>
-    <td>Sélectionne le champ d'adresse du navigateur de l'onglet actuel ; ouvre un nouvel onglet avec un navigateur si besoin.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-N</td>
-    <td>Renomme le dossier sélectionné.</td>
-  </tr>
-  <tr>
-    <td>⌘-R</td>
-    <td>Rafraîchit tous les abonnements.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-R</td>
-    <td>Rafraîchit uniquement les abonnements sélectionnés dans la liste des dossiers.</td>
-  </tr>
-  <tr>
-    <td>Ctrl-⌘-S</td>
-    <td>Stoppe tout rafraîchissement en cours.</td>
-  </tr>
-  <tr>
-    <td>⌘-P</td>
-    <td>Imprime les articles sélectionnés.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-P</td>
-    <td>Affiche la fenêtre de mise en page.</td>
-  </tr>
-  <tr>
-    <td>⌘-Q</td>
-    <td>Quitte Vienna.</td>
-  </tr>
-  <tr>
-    <td>⌘-T</td>
-    <td>Ouvre un nouvel onglet avec un navigateur et sélectionne le champ d'adresse du navigateur.</td>
-  </tr>
-  <tr>
-    <td>⌘-U</td>
-    <td>Passe au prochain article non lu.</td>
-  </tr>
-  <tr>
-    <td>⌘-Z</td>
-    <td>Annule l'action précédente si c'est possible.</td>
-  </tr>
-  <tr>
-    <td>⌘-+ (plus)</td>
-    <td>Augmente la taille du texte dans la page WEB ou l'article actif.</td>
-  </tr>
-  <tr>
-    <td>⌘-- (moins)</td>
-    <td>Diminue la taille du texte dans la page WEB ou l'article actif.</td>
-  </tr>
-  <tr>
-    <td>⌘-, (virgule)</td>
-    <td>Affiche le panneau des préférences.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-BackSpace</td>
-    <td>Vide la corbeille après demande de confirmation.</td>
-  </tr>
-  <tr>
-    <td>⌘-?</td>
-    <td>Affiche l'aide Vienna.</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="250"><b>Raccourcis Articles</b></td>
-    <td>&nbsp;</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="150">Alt-Entrée <i>ou</i> Alt-Return</td>
-    <td>Ouvre la page originelle de l'article dans un onglet sans tenir compte des préférences pour ouvrir les liens dans un navigateur externe.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-Z</td>
-    <td>Rétablit la dernière action si elle vient juste d'être annulée.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-M</td>
-    <td>Marque d'un drapeau les articles sélectionnés.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-U</td>
-    <td>Marque les articles sélectionnés comme étant lus.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-S</td>
-    <td>Ouvre l'application de messagerie par défaut et crée un courrier avec un lien vers l'article actuel.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-S</td>
-    <td>Marque tous les articles du dossier actuel comme étant lus et passe au prochain dossier ayant des articles non lus.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-O</td>
-    <td>Rétablit un article de la corbeille dans son dossier d'origine.</td>
-  </tr>
-  <tr>
-    <td>Shift-⌘-K</td>
-    <td>Marque tous les articles des dossiers sélectionnés comme étant lus.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-K</td>
-    <td>Marque tous les articles de tous les dossiers comme étant lus.</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="250"><b>Raccourcis fenêtre</b></td>
-    <td>&nbsp;</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="150">⌘-W</td>
-    <td>Ferme l'onglet actif si plusieurs sont ouverts ; sinon, ferme la fenêtre Vienna.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-W</td>
-    <td>Ferme tous les onglets autres que la liste des articles. Note : cette commande remplace 
-	la commande "Fermer l'onglet" dans le menu Fichier lorsque la touche Alt est pressée.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-Gauche</td>
-    <td>Affiche l'onglet précédent.</td>
-  </tr>
-  <tr>
-    <td>Alt-⌘-Droite</td>
-    <td>Affiche l'onglet suivant.</td>
-  </tr>
-  <tr>
-    <td>⌘-M</td>
-    <td>Réduit la fenêtre principale ves le dock.</td>
-  </tr>
-  <tr>
-    <td>⌘-0</td>
-    <td>Affiche la fenêtre l'activité.</td>
-  </tr>
-  <tr>
-    <td>⌘-1</td>
-    <td>Réaffiche la fenêtre Vienna si celle-ci a été préalablement fermée.</td>
-  </tr>
-  <tr>
-    <td>⌘-2</td>
-    <td>Affiche la fenêtre de téléchargement.</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="250"><b>Racourcis du navigateur internet</b></td>
-    <td>&nbsp;</td>
-  </tr>
-</table>
-<table width="100%" border="0" cellspacing="10">
-  <tr>
-    <td width="150">Alt-R</td>
-    <td>Recharge la page web active.</td>
-  </tr>
-  <tr>
-    <td>⌘-. (point)</td>
-    <td>Arrête le chargement de la page web active.</td>
-  </tr>
-  <tr>
-    <td>⌘-[ <i>ou</i> ⌘-Gauche</td>
-    <td>Affiche la page web précédente.</td>
-  </tr>
-  <tr>
-    <td>⌘-] <i>ou</i> ⌘-Droite</td>
-    <td>Affiche la page web suivante.</td>
-  </tr>
-  <tr>
-    <td>⌘-F</td>
-    <td>Acitve le champ de recherche. Après validation par Enter, le texte saisi sera recherché sur la page web active.</td>
-  </tr>
-  <tr>
-    <td>⌘-G</td>
-    <td>Recherche l'occurrence suivante sur la page web active.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Raccourcis
+  clavier</span>
+  <p>Dans Vienna vous pouvez utiliser votre clavier pour exécuter
+  rapidement beaucoup d'actions. Pour trouver les raccourcis
+  clavier pour les commandes courantes, regardez dans les menus (ou
+  parcourrez la liste en bas de cette page). Beaucoup d'objets dans
+  Vienna, tels que la liste des dossiers ou celle des articles
+  possèdent aussi un menu contextuel. Pour afficher un menu
+  contextuel, pressez la touche "Ctrl" et cliquez sur l'objet.</p>
+  <p>Pour réaliser une action, pressez les raccourcis indiqués
+  ci-dessous.</p>
+  <table width="100%" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Combinaison de
+      touches</b></td>
+      <td bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="250"><b>Raccourci à une touche</b></td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="150">f</td>
+      <td>Ouvrir la barre de recherche et sélectionne le champ de
+      recherche.</td>
+    </tr>
+    <tr>
+      <td>h</td>
+      <td>Sélectionne le champ de recherche.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marque tous les articles du dossier courant comme étant
+      lus.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Permute l'état affiché/masqué du drapeau pour les
+      articles sélectionnés.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Va à l'article non lu suivant.</td>
+    </tr>
+    <tr>
+      <td>r <i>ou</i> u</td>
+      <td>Permute l'état lu/non lu pour les articles
+      sélectionnés.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marque tous les articles du dossier courant comme étant
+      lus et passe au prochain dossier contenant des articles non
+      lus.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Affiche l'article ou la page web précédent.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Affiche l'article ou la page web suivant.</td>
+    </tr>
+    <tr>
+      <td>Gauche</td>
+      <td>Sélectionne la liste des dossiers lorsque on se trouve
+      dans la liste des articles</td>
+    </tr>
+    <tr>
+      <td>Barre d'espace</td>
+      <td>Passe au prochain article non lu, à moins qu'il reste du
+      texte à afficher pour l'article en cours ; dans ce cas, on
+      affiche la page de texte suivante.</td>
+    </tr>
+    <tr>
+      <td>Entrée <i>ou</i> Return</td>
+      <td>Ouvre la page web source de l'article sélectionné.</td>
+    </tr>
+    <tr>
+      <td>Suppr <i>ou</i> Backspace</td>
+      <td>Déplace les articles sélectionnés dans la corbeille.
+      Lorsque cette commande est utilisée à partir de la corbeille,
+      les articles sélectionnés sont définitivement détruits.</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="250"><b>Raccourcis généraux</b></td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="150">Alt-Click</td>
+      <td>Ouvre la page originelle de l'article dans un onglet sans
+      tenir compte des préférences pour ouvrir les liens dans un
+      navigateur externe.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-B</td>
+      <td>Affiche la barre de filtre.</td>
+    </tr>
+    <tr>
+      <td>⌘-N</td>
+      <td>Crée un nouvel abonnement.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-G</td>
+      <td>Crée un nouveau groupe.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-F</td>
+      <td>Crée un nouveau groupe intelligent.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-E</td>
+      <td>Modifie l'adresse URL du dossier sélectionné ou modifie
+      les critères du dossier intelligent sélectionné.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-D</td>
+      <td>Supprime le groupe sélectionné.</td>
+    </tr>
+    <tr>
+      <td>⌘-C</td>
+      <td>Copie le texte sélectionné dans le presse-papier. Si la
+      zone active est la liste des articles, copie l'intégralité de
+      l'article sélectionné.</td>
+    </tr>
+    <tr>
+      <td>⌘-H</td>
+      <td>Masque Vienna.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-H</td>
+      <td>Masque toutes les applications sauf Vienna.</td>
+    </tr>
+    <tr>
+      <td>⌘-I</td>
+      <td>Affiche la fenêtre d'information pour le dossier
+      sélectionné.</td>
+    </tr>
+    <tr>
+      <td>⌘-L</td>
+      <td>Sélectionne le champ d'adresse du navigateur de l'onglet
+      actuel ; ouvre un nouvel onglet avec un navigateur si
+      besoin.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-N</td>
+      <td>Renomme le dossier sélectionné.</td>
+    </tr>
+    <tr>
+      <td>⌘-R</td>
+      <td>Rafraîchit tous les abonnements.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-R</td>
+      <td>Rafraîchit uniquement les abonnements sélectionnés dans
+      la liste des dossiers.</td>
+    </tr>
+    <tr>
+      <td>Ctrl-⌘-S</td>
+      <td>Stoppe tout rafraîchissement en cours.</td>
+    </tr>
+    <tr>
+      <td>⌘-P</td>
+      <td>Imprime les articles sélectionnés.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-P</td>
+      <td>Affiche la fenêtre de mise en page.</td>
+    </tr>
+    <tr>
+      <td>⌘-Q</td>
+      <td>Quitte Vienna.</td>
+    </tr>
+    <tr>
+      <td>⌘-T</td>
+      <td>Ouvre un nouvel onglet avec un navigateur et sélectionne
+      le champ d'adresse du navigateur.</td>
+    </tr>
+    <tr>
+      <td>⌘-U</td>
+      <td>Passe au prochain article non lu.</td>
+    </tr>
+    <tr>
+      <td>⌘-Z</td>
+      <td>Annule l'action précédente si c'est possible.</td>
+    </tr>
+    <tr>
+      <td>⌘-+ (plus)</td>
+      <td>Augmente la taille du texte dans la page WEB ou l'article
+      actif.</td>
+    </tr>
+    <tr>
+      <td>⌘-- (moins)</td>
+      <td>Diminue la taille du texte dans la page WEB ou l'article
+      actif.</td>
+    </tr>
+    <tr>
+      <td>⌘-, (virgule)</td>
+      <td>Affiche le panneau des préférences.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-BackSpace</td>
+      <td>Vide la corbeille après demande de confirmation.</td>
+    </tr>
+    <tr>
+      <td>⌘-?</td>
+      <td>Affiche l'aide Vienna.</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="250"><b>Raccourcis Articles</b></td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="150">Alt-Entrée <i>ou</i> Alt-Return</td>
+      <td>Ouvre la page originelle de l'article dans un onglet sans
+      tenir compte des préférences pour ouvrir les liens dans un
+      navigateur externe.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-Z</td>
+      <td>Rétablit la dernière action si elle vient juste d'être
+      annulée.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-M</td>
+      <td>Marque d'un drapeau les articles sélectionnés.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-U</td>
+      <td>Marque les articles sélectionnés comme étant lus.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-S</td>
+      <td>Ouvre l'application de messagerie par défaut et crée un
+      courrier avec un lien vers l'article actuel.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-S</td>
+      <td>Marque tous les articles du dossier actuel comme étant
+      lus et passe au prochain dossier ayant des articles non
+      lus.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-O</td>
+      <td>Rétablit un article de la corbeille dans son dossier
+      d'origine.</td>
+    </tr>
+    <tr>
+      <td>Shift-⌘-K</td>
+      <td>Marque tous les articles des dossiers sélectionnés comme
+      étant lus.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-K</td>
+      <td>Marque tous les articles de tous les dossiers comme étant
+      lus.</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="250"><b>Raccourcis fenêtre</b></td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="150">⌘-W</td>
+      <td>Ferme l'onglet actif si plusieurs sont ouverts ; sinon,
+      ferme la fenêtre Vienna.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-W</td>
+      <td>Ferme tous les onglets autres que la liste des articles.
+      Note : cette commande remplace la commande "Fermer l'onglet"
+      dans le menu Fichier lorsque la touche Alt est pressée.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-Gauche</td>
+      <td>Affiche l'onglet précédent.</td>
+    </tr>
+    <tr>
+      <td>Alt-⌘-Droite</td>
+      <td>Affiche l'onglet suivant.</td>
+    </tr>
+    <tr>
+      <td>⌘-M</td>
+      <td>Réduit la fenêtre principale ves le dock.</td>
+    </tr>
+    <tr>
+      <td>⌘-0</td>
+      <td>Affiche la fenêtre l'activité.</td>
+    </tr>
+    <tr>
+      <td>⌘-1</td>
+      <td>Réaffiche la fenêtre Vienna si celle-ci a été
+      préalablement fermée.</td>
+    </tr>
+    <tr>
+      <td>⌘-2</td>
+      <td>Affiche la fenêtre de téléchargement.</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="250"><b>Racourcis du navigateur internet</b></td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+  <table width="100%" border="0" cellspacing="10">
+    <tr>
+      <td width="150">Alt-R</td>
+      <td>Recharge la page web active.</td>
+    </tr>
+    <tr>
+      <td>⌘-. (point)</td>
+      <td>Arrête le chargement de la page web active.</td>
+    </tr>
+    <tr>
+      <td>⌘-[ <i>ou</i> ⌘-Gauche</td>
+      <td>Affiche la page web précédente.</td>
+    </tr>
+    <tr>
+      <td>⌘-] <i>ou</i> ⌘-Droite</td>
+      <td>Affiche la page web suivante.</td>
+    </tr>
+    <tr>
+      <td>⌘-F</td>
+      <td>Acitve le champ de recherche. Après validation par Enter,
+      le texte saisi sera recherché sur la page web active.</td>
+    </tr>
+    <tr>
+      <td>⌘-G</td>
+      <td>Recherche l'occurrence suivante sur la page web
+      active.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/it.lproj/Vienna Help/advanced.html
+++ b/lproj/it.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/it.lproj/Vienna Help/faq.html
+++ b/lproj/it.lproj/Vienna Help/faq.html
@@ -1,169 +1,220 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Come Faccio A?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Come Faccio A?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Come Faccio A?</span>
-<p>Qui sotto ci sono alcune delle domande più comuni che ci sono state fatte su Vienna mentre veniva effettuato il test pre-rilascio.
-Vai alla <a href="http://www.vienna-rss.org/vienna_faq.html">Pagina FAQ Ufficiale di Vienna</a> per questi e i più recenti trucchi e suggerimenti per usare Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Dove ottengo il codice sorgente di Vienna?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">Ho trovato un problema in Vienna. Come lo segnalo?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">Come faccio a creare i miei stili?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">Come faccio a creare i miei script?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-Come posso vedere cosa è successo quando sono state aggiornate le mie iscrizioni?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">Come faccio a spostare il mio database di Vienna in un'altra cartella?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Una delle mie iscrizioni segnala &quot;Errore nell'interpretazione dei dati XML nel feed&quot;. 
-Cosa significa?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-C'è un'abbreviazione da tastiera per andare al prossimo articolo, segnalarlo come letto, ecc.?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">Coma faccio ad usare Scadenza Automatica e cosa fa?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">Come faccio a richiedere un miglioramento in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Dove ottengo il codice sorgente di Vienna?</a></h2>
-<p>Vedi la <a href="http://www.vienna-rss.org/vienna_dev.html">pagina Development</a> per
-istruzioni su come ottenere il codice sorgente di Vienna. Il codice sorgente è
-liberamente disponibile se sei interessato ad imparare come funziona Vienna, se
-vuoi compilare una tua copia di Vienna da zero sulla tua
-macchina o se vuoi prenderne una parte da includere nel tuo progetto.
-Il sorgente viene fornito sotto<a href="http://www.apache.org/licenses/LICENSE-2.0.html">licenza Apache 2.0 
-</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">Ho trovato
-un problema in Vienna. Come lo segnalo?</a></h2>
-<p>Invia un messaggio nel forum Support e qualcuno investigherà. 
-Fornisci quante più informazioni puoi sul problema
-incluso: il numero della build di Vienna (ottenuta dalla finestra Informazioni su Vienna), 
-i passi per riprodurlo e cosa ti aspetti che accada.</p>
-
-<p>Assicurati di avere in esecuzione sempre la build più recente di Vienna. Il 
-comando Controlla Aggiornamenti segnalerà se c'è una build più recente disponibile
-rispetto a quella in tuo possesso.</p>
-<p>Le correzioni di problemi hanno priorità sulle nuove funzionalità per cui sel il tuo problema
-viene confermato come baco ad alto impatto e non c'è un alternativa semplice di funzionamento
-cercherò di rendere disponibile una correzione non appena ragionevolmente possibile.</p>
-<h2><a name="How_do_I_create_my_own_styles">Come faccio a creare i miei
-stili?</a></h2>
-<p>Vedi la <a href="http://www.vienna-rss.org/vienna_styles.html">pagina Custom Styles</a> per
-istruzioni.</p>
-<h2><a name="How_do_I_create_my_own_scripts">ome faccio a creare i miei script?</a></h2>
-
-<<p>Gli script di Vienna sono scritti usando AppleScript. Vedi la
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-pagine risorse di Apple</a> per ulteriori dettagli.</p>
-<p>Un modo per iniziare è scaricare uno degli script esistenti 
-dalla <a href="http://www.vienna-rss.org/vienna_files.html">pagina Vienna Downloads</a> e visualizzarlo 
-nell'editor AppleScript. Dai uno sguardo anche alla
-<a href="http://www.vienna-rss.org/vienna_scripting.html">pagina Scripts</a> per ulteriori dettagli sul 
-dizionario di scripting di Vienna ed esempi di cosa puoi ottenere.</p>
-
-<p>Per pubblicare il tuo script, invialo a
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-e dopo esser stato controllato, sarà reso disponibile sulla 
-pagina Downloads.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-Come posso vedere cosa è successo quando sono state aggiornate le mie iscrizioni?</a></h2>
-<p>Apri la Finestra Attività dal menu Finestra. La finestra attività 
-mostra tutte le iscrizioni e lo stato relativo all'ultima volta che sono state
-aggiornate in quella sessione. In fondo la fiestra attività mostra ulteriori
-dettagli incluse le intestazioni HTTP e può essere utile per il debug. (Se il 
-pannello dettagli non è visibile, prendi il separatore in fondo alla 
-Finestra Attività e trascinalo sopra in modo da scoprire il pannello).</p>
-
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">Come faccio
-a spostare il mio database di Vienna in un'altra cartella?</a></h2>
-
-<p>Di default, il tuo database Vienna è il file messages.db che è
-posizionato in ~/Libreria/Application Support/Vienna. Puoi spostarlo
-in un'altra cartella se lo desideri. I passi seguenti mostrano come:</p>
-<ol>
-<li>Chiudi Vienna.</li>
-<li>Apri una finestra del terminale ed inserisci:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;percorso al nuovo messages.db&gt;'</font><br>
-
-<br>
-dove &lt;percorso al nuovo messages.db&gt; è il nome della cartella che 
-contiene il file messages.db. Il percordo stesso dovrebbe avere il nome
-file messages.db alla fine. Ad esempio:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Riavvia Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Una delle mie iscrizioni segnala &quot;Errore nell'interpretazione dei dati XML nel feed&quot;. 
-Cosa significa?</a></h2>
-<p>Significa che Vienna ha ottenuto una risposta dall'iscrizione che non è
-riuscita ad interpretare. Ci sono diverse ragioni per cui ciò può accadere:</p>
-
-<ol>
-<li>La URL del feed potrebbe non puntare ad un feed RSS o Atom 
-ma ad una pagina web. Controlla la URL del feed che crea problemi attentamente.</li>
-<li>Il feed stesso potrebbe contenere XML malformato. Alcune iscrizioni 
-commettono un errore nel mettere insieme l'XML che definisce il feed
-e Vienna non puà interpretare XML malformato. Usa il comando Convalida Feed 
-nel menu Archivio per vedere se sei in questo caso. Sfortunatamente 
-non puoi far molto per questo in Vienna tranne attendere che il feed 
-stesso venga corretto dal sito.</li>
-<li>Il feed potrebbe essere incompleto. Se l'aggiornamento è stato interrotto dopo
-i dati XML saranno incompleti ed appariranno malformati in Vienna. 
-Un secondo aggiornamento potrebbe correggere questo problema.</li>
-</ol>
-<p>Se nessuna delle ragioni sopra indicate spiega il problema, invia un messaggio sul
-forum di supporto con la URL del feed che mostra tale problema. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-C'è un'abbreviazione da tastiera per andare al prossimo articolo, segnalarlo come letto,
-ecc.?</a></h2>
-<p>Probabilmente. Ci sono equivalenti a tasto singolo per alcuni dei comandi del
-menu come:</p>
-<p>Spazio - va al prossimo articolo da leggere. Se l'articolo corrente è lungo
-diverse pagine, andrà avanti all'interno dell'articolo per prima cosa. Se sei
-alla fine dell'articolo corrente poi andrà all'articolo successivo non
-letto. Per contrasto il comando Successivo Non Letto (Cmd+U) va sempre
-dritto all'articolo successivo non letto.</p>
-<p>R - segnala l'articolo corrente come letto se non è ancora stato letto, o come non letto se è già stato letto.</p>
-<p>F - segnala con contrassegno l'articolo corrente se non è già con contrassegno, o rimuove
-il contrassegno esistente se già lo è.</p>
-
-<p>Cerca in Aiuto Vienna per ulteriori abbreviazioni.</p>
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">Coma faccio ad
-usare Scadenza Automatica e cosa fa?</a></h2>
-<p>Scadenza Automatica sposta gli articoli più vecchi di un certo numero di giorni nella
-cartella Cestino. Ti permette di mantenere le tue cartelle gestibili trattenendo
-solo gli articoli che siano recenti. La scadenza automatica viene eseguita sia
-all'avvio di Vienna che dopo che tu abbia aggiornato qualsiasi iscrizione. Per controllare 
-la data degli articoli da far scadere automaticamente, modifca l'opzione &quot;Fai scadere articoli più vecchi 
-di&quot; nelle Preferenze.</p>
-<p>Scadenza Automatica non eliminerà articoli non letti o segnalati con contrassegno. Assume
-che tu non abbia letto questi articoli e così li lascia là.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">Come faccio
-a richiedere un miglioramento in Vienna?</a></h2>
-
-<p>Invia un messaggio sul 
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">forum di supporto</a>. Tutti 
-i miglioramenti richiesti sono registrati nel file TODO incluso insieme al 
-codice sorgente come guida per gli sviluppatori futuri.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Come Faccio
+  A?</span>
+  <p>Qui sotto ci sono alcune delle domande più comuni che ci sono
+  state fatte su Vienna mentre veniva effettuato il test
+  pre-rilascio. Vai alla <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Pagina FAQ Ufficiale
+  di Vienna</a> per questi e i più recenti trucchi e suggerimenti
+  per usare Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Dove
+    ottengo il codice sorgente di Vienna?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">Ho trovato
+    un problema in Vienna. Come lo segnalo?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">Come faccio a
+    creare i miei stili?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">Come faccio a
+    creare i miei script?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    Come posso vedere cosa è successo quando sono state aggiornate
+    le mie iscrizioni?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">Come
+    faccio a spostare il mio database di Vienna in un'altra
+    cartella?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    Una delle mie iscrizioni segnala "Errore nell'interpretazione
+    dei dati XML nel feed". Cosa significa?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    C'è un'abbreviazione da tastiera per andare al prossimo
+    articolo, segnalarlo come letto, ecc.?</a></li>
+    <li><a href=
+    "#How_do_I_use_Auto_Expire_and_what_does_it_do">Coma faccio ad
+    usare Scadenza Automatica e cosa fa?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">Come
+    faccio a richiedere un miglioramento in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Dove ottengo il codice
+  sorgente di Vienna?</a></h2>
+  <p>Vedi la <a href=
+  "http://www.vienna-rss.org/vienna_dev.html">pagina
+  Development</a> per istruzioni su come ottenere il codice
+  sorgente di Vienna. Il codice sorgente è liberamente disponibile
+  se sei interessato ad imparare come funziona Vienna, se vuoi
+  compilare una tua copia di Vienna da zero sulla tua macchina o se
+  vuoi prenderne una parte da includere nel tuo progetto. Il
+  sorgente viene fornito sotto<a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">licenza Apache
+  2.0</a> .</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">Ho trovato
+  un problema in Vienna. Come lo segnalo?</a></h2>
+  <p>Invia un messaggio nel forum Support e qualcuno investigherà.
+  Fornisci quante più informazioni puoi sul problema incluso: il
+  numero della build di Vienna (ottenuta dalla finestra
+  Informazioni su Vienna), i passi per riprodurlo e cosa ti aspetti
+  che accada.</p>
+  <p>Assicurati di avere in esecuzione sempre la build più recente
+  di Vienna. Il comando Controlla Aggiornamenti segnalerà se c'è
+  una build più recente disponibile rispetto a quella in tuo
+  possesso.</p>
+  <p>Le correzioni di problemi hanno priorità sulle nuove
+  funzionalità per cui sel il tuo problema viene confermato come
+  baco ad alto impatto e non c'è un alternativa semplice di
+  funzionamento cercherò di rendere disponibile una correzione non
+  appena ragionevolmente possibile.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">Come faccio a creare i miei
+  stili?</a></h2>
+  <p>Vedi la <a href=
+  "http://www.vienna-rss.org/vienna_styles.html">pagina Custom
+  Styles</a> per istruzioni.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">ome faccio a creare i miei
+  script?</a></h2>&lt;&lt;p&gt;Gli script di Vienna sono scritti
+  usando AppleScript. Vedi la <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  pagine risorse di Apple</a> per ulteriori dettagli.
+  <p>Un modo per iniziare è scaricare uno degli script esistenti
+  dalla <a href=
+  "http://www.vienna-rss.org/vienna_files.html">pagina Vienna
+  Downloads</a> e visualizzarlo nell'editor AppleScript. Dai uno
+  sguardo anche alla <a href=
+  "http://www.vienna-rss.org/vienna_scripting.html">pagina
+  Scripts</a> per ulteriori dettagli sul dizionario di scripting di
+  Vienna ed esempi di cosa puoi ottenere.</p>
+  <p>Per pubblicare il tuo script, invialo a <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  e dopo esser stato controllato, sarà reso disponibile sulla
+  pagina Downloads.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  Come posso vedere cosa è successo quando sono state aggiornate le
+  mie iscrizioni?</a></h2>
+  <p>Apri la Finestra Attività dal menu Finestra. La finestra
+  attività mostra tutte le iscrizioni e lo stato relativo
+  all'ultima volta che sono state aggiornate in quella sessione. In
+  fondo la fiestra attività mostra ulteriori dettagli incluse le
+  intestazioni HTTP e può essere utile per il debug. (Se il
+  pannello dettagli non è visibile, prendi il separatore in fondo
+  alla Finestra Attività e trascinalo sopra in modo da scoprire il
+  pannello).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">Come
+  faccio a spostare il mio database di Vienna in un'altra
+  cartella?</a></h2>
+  <p>Di default, il tuo database Vienna è il file messages.db che è
+  posizionato in ~/Libreria/Application Support/Vienna. Puoi
+  spostarlo in un'altra cartella se lo desideri. I passi seguenti
+  mostrano come:</p>
+  <ol>
+    <li>Chiudi Vienna.</li>
+    <li>Apri una finestra del terminale ed inserisci:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;percorso al
+    nuovo messages.db&gt;'</font><br />
+    <br />
+    dove &lt;percorso al nuovo messages.db&gt; è il nome della
+    cartella che contiene il file messages.db. Il percordo stesso
+    dovrebbe avere il nome file messages.db alla fine. Ad
+    esempio:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Riavvia Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  Una delle mie iscrizioni segnala "Errore nell'interpretazione dei
+  dati XML nel feed". Cosa significa?</a></h2>
+  <p>Significa che Vienna ha ottenuto una risposta dall'iscrizione
+  che non è riuscita ad interpretare. Ci sono diverse ragioni per
+  cui ciò può accadere:</p>
+  <ol>
+    <li>La URL del feed potrebbe non puntare ad un feed RSS o Atom
+    ma ad una pagina web. Controlla la URL del feed che crea
+    problemi attentamente.</li>
+    <li>Il feed stesso potrebbe contenere XML malformato. Alcune
+    iscrizioni commettono un errore nel mettere insieme l'XML che
+    definisce il feed e Vienna non puà interpretare XML malformato.
+    Usa il comando Convalida Feed nel menu Archivio per vedere se
+    sei in questo caso. Sfortunatamente non puoi far molto per
+    questo in Vienna tranne attendere che il feed stesso venga
+    corretto dal sito.</li>
+    <li>Il feed potrebbe essere incompleto. Se l'aggiornamento è
+    stato interrotto dopo i dati XML saranno incompleti ed
+    appariranno malformati in Vienna. Un secondo aggiornamento
+    potrebbe correggere questo problema.</li>
+  </ol>
+  <p>Se nessuna delle ragioni sopra indicate spiega il problema,
+  invia un messaggio sul forum di supporto con la URL del feed che
+  mostra tale problema.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  C'è un'abbreviazione da tastiera per andare al prossimo articolo,
+  segnalarlo come letto, ecc.?</a></h2>
+  <p>Probabilmente. Ci sono equivalenti a tasto singolo per alcuni
+  dei comandi del menu come:</p>
+  <p>Spazio - va al prossimo articolo da leggere. Se l'articolo
+  corrente è lungo diverse pagine, andrà avanti all'interno
+  dell'articolo per prima cosa. Se sei alla fine dell'articolo
+  corrente poi andrà all'articolo successivo non letto. Per
+  contrasto il comando Successivo Non Letto (Cmd+U) va sempre
+  dritto all'articolo successivo non letto.</p>
+  <p>R - segnala l'articolo corrente come letto se non è ancora
+  stato letto, o come non letto se è già stato letto.</p>
+  <p>F - segnala con contrassegno l'articolo corrente se non è già
+  con contrassegno, o rimuove il contrassegno esistente se già lo
+  è.</p>
+  <p>Cerca in Aiuto Vienna per ulteriori abbreviazioni.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">Coma faccio ad
+  usare Scadenza Automatica e cosa fa?</a></h2>
+  <p>Scadenza Automatica sposta gli articoli più vecchi di un certo
+  numero di giorni nella cartella Cestino. Ti permette di mantenere
+  le tue cartelle gestibili trattenendo solo gli articoli che siano
+  recenti. La scadenza automatica viene eseguita sia all'avvio di
+  Vienna che dopo che tu abbia aggiornato qualsiasi iscrizione. Per
+  controllare la data degli articoli da far scadere
+  automaticamente, modifca l'opzione "Fai scadere articoli più
+  vecchi di" nelle Preferenze.</p>
+  <p>Scadenza Automatica non eliminerà articoli non letti o
+  segnalati con contrassegno. Assume che tu non abbia letto questi
+  articoli e così li lascia là.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">Come faccio a
+  richiedere un miglioramento in Vienna?</a></h2>
+  <p>Invia un messaggio sul <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">forum di
+  supporto</a>. Tutti i miglioramenti richiesti sono registrati nel
+  file TODO incluso insieme al codice sorgente come guida per gli
+  sviluppatori futuri.</p>
 </body>
 </html>

--- a/lproj/it.lproj/Vienna Help/index.html
+++ b/lproj/it.lproj/Vienna Help/index.html
@@ -1,34 +1,41 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Aiuto Vienna</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Aiuto Vienna</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduzione a Vienna</p>
-		<p><a href="intro.html">Impara come iniziare ad usare Vienna.</a></p>
-
-		<p class="header">Abbreviazioni da Tastiera</p>
-		<p><a href="keyboard.html">Scopri le abbreviazioni da tastiera per i comandi comuni</a></p>
-
-		<p class="header">Come Faccio A</p>
-		<p><a href="faq.html">Domande Frequenti, come ottenere supporto e passi da eseguire per la risoluzione dei problemi.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Aiuto Vienna</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduzione a Vienna</p>
+          <p><a href="intro.html">Impara come iniziare ad usare
+          Vienna.</a></p>
+          <p class="header">Abbreviazioni da Tastiera</p>
+          <p><a href="keyboard.html">Scopri le abbreviazioni da
+          tastiera per i comandi comuni</a></p>
+          <p class="header">Come Faccio A</p>
+          <p><a href="faq.html">Domande Frequenti, come ottenere
+          supporto e passi da eseguire per la risoluzione dei
+          problemi.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/it.lproj/Vienna Help/intro.html
+++ b/lproj/it.lproj/Vienna Help/intro.html
@@ -1,25 +1,105 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduzione a Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduzione a  Vienna</span>
-<p>Vienna è un'applicazione che ti permette di leggere feed di notizie in formato RSS o Atom sul tuo computer con Mac OSX. Automatizza il compito di recuperare i nuovi articoli da tutti i feed cui si è iscritti e di memorizzarli in un database locale per leggerli quando si è off-line. Fornisce caratteristiche che ti permettono di cercare nei feed per parole chiave o frasi, segnalare gli articoli con contrassegno per riferimento futuro ed organizzare insieme in gruppi i feed correlati. Puoi creare cartelle smart che rendano semplice recuperare e visualizzare tutti gli articoli nel database che soddisfino un dato criterio di ricerca. Il browser interno ti permette di andare alla pagina web degli articoli direttamente all'interno di Vienna su pannelli separati.</p>
-<p>Vienna è progettato in modo da essere semplice e facile da utilizzare. Un'interfaccia pulita e ordinata massimizza lo spazio per gli articoli e solo pochi pulsanti sono necessari per eseguire la maggior parte delle operazioni nell'interfaccia utente.</p>
-<b>Come Iniziare</b>
-<p>Se questa è la prima volta che usi Vienna allora il programma avrà creato un nuovo database per te ad aggiunto alcune iscrizioni e notizie di esempio. Vai allora avanti e premi Comando+T o scegli Aggiorna Tutte le Iscrizioni dal menu Archivio per ottenere gli ultimi articoli da queste iscrizioni.</p>
-<p>Alternativamente, iscriviti ai tuoi feed di notizie personali. Ci sono vari modi per trovare feed. Quando navighi sul web, cerca la <img src="images/rssfeed.gif" alt=""> o le icone XML che indicano che la pagina ha dei feed associati ad essa. Alternativamente quasi tutti i servizi di blogging come LiveJournal o Blogger forniscono feed RSS come alternativa alla lettura degli articoli online.</p>
-<p>Se conosci il nome utente di blogger su Splinder, LiveJournal, Blogger, MSN Spaces o Xanga allora Vienna rende più facile iscriversi ai loro news feed. Inizia premendo Comando+N o scegli il comando Nuova Iscrizione dal menu Archivio.
-Nella finestra "Crea una nuova iscrizione RSS", scegli il servizio di blogging dall'elenco a comparsa ed inserisci il nome utente nel campo di testo sottostante. Poi scegli Iscriviti e Vienna aggiungerà l'iscrizione all'elenco cartelle. Se in quel momento eri connesso ad internet, Vienna inizierà anche immediatamente a raccogliere gli articoli dal feed.</p>
-<p>Normalmente devi dire manualmente a Vienna quando aggiornare tutte le tue iscrizioni. Comunque puoi scegliere di chiedere a Vienna di aggiornare automaticamente ad intervalli di tempo regolari. Nella sezione Generale delle Preferenze, scegli l'intervallo di tempo desiderato dall'elenco a comparsa vicino a 'Controlla nuovi articoli'. Vienna deve essere in esecuzione perché possa aggiornare automaticamente le iscrizioni.</p>
-<p>Per leggere gli articoli, premi la Barra Spaziatrice per passare all'articolo successivo non letto in ogni iscrizione. Ogni articolo è segnalato automaticamente come letto dopo un breve periodo di tempo. Se preferisci aspettare fino a quando ti sposti all'articolo successivo non letto prima che quello corrente sia segnalato come letto, puoi impostare questo comportamento nel pannello Generale delle Preferenze. Per selezionare un articolo come non letto di nuovo, scegli il comando Segnala come Non Letto dal menu Articolo o premi semplicemente il tasto 'R'.</p>
-<p>Infine puoi visualizzare la pagina web dell'articolo oppure qualsiasi collegamento a pagine web in un articolo all'interno di Vienna. Di default facendo clic su un collegamento web all'interno di Vienna, il programma aprirà la pagina web in un nuovo pannello. Vienna fornisce un buon supporto per la navigazione web di base ma ci saranno volte in cui preferirai aprire i collegamenti nel tuo browser web di default. Se preferisci visualizzare tutte le pagine web fuori da Vienna, allora attiva l'opzione 'Apri collegamenti in un browser esterno' nella sezione Generale delle Preferenze. Se comunque preferisci visualizzare il collegamento o pagina corrente nel tuo browser esterno, fai clic con il pulsante destro sulla pagina o scegli l'opzione "Apri Collegamento in XXX" o "Apri Pagina in XXX" dove XXX sarà il nome del tuo browser di  default.</p>
-<p>Dopo esserti impratichito nell'usare Vienna, vai avanti ed esplora la varie  opzioni. Puoi modificare lo stile in cui gli articoli sono visualizzati attraverso l'elenco a comparsa Stili nel menu Vista. Puoi trovare molti altri stili personalizzati nella pagina Downloads sul sito web di Vienna insieme a script personalizzati che ti permettono di integrare Vienna con altre applicazioni sulla tua macchina. Oppure fai esperimenti con le cartelle smart per organizzare gli articoli secondo criteri basati sui contenuti di ogni articolo. Ad esempio, puoi facilmente impostare una cartella smart per raggruppare insieme tutti gli articoli che menzionano "Joss Whedon" e "Firefly" per trovare riferimenti alla serie di culto Firefly o al film tratto da essa.</p>
-<p>Se hai domande su Vienna o riscontri dei problemi, vai sul <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-forum Support</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduzione a
+  Vienna</span>
+  <p>Vienna è un'applicazione che ti permette di leggere feed di
+  notizie in formato RSS o Atom sul tuo computer con Mac OSX.
+  Automatizza il compito di recuperare i nuovi articoli da tutti i
+  feed cui si è iscritti e di memorizzarli in un database locale
+  per leggerli quando si è off-line. Fornisce caratteristiche che
+  ti permettono di cercare nei feed per parole chiave o frasi,
+  segnalare gli articoli con contrassegno per riferimento futuro ed
+  organizzare insieme in gruppi i feed correlati. Puoi creare
+  cartelle smart che rendano semplice recuperare e visualizzare
+  tutti gli articoli nel database che soddisfino un dato criterio
+  di ricerca. Il browser interno ti permette di andare alla pagina
+  web degli articoli direttamente all'interno di Vienna su pannelli
+  separati.</p>
+  <p>Vienna è progettato in modo da essere semplice e facile da
+  utilizzare. Un'interfaccia pulita e ordinata massimizza lo spazio
+  per gli articoli e solo pochi pulsanti sono necessari per
+  eseguire la maggior parte delle operazioni nell'interfaccia
+  utente.</p><b>Come Iniziare</b>
+  <p>Se questa è la prima volta che usi Vienna allora il programma
+  avrà creato un nuovo database per te ad aggiunto alcune
+  iscrizioni e notizie di esempio. Vai allora avanti e premi
+  Comando+T o scegli Aggiorna Tutte le Iscrizioni dal menu Archivio
+  per ottenere gli ultimi articoli da queste iscrizioni.</p>
+  <p>Alternativamente, iscriviti ai tuoi feed di notizie personali.
+  Ci sono vari modi per trovare feed. Quando navighi sul web, cerca
+  la <img src="images/rssfeed.gif" alt="" /> o le icone XML che
+  indicano che la pagina ha dei feed associati ad essa.
+  Alternativamente quasi tutti i servizi di blogging come
+  LiveJournal o Blogger forniscono feed RSS come alternativa alla
+  lettura degli articoli online.</p>
+  <p>Se conosci il nome utente di blogger su Splinder, LiveJournal,
+  Blogger, MSN Spaces o Xanga allora Vienna rende più facile
+  iscriversi ai loro news feed. Inizia premendo Comando+N o scegli
+  il comando Nuova Iscrizione dal menu Archivio. Nella finestra
+  "Crea una nuova iscrizione RSS", scegli il servizio di blogging
+  dall'elenco a comparsa ed inserisci il nome utente nel campo di
+  testo sottostante. Poi scegli Iscriviti e Vienna aggiungerà
+  l'iscrizione all'elenco cartelle. Se in quel momento eri connesso
+  ad internet, Vienna inizierà anche immediatamente a raccogliere
+  gli articoli dal feed.</p>
+  <p>Normalmente devi dire manualmente a Vienna quando aggiornare
+  tutte le tue iscrizioni. Comunque puoi scegliere di chiedere a
+  Vienna di aggiornare automaticamente ad intervalli di tempo
+  regolari. Nella sezione Generale delle Preferenze, scegli
+  l'intervallo di tempo desiderato dall'elenco a comparsa vicino a
+  'Controlla nuovi articoli'. Vienna deve essere in esecuzione
+  perché possa aggiornare automaticamente le iscrizioni.</p>
+  <p>Per leggere gli articoli, premi la Barra Spaziatrice per
+  passare all'articolo successivo non letto in ogni iscrizione.
+  Ogni articolo è segnalato automaticamente come letto dopo un
+  breve periodo di tempo. Se preferisci aspettare fino a quando ti
+  sposti all'articolo successivo non letto prima che quello
+  corrente sia segnalato come letto, puoi impostare questo
+  comportamento nel pannello Generale delle Preferenze. Per
+  selezionare un articolo come non letto di nuovo, scegli il
+  comando Segnala come Non Letto dal menu Articolo o premi
+  semplicemente il tasto 'R'.</p>
+  <p>Infine puoi visualizzare la pagina web dell'articolo oppure
+  qualsiasi collegamento a pagine web in un articolo all'interno di
+  Vienna. Di default facendo clic su un collegamento web
+  all'interno di Vienna, il programma aprirà la pagina web in un
+  nuovo pannello. Vienna fornisce un buon supporto per la
+  navigazione web di base ma ci saranno volte in cui preferirai
+  aprire i collegamenti nel tuo browser web di default. Se
+  preferisci visualizzare tutte le pagine web fuori da Vienna,
+  allora attiva l'opzione 'Apri collegamenti in un browser esterno'
+  nella sezione Generale delle Preferenze. Se comunque preferisci
+  visualizzare il collegamento o pagina corrente nel tuo browser
+  esterno, fai clic con il pulsante destro sulla pagina o scegli
+  l'opzione "Apri Collegamento in XXX" o "Apri Pagina in XXX" dove
+  XXX sarà il nome del tuo browser di default.</p>
+  <p>Dopo esserti impratichito nell'usare Vienna, vai avanti ed
+  esplora la varie opzioni. Puoi modificare lo stile in cui gli
+  articoli sono visualizzati attraverso l'elenco a comparsa Stili
+  nel menu Vista. Puoi trovare molti altri stili personalizzati
+  nella pagina Downloads sul sito web di Vienna insieme a script
+  personalizzati che ti permettono di integrare Vienna con altre
+  applicazioni sulla tua macchina. Oppure fai esperimenti con le
+  cartelle smart per organizzare gli articoli secondo criteri
+  basati sui contenuti di ogni articolo. Ad esempio, puoi
+  facilmente impostare una cartella smart per raggruppare insieme
+  tutti gli articoli che menzionano "Joss Whedon" e "Firefly" per
+  trovare riferimenti alla serie di culto Firefly o al film tratto
+  da essa.</p>
+  <p>Se hai domande su Vienna o riscontri dei problemi, vai sul
+  <a href="http://forums.cocoaforge.com/viewforum.php?f=18">forum
+  Support</a>.</p>
 </body>
 </html>

--- a/lproj/it.lproj/Vienna Help/keyboard.html
+++ b/lproj/it.lproj/Vienna Help/keyboard.html
@@ -1,224 +1,260 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Abbreviazioni da Tastiera</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Abbreviazioni da Tastiera</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Abbreviazioni da Tastiera</span>
-<p>Puoi usare la tua tastiera per eseguire rapidamente diverse operazioni in Vienna. Per trovare le abbreviazioni per i comandi comuni, guarda nei menu
-(o vedi la lista in fondo a questa pagina). Molti elementi di Vienna come l'area cartella e l'elenco degli articoli hanno anche dei menu contestuali. Per vedere un menu contestuale, premi il tasto Control e fai clic sull'elemento.</p>
-<p>Per eseguire un'azione, premi i tasti di abbreviazione sotto indicati.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Tasto</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Azione</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Abbreviazioni a Tasto Singolo</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Imposta il focus dell'input sulla finestra di ricerca.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Segnala gli articoli selezionati come letti.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Segnala la cartella corrente come letta poi passa alla cartella successiva con articoli non letti.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Segnala la cartella corrente come letta.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Segnala con contrassegno gli articoli selezionati.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Mostra l'articolo o pagina web vista in precedenza.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Mostra l'articolo o pagina web vista successivamente.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Va all'articolo successivo non letto a meno che l'articolo corrente non abbia altro testo da scorrere ed in tal caso va su di una pagina all'interno dell'articolo corrente.</td>
-  </tr>
-  <tr>
-    <td>Comando-U</td>
-    <td>Va all'articolo successivo non letto.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Apre l'articolo selezionato nella pagina web originale.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Sposta gli articoli selezionati nella cartella Cestino. Se questo tasto viene utilizzato nella cartella Cestino, gli articoli selezionati saranno eliminati in modo permanente.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>Abbreviazioni Generali</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Comando-N</td>
-    <td>Crea una nuova iscrizione.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-F</td>
-    <td>Crea una cartella smart.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-E</td>
-    <td>Modifica la URL della cartella selezionata o modifica il criterio di una cartella smart.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-D</td>
-    <td>Elimina la cartella selezionata.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-N</td>
-    <td>Rinomina la cartella selezionata.</td>
-  </tr>
-  <tr>
-    <td>Comando-R</td>
-    <td>Aggionta tutte le iscrizioni.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-R</td>
-    <td>Aggiorna solo quelle iscrizioni che siano selezionate nell'elenco cartelle.</td>
-  </tr>
-  <tr>
-    <td>Comando-Meno</td>
-    <td>Interrompi ogni aggiornamento attivo.</td>
-  </tr>
-  <tr>
-    <td>Comando-P</td>
-    <td>Stampa gli articoli selezionati.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-P</td>
-    <td>Attiva la finestra Formato di stampa.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-V</td>
-    <td>Convalida il feed selezionato.</td>
-  </tr>
-  <tr>
-    <td>Comando-?</td>
-    <td>Visualizza le pagine dell'aiuto di Vienna.</td>
-  </tr>
-  <tr>
-    <td><b>Abbreviazioni Articoli</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-M</td>
-    <td>Segnala con contrassegno gli articoli selezionati.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-U</td>
-    <td>Segnala gli articoli selezionati come letti.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-S</td>
-    <td>Segnala la cartella corrente come letta poi passa alla cartella successiva con articoli non letti.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-O</td>
-    <td>Ripristina un articolo dal cestino riportandolo nella sua cartella originale.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-K</td>
-    <td>Segnala tutti gli articoli nelle cartelle selezionate come letti.</td>
-  </tr>
-  <tr>
-    <td>Alt-Comando-K</td>
-    <td>Segnala tutti gli articoli in tutte le cartelle come letti.</td>
-  </tr>
-  <tr>
-    <td><b>Abbreviazioni Finestra</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Comando-W</td>
-    <td>Chiude il pannello attivo se ce n' uno aperto. Altrimenti se non
-    ci sono pannelli aperti, chiude la finestra di Vienna.</td>
-  </tr>
-  <tr>
-    <td>Alt-Comando-W</td>
-    <td>Chiude tutti i pannelli. Nota che questo comando sostituisce il comando
-    Chiudi Pannello nel menu Archivio quando si tiene premuto il tasto Alt.</td>
-  </tr>
-  <tr>
-    <td>Control-Comando-Freccia Sinistra</td>
-    <td>Visualizza il pannello precedente.</td>
-  </tr>
-  <tr>
-    <td>Control-Comando-Freccia Destra</td>
-    <td>Visualizza il pannello successivo.</td>
-  </tr>
-  <tr>
-    <td>Shift-Comando-W</td>
-    <td>Chiude la finestra di Vienna ma lascia Vienna in esecuzione in background. 
-	Puoi riportare la finestra in vista facendo clic sull'icon nel dock di Vienna o
-	premendo Comando-1.</td>
-  </tr>
-  <tr>
-    <td>Comando-M</td>
-    <td>Ridimenziona la finestra di Vienna nel dock.</td>
-  </tr>
-  <tr>
-    <td>Comando-0</td>
-    <td>Visualizza la finestra con il visore resoconto attivitˆ.</td>
-  </tr>
-  <tr>
-    <td>Comando-1</td>
-    <td>Riapre la finestra di Vienna se era stata chiusa precedentemente.</td>
-  </tr>
-  <tr>
-    <td>Comando-2</td>
-    <td>Visualizza la finestra Downloads.</td>
-  </tr>
-  <tr>
-    <td><b>Abbreviazioni Finestra Browser</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Ricarica la pagina web corrente.</td>
-  </tr>
-  <tr>
-    <td>Comando-Punto</td>
-    <td>Annulla il caricamento della pagina web corrente.</td>
-  </tr>
-  <tr>
-    <td>Comando-[/Comando-sinistra</td>
-    <td>Vai indietro alla pagina web precedente.</td>
-  </tr>
-  <tr>
-    <td>Comando-]/Command-destra</td>
-    <td>Vai avanti alla pagina web successiva.</td>
-  </tr>
-  <tr>
-    <td>Comando-F</td>
-    <td>Imposta il focus sul campo di ricerca. Inserendo del testo qui e
-	premendo Enter, il programma cercherˆ quel testo nella pagina web corrente.</td>
-  </tr>
-  <tr>
-    <td>Comando-G</td>
-    <td>Ricerca la prossima occorrenza del testo cercato nella pagina web.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Abbreviazioni da
+  Tastiera</span>
+  <p>Puoi usare la tua tastiera per eseguire rapidamente diverse
+  operazioni in Vienna. Per trovare le abbreviazioni per i comandi
+  comuni, guarda nei menu (o vedi la lista in fondo a questa
+  pagina). Molti elementi di Vienna come l'area cartella e l'elenco
+  degli articoli hanno anche dei menu contestuali. Per vedere un
+  menu contestuale, premi il tasto Control e fai clic
+  sull'elemento.</p>
+  <p>Per eseguire un'azione, premi i tasti di abbreviazione sotto
+  indicati.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Tasto</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Azione</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Abbreviazioni a Tasto Singolo</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Imposta il focus dell'input sulla finestra di
+      ricerca.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Segnala gli articoli selezionati come letti.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Segnala la cartella corrente come letta poi passa alla
+      cartella successiva con articoli non letti.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Segnala la cartella corrente come letta.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Segnala con contrassegno gli articoli selezionati.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Mostra l'articolo o pagina web vista in precedenza.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Mostra l'articolo o pagina web vista
+      successivamente.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Va all'articolo successivo non letto a meno che
+      l'articolo corrente non abbia altro testo da scorrere ed in
+      tal caso va su di una pagina all'interno dell'articolo
+      corrente.</td>
+    </tr>
+    <tr>
+      <td>Comando-U</td>
+      <td>Va all'articolo successivo non letto.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Apre l'articolo selezionato nella pagina web
+      originale.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Sposta gli articoli selezionati nella cartella Cestino.
+      Se questo tasto viene utilizzato nella cartella Cestino, gli
+      articoli selezionati saranno eliminati in modo
+      permanente.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>Abbreviazioni Generali</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Comando-N</td>
+      <td>Crea una nuova iscrizione.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-F</td>
+      <td>Crea una cartella smart.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-E</td>
+      <td>Modifica la URL della cartella selezionata o modifica il
+      criterio di una cartella smart.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-D</td>
+      <td>Elimina la cartella selezionata.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-N</td>
+      <td>Rinomina la cartella selezionata.</td>
+    </tr>
+    <tr>
+      <td>Comando-R</td>
+      <td>Aggionta tutte le iscrizioni.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-R</td>
+      <td>Aggiorna solo quelle iscrizioni che siano selezionate
+      nell'elenco cartelle.</td>
+    </tr>
+    <tr>
+      <td>Comando-Meno</td>
+      <td>Interrompi ogni aggiornamento attivo.</td>
+    </tr>
+    <tr>
+      <td>Comando-P</td>
+      <td>Stampa gli articoli selezionati.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-P</td>
+      <td>Attiva la finestra Formato di stampa.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-V</td>
+      <td>Convalida il feed selezionato.</td>
+    </tr>
+    <tr>
+      <td>Comando-?</td>
+      <td>Visualizza le pagine dell'aiuto di Vienna.</td>
+    </tr>
+    <tr>
+      <td><b>Abbreviazioni Articoli</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-M</td>
+      <td>Segnala con contrassegno gli articoli selezionati.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-U</td>
+      <td>Segnala gli articoli selezionati come letti.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-S</td>
+      <td>Segnala la cartella corrente come letta poi passa alla
+      cartella successiva con articoli non letti.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-O</td>
+      <td>Ripristina un articolo dal cestino riportandolo nella sua
+      cartella originale.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-K</td>
+      <td>Segnala tutti gli articoli nelle cartelle selezionate
+      come letti.</td>
+    </tr>
+    <tr>
+      <td>Alt-Comando-K</td>
+      <td>Segnala tutti gli articoli in tutte le cartelle come
+      letti.</td>
+    </tr>
+    <tr>
+      <td><b>Abbreviazioni Finestra</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Comando-W</td>
+      <td>Chiude il pannello attivo se ce n'è uno aperto.
+      Altrimenti se non ci sono pannelli aperti, chiude la finestra
+      di Vienna.</td>
+    </tr>
+    <tr>
+      <td>Alt-Comando-W</td>
+      <td>Chiude tutti i pannelli. Nota che questo comando
+      sostituisce il comando Chiudi Pannello nel menu Archivio
+      quando si tiene premuto il tasto Alt.</td>
+    </tr>
+    <tr>
+      <td>Control-Comando-Freccia Sinistra</td>
+      <td>Visualizza il pannello precedente.</td>
+    </tr>
+    <tr>
+      <td>Control-Comando-Freccia Destra</td>
+      <td>Visualizza il pannello successivo.</td>
+    </tr>
+    <tr>
+      <td>Shift-Comando-W</td>
+      <td>Chiude la finestra di Vienna ma lascia Vienna in
+      esecuzione in background. Puoi riportare la finestra in vista
+      facendo clic sull'icon nel dock di Vienna o premendo
+      Comando-1.</td>
+    </tr>
+    <tr>
+      <td>Comando-M</td>
+      <td>Ridimenziona la finestra di Vienna nel dock.</td>
+    </tr>
+    <tr>
+      <td>Comando-0</td>
+      <td>Visualizza la finestra con il visore resoconto
+      attività.</td>
+    </tr>
+    <tr>
+      <td>Comando-1</td>
+      <td>Riapre la finestra di Vienna se era stata chiusa
+      precedentemente.</td>
+    </tr>
+    <tr>
+      <td>Comando-2</td>
+      <td>Visualizza la finestra Downloads.</td>
+    </tr>
+    <tr>
+      <td><b>Abbreviazioni Finestra Browser</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Ricarica la pagina web corrente.</td>
+    </tr>
+    <tr>
+      <td>Comando-Punto</td>
+      <td>Annulla il caricamento della pagina web corrente.</td>
+    </tr>
+    <tr>
+      <td>Comando-[/Comando-sinistra</td>
+      <td>Vai indietro alla pagina web precedente.</td>
+    </tr>
+    <tr>
+      <td>Comando-]/Command-destra</td>
+      <td>Vai avanti alla pagina web successiva.</td>
+    </tr>
+    <tr>
+      <td>Comando-F</td>
+      <td>Imposta il focus sul campo di ricerca. Inserendo del
+      testo qui e premendo Enter, il programma cercherà quel testo
+      nella pagina web corrente.</td>
+    </tr>
+    <tr>
+      <td>Comando-G</td>
+      <td>Ricerca la prossima occorrenza del testo cercato nella
+      pagina web.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/ja.lproj/Vienna Help/advanced.html
+++ b/lproj/ja.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/ja.lproj/Vienna Help/faq.html
+++ b/lproj/ja.lproj/Vienna Help/faq.html
@@ -1,181 +1,208 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.html">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the Support forum and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.html">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.html">Vienna Downloads page</a> and view 
-it in the AppleScript editor. Also take a look at the
-<a href="http://www.vienna-rss.org/vienna_scripting.html">Scripts page</a> for more details of the 
-Vienna scripting dictionary and examples of what you can accomplish.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the &quot;Expire articles older 
-than&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.html">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the Support forum and somebody will
+  investigate. Provide as much information about the problem as you
+  can including: the build of Vienna (obtained from the About
+  Vienna panel), repro steps and what you expected to happen.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.html">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.html">Vienna Downloads
+  page</a> and view it in the AppleScript editor. Also take a look
+  at the <a href=
+  "http://www.vienna-rss.org/vienna_scripting.html">Scripts
+  page</a> for more details of the Vienna scripting dictionary and
+  examples of what you can accomplish.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Expire articles older than" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/ja.lproj/Vienna Help/index.html
+++ b/lproj/ja.lproj/Vienna Help/index.html
@@ -1,34 +1,40 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/ja.lproj/Vienna Help/intro.html
+++ b/lproj/ja.lproj/Vienna Help/intro.html
@@ -1,55 +1,95 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OSX computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+T or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt=""> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the Downloads page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OSX computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+T or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="" /> or XML icons
+  indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the Downloads
+  page on the Vienna web site along with custom scripts that allow
+  you to integrate Vienna with other applications on your machine.
+  Or experiment with smart folders to organise articles according
+  to criteria based on the contents of each article. For example,
+  you can easily set up a smart folder to group together all
+  articles that mention "Joss Whedon" and "Firefly" to find
+  references to the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/ja.lproj/Vienna Help/keyboard.html
+++ b/lproj/ja.lproj/Vienna Help/keyboard.html
@@ -1,225 +1,248 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Command-Minus</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-V</td>
-    <td>Validate the selected feed.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-W</td>
-    <td>Closes the Vienna window but leaves Vienna running in the background. 
-	You can bring the window back by clicking on the Vienna dock icon or 
-	pressing Command-1.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Command-Minus</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-V</td>
+      <td>Validate the selected feed.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-W</td>
+      <td>Closes the Vienna window but leaves Vienna running in the
+      background. You can bring the window back by clicking on the
+      Vienna dock icon or pressing Command-1.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/ko.lproj/Vienna Help/advanced.html
+++ b/lproj/ko.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/ko.lproj/Vienna Help/faq.html
+++ b/lproj/ko.lproj/Vienna Help/faq.html
@@ -1,181 +1,208 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.html">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the Support forum and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.html">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.html">Vienna Downloads page</a> and view 
-it in the AppleScript editor. Also take a look at the
-<a href="http://www.vienna-rss.org/vienna_scripting.html">Scripts page</a> for more details of the 
-Vienna scripting dictionary and examples of what you can accomplish.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the &quot;Expire articles older 
-than&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.html">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the Support forum and somebody will
+  investigate. Provide as much information about the problem as you
+  can including: the build of Vienna (obtained from the About
+  Vienna panel), repro steps and what you expected to happen.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.html">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.html">Vienna Downloads
+  page</a> and view it in the AppleScript editor. Also take a look
+  at the <a href=
+  "http://www.vienna-rss.org/vienna_scripting.html">Scripts
+  page</a> for more details of the Vienna scripting dictionary and
+  examples of what you can accomplish.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Expire articles older than" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/ko.lproj/Vienna Help/index.html
+++ b/lproj/ko.lproj/Vienna Help/index.html
@@ -1,34 +1,40 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/ko.lproj/Vienna Help/intro.html
+++ b/lproj/ko.lproj/Vienna Help/intro.html
@@ -1,55 +1,95 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OSX computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+T or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the Downloads page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OSX computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+T or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the Downloads
+  page on the Vienna web site along with custom scripts that allow
+  you to integrate Vienna with other applications on your machine.
+  Or experiment with smart folders to organise articles according
+  to criteria based on the contents of each article. For example,
+  you can easily set up a smart folder to group together all
+  articles that mention "Joss Whedon" and "Firefly" to find
+  references to the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/ko.lproj/Vienna Help/keyboard.html
+++ b/lproj/ko.lproj/Vienna Help/keyboard.html
@@ -1,233 +1,259 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Command-Minus</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-V</td>
-    <td>Validate the selected feed.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-W</td>
-    <td>Closes the Vienna window but leaves Vienna running in the background. 
-	You can bring the window back by clicking on the Vienna dock icon or 
-	pressing Command-1.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Command-Minus</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-V</td>
+      <td>Validate the selected feed.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-W</td>
+      <td>Closes the Vienna window but leaves Vienna running in the
+      background. You can bring the window back by clicking on the
+      Vienna dock icon or pressing Command-1.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/nl.lproj/Vienna Help/advanced.html
+++ b/lproj/nl.lproj/Vienna Help/advanced.html
@@ -1,15 +1,30 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-	<title>Geavanceerde voorkeuren</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <title>Geavanceerde voorkeuren</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Geavanceerde voorkeuren</span>
-<p>De "Geavanceerd" sectie van de Voorkeuren geeft de mogelijkheid om specifieke opties van Vienna te wijzigen die niet essentieel zijn voor het normale gebruik, maar bepaalde problemen kan oplossen zoals geadviseerd door het support forum. Deze pagina geeft uitleg over die mogelijkheden.
-</p>
-<h2><b>Activeer JavaScript in interne browser</b></h2>
-<p>Schakelt ondersteuning voor JavaScript scripts in de interne browser van Vienna aan of uit. Standaard is dit ingeschakeld. Door dit uit te schakelen kan JavaScript code op webpagina's niet uitgevoerd worden. Dit kan problemen oplossen zoals pop-up vensters of ander ongewenst c.q. onverwacht gedrag. Echter dit kan er ook toe leiden dat webpagina's niet volledig laden of niet werken, danwel onvolledig werken.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Geavanceerde
+  voorkeuren</span>
+  <p>De "Geavanceerd" sectie van de Voorkeuren geeft de
+  mogelijkheid om specifieke opties van Vienna te wijzigen die niet
+  essentieel zijn voor het normale gebruik, maar bepaalde problemen
+  kan oplossen zoals geadviseerd door het support forum. Deze
+  pagina geeft uitleg over die mogelijkheden.</p>
+  <h2><b>Activeer JavaScript in interne browser</b></h2>
+  <p>Schakelt ondersteuning voor JavaScript scripts in de interne
+  browser van Vienna aan of uit. Standaard is dit ingeschakeld.
+  Door dit uit te schakelen kan JavaScript code op webpagina's niet
+  uitgevoerd worden. Dit kan problemen oplossen zoals pop-up
+  vensters of ander ongewenst c.q. onverwacht gedrag. Echter dit
+  kan er ook toe leiden dat webpagina's niet volledig laden of niet
+  werken, danwel onvolledig werken.</p>
 </body>
 </html>

--- a/lproj/nl.lproj/Vienna Help/faq.html
+++ b/lproj/nl.lproj/Vienna Help/faq.html
@@ -1,117 +1,215 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="content-type" content=
+  "text/html; charset=utf-8" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Hoe kan ik?</span>
-<p>Hier zijn een aantal vragen die naar voren kwamen tijdens de ontwikkeling van Vienna in de test-fase.
-Kijk hiervoor op <a href="http://www.vienna-rss.org/?page_id=96">Official Vienna FAQ Page</a> en de laatste hints en tips voor Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Waar kan ik de Vienna broncode vinden?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">Ik heb een probleem gevonden in Vienna. Hoe kan ik dit melden?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">Hoe creëer ik mijn eigen stijlen?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">Hoe kan ik mijn eigen scripts maken?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-Hoe kan ik zien wat er gebeurt als mijn abonnementen worden bijgewerkt?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">Hoe kan ik mijn Vienna database verplaatsen naar een andere map?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Een van mijn abonnementen meldt &quot;Error parsing XML data in feed&quot;.
-Wat betekent dit?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is er een toetscombinatie om naar het volgende artikel te gaan, artikelen te markeren, etc?</a></li>
-<li>
-	<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-	What do the green dots mean in the list of articles?</a></li>
-	<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">Hoe gebruik ik Auto Expiratie en wat doet het?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">Hoe vraag ik om een verbetering aan Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Waar kan ik de Vienna broncode vinden?</a></h2>
-<p>Kijk op de <a href="https://github.com/ViennaRSS/vienna-rss/">Development</a> pagina voor instructies om de broncode van Vienna te krijgen. De broncode is vrij beschikbaar om in te kijken als u geïnteresseerd bent hoe Vienna werkt, als u zelf een kopie van Vienna wilt compileren of om in een ander project delen ervan te gebruiken. De broncode wordt aangeboden onder de <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 license</a>.</p>
-
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">Ik heb een probleem gevonden in Vienna. Hoe kan ik dit melden?</a></h2>
-<p>Plaats een bericht in het <a href="http://forums.cocoaforge.com/viewforum.php?f=18"> Support forum</a> of in de <a href="https://github.com/ViennaRSS/vienna-rss/issues">issues list</a> <i>(beide Engels-talig)</i> en iemand zal het onderzoeken. Geef zoveel informatie over het probleem als u kan, inclusief: de 'build' van Vienna (te vinden in het <b>Vienna &rarr; Over Vienna</b> venster), hoe de fout te reproduceren en wat u verwachte dat er zou gebeuren. Er is een sticky note in het forum met tips hoe u een goed bug rapport schrijft.</p>
-
-<p>Zorg ervoor dat u altijd de laatste versie van Vienna gebruikt. Het <b>Vienna &rarr; Zoek naar updates</b> menu zal rapporteren of er een nieuwere versie is dan degene die u gebruikt.</p>
-
-<h2><a name="How_do_I_create_my_own_styles">Hoe creëer ik mijn eigen stijlen?</a></h2>
-<p>Kijk op de <a href="http://www.vienna-rss.org/?page_id=65">Custom Styles page</a> voor
-instructies.</p>
-
-<h2><a name="How_do_I_create_my_own_scripts">Hoe kan ik mijn eigen scripts maken?</a></h2>
-<p>Vienna's scripts zijn geschreven in AppleScript. Kijk op <a href="http://developer.apple.com/applescript/"> Apple resource page</a> voor meer informatie.</p>
-<p>Om te beginnen kan u een bestaand script downladen zoals <a href="http://www.cortig.net/files/ShareWithPapers.zip">Cortig's original
-Share with Papers plugin</a> of <a href="https://github.com/reefdog/Vienna-to-Yojimbo-AppleScripts">reefdog's Vienna to Yojimbo script</a> en dit bekijken in AppleScript editor.</p>
-
-<p>Heeft u een script dat u wilt aanmelden, stuur dit naar
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> en nadat het is bekeken, zal het beschikbaar komen op de Downloads pagina.</p>
-
-<h2><a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-Hoe kan ik zien wat er gebeurt als mijn abonnementen worden bijgewerkt?</a></h2>
-<p>Selecteer <b>Venster &rarr; Activiteitenoverzicht</b>. Het venster toont alle abonnementen en hun status van de laatste bijwerking. Onderin staan gedetailleerde gegevens en deze kunnen bruikbaar zijn voor het oplossen van problemen. (Als de details niet zichtbaar zijn, pak dan de splitter onder in het venster en sleep deze omhoog om dit paneel te tonen).</p>
-
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">Hoe kan ik mijn Vienna database verplaatsen naar een andere map?</a></h2>
-<p>De Vienna database heet messages.db en is normaliter te vinden in <i>~/Library/Application Support/Vienna</i>. U kan deze op een andere plaats bewaren. Volg deze stappen:</p>
-<ol>
-<li>Stop Vienna.</li>
-<li>Open een Terminal venster en typ:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2
-&quot;DefaultDatabase&quot; '&lt;pad naar nieuwe messages.db&gt;'</font><br>
-
-<br>
-waar &lt;pad naar nieuwe messages.db&gt; de padnaam naar de map is  die de messages.db gaat bevatten. De padnaam moet de messages.db bestandsnaam aan het einde bevatten. Bijvoorbeeld:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Start Vienna.</li>
-</ol>
-
-<h2><a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-Een van mijn abonnementen meldt &quot;Error parsing XML data in feed&quot;.
-Wat betekent dit?</a></h2>
-<p>Dit betekent dat Vienna van een feed uit de abonnementen data kreeg waar het niet mee uit de voeten kan.
-Hier kunnen meerdere redenen voor zijn:</p>
-
-<ol>
-<li>De URL van de feed wijst niet naar een RSS of Atom feed maar naar een webpagina. Controleer de URL van de betreffende feed zorgvuldig.</li>
-<li>De feed zelf kan non valide XML bevatten. Kies <b>Map &rarr; Toon info&hellip;</b> en vervolgens Valideer om te zien of dit het geval is. Helaas kunt u in Vienna niets doen om dit op te lossen, behalve wachten tot de site de feed corrigeert.</li>
-<li>De feed kan incompleet zijn. Als het bijwerken werd onderbroken dan kan de XML data incompleet zijn en verminkt lijken voor Vienna. Een tweede keer bijwerken kan dit probleem oplossen.</li>
-</ol>
-<p>Als het bovenstaande uw probleem niet verklaart, plaats dan een bericht op het support forum met de problematische feed URL.</p>
-
-<h2><a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is er een toetscombinatie om naar het volgende artikel te gaan, artikelen te markeren, etc?</a></h2>
-<p>Waarschijnlijk. Er zijn enkeltoets equivalenten voor sommige menu commando's zoals:</p> <p><b>Spatiebalk</b> - ga naar het volgende ongelezen artikel. Als het huidige artikel enkele pagina's lang is, dan wordt er eerst door dat artikel geschoven. Aan het einde van het artikel zal dan naar het volgende ongelezen artikel gegaan worden. Dit in tegenstelling tot het <b>Volgende ongelezen</b> menu (toetscombinatie <b>&#x2318;U</b>) dat altijd direct naar het volgende ongelezen artikel gaat.</p>
-<p><b>R</b> - markeert het huidige artikel als gelezen als het ongelezen is en vice versa.</p>
-<p><b>F</b> - markeert het huidige artikel met een vlag als het die nog niet heeft, of verwijderd deze als die wel aanwezig is.</p>
-
-<p>Kijk in het Vienna help bestand voor meer toetscombinaties.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">Welke betekenis hebben de groene bolletjes in de artikel lijst?</a></h2>
-<p>Blauwe bolletjes zijn voor nieuwe artikelen, en de groene voor bijgewerkte artikelen:
-artikelen waarvan de tekst gewijzigd is sinds ze voor het laatst zijn gedownload.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">Hoe gebruik ik Auto Expiratie en wat doet het?</a></h2>
-<p>Auto-expiratie verplaatst artikelen die ouder zijn dan x dagen naar de prullenmand. Hierdoor kunt u uw mappen handelbaar houden door alleen recente artikelen te bewaren. Dit is actief bij het starten van Vienna en na het bijwerken van abonnementen. Ga naar <b>Voorkeuren &rarr; Algemeen</b> en pas daar de <b>Verplaats artikelen naar prullenmand</b> optie aan.</p>
-<p>Auto-expire verwijderd GEEN ongelezen of gemarkeerde artikelen. Het gaat ervan uit dat u die nog niet gelezen heeft en laat ze daarom met rust.</p>
-
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">Hoe vraag ik om een verbetering aan Vienna?</a></h2>
-<p>Plaats een bericht in de
-<a href="https://github.com/ViennaRSS/vienna-rss/issues">issues list</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Hoe kan ik?</span>
+  <p>Hier zijn een aantal vragen die naar voren kwamen tijdens de
+  ontwikkeling van Vienna in de test-fase. Kijk hiervoor op
+  <a href="http://www.vienna-rss.org/?page_id=96">Official Vienna
+  FAQ Page</a> en de laatste hints en tips voor Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Waar kan
+    ik de Vienna broncode vinden?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">Ik heb een
+    probleem gevonden in Vienna. Hoe kan ik dit melden?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">Hoe creëer ik mijn
+    eigen stijlen?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">Hoe kan ik mijn
+    eigen scripts maken?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    Hoe kan ik zien wat er gebeurt als mijn abonnementen worden
+    bijgewerkt?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">Hoe kan
+    ik mijn Vienna database verplaatsen naar een andere
+    map?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    Een van mijn abonnementen meldt "Error parsing XML data in
+    feed". Wat betekent dit?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is er een toetscombinatie om naar het volgende artikel te gaan,
+    artikelen te markeren, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">Hoe
+    gebruik ik Auto Expiratie en wat doet het?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">Hoe
+    vraag ik om een verbetering aan Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Waar kan ik de Vienna
+  broncode vinden?</a></h2>
+  <p>Kijk op de <a href=
+  "https://github.com/ViennaRSS/vienna-rss/">Development</a> pagina
+  voor instructies om de broncode van Vienna te krijgen. De
+  broncode is vrij beschikbaar om in te kijken als u geïnteresseerd
+  bent hoe Vienna werkt, als u zelf een kopie van Vienna wilt
+  compileren of om in een ander project delen ervan te gebruiken.
+  De broncode wordt aangeboden onder de <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">Ik heb een
+  probleem gevonden in Vienna. Hoe kan ik dit melden?</a></h2>
+  <p>Plaats een bericht in het <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> of in de <a href=
+  "https://github.com/ViennaRSS/vienna-rss/issues">issues list</a>
+  <i>(beide Engels-talig)</i> en iemand zal het onderzoeken. Geef
+  zoveel informatie over het probleem als u kan, inclusief: de
+  'build' van Vienna (te vinden in het <b>Vienna → Over Vienna</b>
+  venster), hoe de fout te reproduceren en wat u verwachte dat er
+  zou gebeuren. Er is een sticky note in het forum met tips hoe u
+  een goed bug rapport schrijft.</p>
+  <p>Zorg ervoor dat u altijd de laatste versie van Vienna
+  gebruikt. Het <b>Vienna → Zoek naar updates</b> menu zal
+  rapporteren of er een nieuwere versie is dan degene die u
+  gebruikt.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">Hoe creëer ik mijn eigen
+  stijlen?</a></h2>
+  <p>Kijk op de <a href=
+  "http://www.vienna-rss.org/?page_id=65">Custom Styles page</a>
+  voor instructies.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">Hoe kan ik mijn eigen scripts
+  maken?</a></h2>
+  <p>Vienna's scripts zijn geschreven in AppleScript. Kijk op
+  <a href="http://developer.apple.com/applescript/">Apple resource
+  page</a> voor meer informatie.</p>
+  <p>Om te beginnen kan u een bestaand script downladen zoals
+  <a href=
+  "http://www.cortig.net/files/ShareWithPapers.zip">Cortig's
+  original Share with Papers plugin</a> of <a href=
+  "https://github.com/reefdog/Vienna-to-Yojimbo-AppleScripts">reefdog's
+  Vienna to Yojimbo script</a> en dit bekijken in AppleScript
+  editor.</p>
+  <p>Heeft u een script dat u wilt aanmelden, stuur dit naar
+  <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  en nadat het is bekeken, zal het beschikbaar komen op de
+  Downloads pagina.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  Hoe kan ik zien wat er gebeurt als mijn abonnementen worden
+  bijgewerkt?</a></h2>
+  <p>Selecteer <b>Venster → Activiteitenoverzicht</b>. Het venster
+  toont alle abonnementen en hun status van de laatste bijwerking.
+  Onderin staan gedetailleerde gegevens en deze kunnen bruikbaar
+  zijn voor het oplossen van problemen. (Als de details niet
+  zichtbaar zijn, pak dan de splitter onder in het venster en sleep
+  deze omhoog om dit paneel te tonen).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">Hoe kan
+  ik mijn Vienna database verplaatsen naar een andere map?</a></h2>
+  <p>De Vienna database heet messages.db en is normaliter te vinden
+  in <i>~/Library/Application Support/Vienna</i>. U kan deze op een
+  andere plaats bewaren. Volg deze stappen:</p>
+  <ol>
+    <li>Stop Vienna.</li>
+    <li>Open een Terminal venster en typ:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;pad naar
+    nieuwe messages.db&gt;'</font><br />
+    <br />
+    waar &lt;pad naar nieuwe messages.db&gt; de padnaam naar de map
+    is die de messages.db gaat bevatten. De padnaam moet de
+    messages.db bestandsnaam aan het einde bevatten.
+    Bijvoorbeeld:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Start Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  Een van mijn abonnementen meldt "Error parsing XML data in feed".
+  Wat betekent dit?</a></h2>
+  <p>Dit betekent dat Vienna van een feed uit de abonnementen data
+  kreeg waar het niet mee uit de voeten kan. Hier kunnen meerdere
+  redenen voor zijn:</p>
+  <ol>
+    <li>De URL van de feed wijst niet naar een RSS of Atom feed
+    maar naar een webpagina. Controleer de URL van de betreffende
+    feed zorgvuldig.</li>
+    <li>De feed zelf kan non valide XML bevatten. Kies <b>Map →
+    Toon info…</b> en vervolgens Valideer om te zien of dit het
+    geval is. Helaas kunt u in Vienna niets doen om dit op te
+    lossen, behalve wachten tot de site de feed corrigeert.</li>
+    <li>De feed kan incompleet zijn. Als het bijwerken werd
+    onderbroken dan kan de XML data incompleet zijn en verminkt
+    lijken voor Vienna. Een tweede keer bijwerken kan dit probleem
+    oplossen.</li>
+  </ol>
+  <p>Als het bovenstaande uw probleem niet verklaart, plaats dan
+  een bericht op het support forum met de problematische feed
+  URL.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is er een toetscombinatie om naar het volgende artikel te gaan,
+  artikelen te markeren, etc?</a></h2>
+  <p>Waarschijnlijk. Er zijn enkeltoets equivalenten voor sommige
+  menu commando's zoals:</p>
+  <p><b>Spatiebalk</b> - ga naar het volgende ongelezen artikel.
+  Als het huidige artikel enkele pagina's lang is, dan wordt er
+  eerst door dat artikel geschoven. Aan het einde van het artikel
+  zal dan naar het volgende ongelezen artikel gegaan worden. Dit in
+  tegenstelling tot het <b>Volgende ongelezen</b> menu
+  (toetscombinatie <b>⌘U</b>) dat altijd direct naar het volgende
+  ongelezen artikel gaat.</p>
+  <p><b>R</b> - markeert het huidige artikel als gelezen als het
+  ongelezen is en vice versa.</p>
+  <p><b>F</b> - markeert het huidige artikel met een vlag als het
+  die nog niet heeft, of verwijderd deze als die wel aanwezig
+  is.</p>
+  <p>Kijk in het Vienna help bestand voor meer
+  toetscombinaties.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">Welke
+  betekenis hebben de groene bolletjes in de artikel
+  lijst?</a></h2>
+  <p>Blauwe bolletjes zijn voor nieuwe artikelen, en de groene voor
+  bijgewerkte artikelen: artikelen waarvan de tekst gewijzigd is
+  sinds ze voor het laatst zijn gedownload.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">Hoe gebruik ik
+  Auto Expiratie en wat doet het?</a></h2>
+  <p>Auto-expiratie verplaatst artikelen die ouder zijn dan x dagen
+  naar de prullenmand. Hierdoor kunt u uw mappen handelbaar houden
+  door alleen recente artikelen te bewaren. Dit is actief bij het
+  starten van Vienna en na het bijwerken van abonnementen. Ga naar
+  <b>Voorkeuren → Algemeen</b> en pas daar de <b>Verplaats
+  artikelen naar prullenmand</b> optie aan.</p>
+  <p>Auto-expire verwijderd GEEN ongelezen of gemarkeerde
+  artikelen. Het gaat ervan uit dat u die nog niet gelezen heeft en
+  laat ze daarom met rust.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">Hoe vraag ik om een
+  verbetering aan Vienna?</a></h2>
+  <p>Plaats een bericht in de <a href=
+  "https://github.com/ViennaRSS/vienna-rss/issues">issues
+  list</a>.</p>
 </body>
 </html>

--- a/lproj/nl.lproj/Vienna Help/index.html
+++ b/lproj/nl.lproj/Vienna Help/index.html
@@ -1,34 +1,39 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Inleiding voor Vienna</p>
-		<p><a href="intro.html">De eerste stappen met Vienna.</a></p>
-
-		<p class="header">Toetscombinaties</p>
-		<p><a href="keyboard.html">Ontdek toetscombinaties voor veelgebruikte commando's</a></p>
-
-		<p class="header">Hoe kan ik?</p>
-		<p><a href="faq.html">Veelgestelde vragen, ondersteuning verkrijgen en problemen oplossen.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Inleiding voor Vienna</p>
+          <p><a href="intro.html">De eerste stappen met
+          Vienna.</a></p>
+          <p class="header">Toetscombinaties</p>
+          <p><a href="keyboard.html">Ontdek toetscombinaties voor
+          veelgebruikte commando's</a></p>
+          <p class="header">Hoe kan ik?</p>
+          <p><a href="faq.html">Veelgestelde vragen, ondersteuning
+          verkrijgen en problemen oplossen.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/nl.lproj/Vienna Help/intro.html
+++ b/lproj/nl.lproj/Vienna Help/intro.html
@@ -1,58 +1,108 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Inleiding</span>
-<p>Vienna is een programma waarmee u RSS en Atom feeds kunt lezen op uw Mac OS X computer. Het automatiseert het ophalen
-van nieuwe artikelen van uw abonnementen en bewaart deze in een lokale database zodat u hen ook offline kan lezen.
-U kunt artikelen doorzoeken op sleutelwoorden, markeren voor later en feeds organiseren in mappen. U kunt slimme
-mappen aanmaken die het eenvoudig maken om automatisch artikelen bij elkaar te groeperen gebaseerd op zoekcriteria.
-De ingebouwde webbrowser geeft u de mogelijkheid om de webpagina's van de artikelen te bekijken of om links te volgen
-in aparte tabbladen.</p>
-<p>Vienna is ontworpen met als doel eenvoud. Veel ruimte voor uw nieuws en een simpele bediening.</p>
-<b>Beginnen met Vienna</b>
-<p> Als dit de eerste keer is dat u Vienna gebruikt dan wordt er een database gecreëerd en een aantal standaard
-abonnmementen toegevoegd. Kies <b>Archief &rarr; Werk alle abonnementen bij</b> uit het menu of <b>&#8984;R</b> om de meest recente
-artikelen op te halen.</p>
-<p>Abonneer u op uw eigen feeds. Er zijn diverse manieren om feeds te vinden. Tijdens het web browsen ziet u <img src="images/rssfeed.gif" alt=""> of XML iconen die
-aangeven dat de webpagina een RSS-feed heeft. Bijna alle online blog diensten zoals Blogger of LiveJournal hebben RSS feeds.</p>
-<p>Indien u de gebruikersnaam van een blogger op LiveJournal, Blogger, MSN Spaces of Xanga kent, dan maakt Vienna het eenvoudig
-om een abonnement te nemen op hun feed. Begin door <b>&#8984;N</b> in te toetsen of door <b>Archief &rarr; Nieuw abonnement...</b> te kiezen.
-In het <i>Neem een nieuw abonnement</i> venster, kies de blog dienst uit de <i>Bron</i> lijst en voer de gebruikersnaam in.
-Kies dan <i>Abonneer</i> en Vienna voegt het abonnement toe aan de lijst. Als u verbonden bent met het internet worden
-direct de artikelen van de feed binnen gehaald.</p>
-<p>U kan Vienna ook gebruiken in combinatie met een Open Reader account. Kies <b>Vienna &rarr; Voorkeuren &rarr; Synchroniseren</b> en vink <i>Synchroniseer met Open Reader</i> aan.<br>
-Bedenk vooraf welke feeds u via Open Reader wil lezen en welke u direct wil benaderen.
-Vienna voorkomt duplicaten tussen de twee, maar als u feeds in Open Reader heeft die Vienna al direct ophaalt dan onstaan er onderlinge afwijkingen in uw lees lijsten. Houd hier rekening mee bij het organiseren van uw feeds.<br>
-Houd de volgende dingen in de gaten:
-<ul>
-<li>Open Reader feeds kunnen synchroniseren tussen meerdere programma's en apparaten die dit ondersteunen</li>
-<li>Open Reader ondersteunt geen feeds die een gebruikersnaam en wachtwoord vereisen</li>
-<li>Feeds direct ophalen vermijdt Google als tussenpersoon. Voor minder 'populaire' feeds krijgt u sneller artikelen binnen.</li>
-<li>In het algemeen geldt dat feeds direct ophalen van de originele website minder netwerkverkeer oplevert. Als de server geen nieuwe artikelen heeft sinds de laatste bijwerking, dan voorkomt Vienna een nodeloze download.</li>
-</ul></p>
-<p>Normaal moet u in Vienna handmatig uw abonnementen bijwerken. U kan dit ook automatisch laten doen met een tijd-interval.
-In de <i>Algemeen</i> sectie van de <i>Voorkeuren</i> selecteert u de gewenste interval uit de lijst <i>Zoek naar nieuwe
-artikelen</i>. Vienna moet actief zijn om automatisch de abonnementen bij te werken.</p>
-<p>Tijdens het lezen drukt u de spatiebalk in om naar een volgend ongelezen artikel te gaan. Ieder artikel wordt als
-gelezen gemarkeerd na een korte vertraging. Als u liever heeft dat dit gebeurt als u naar het volgende artikel gaat, dan
- kan u dit aanpassen in <i>Voorkeuren &rarr; Algemeen</i>. Om een artikel als ongelezen te markeren kies <b>Artikel &rarr; Markeer als
-ongelezen</b> of druk eenvoudigweg de <b>R</b> toets in.</p>
-<p>Tenslotte, u kunt de webpagina van een artikel of een koppeling uit het artikel bekijken in Vienna. Op een koppeling klikken
-opent de webpagina in de interne browser in een nieuwe tab. Als u de voorkeur heeft om alle webpagina's in uw standaard
-webbrowser te bekijken selecteer dan in <i>Voorkeuren &rarr; Algemeen</i> de optie <i>Open koppeling in externe browser</i>.
-Als u rechts-klikt in een artikel of webpagina dan kunt u die bekijken in uw standaard ingestelde externe browser, u ziet
-dan in het contextuele menu de optie <i>Open koppeling in xxx</i> of <i> Open pagina in xxx</i> waar xxx vervangen wordt door
-de naam van uw standaard browser.</p>
-<p>Ontdek nog meer mogelijkheden van Vienna. U kunt de stilering van de artikelen veranderen door <b>Weergave &rarr; Stijl</b> te kiezen. Veel meer stijlen zijn te vinden op de  <a href="http://www.vienna-rss.org/?page_id=76">Downloads</a> pagina van de Vienna website samen met scripts waarmee u Vienna kan integreren met andere programma's op uw computer.
-Of experimenteer met slimme mappen om uw artikelen te organiseren volgens de door u opgegeven criteria omtrent de inhoud van die artikelen.</p>
-
-<p>Indien u vragen heeft over Vienna of problemen ondervind, stuur dan een email naar <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> of ga naar het <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Inleiding</span>
+  <p>Vienna is een programma waarmee u RSS en Atom feeds kunt lezen
+  op uw Mac OS X computer. Het automatiseert het ophalen van nieuwe
+  artikelen van uw abonnementen en bewaart deze in een lokale
+  database zodat u hen ook offline kan lezen. U kunt artikelen
+  doorzoeken op sleutelwoorden, markeren voor later en feeds
+  organiseren in mappen. U kunt slimme mappen aanmaken die het
+  eenvoudig maken om automatisch artikelen bij elkaar te groeperen
+  gebaseerd op zoekcriteria. De ingebouwde webbrowser geeft u de
+  mogelijkheid om de webpagina's van de artikelen te bekijken of om
+  links te volgen in aparte tabbladen.</p>
+  <p>Vienna is ontworpen met als doel eenvoud. Veel ruimte voor uw
+  nieuws en een simpele bediening.</p><b>Beginnen met Vienna</b>
+  <p>Als dit de eerste keer is dat u Vienna gebruikt dan wordt er
+  een database gecreëerd en een aantal standaard abonnmementen
+  toegevoegd. Kies <b>Archief → Werk alle abonnementen bij</b> uit
+  het menu of <b>⌘R</b> om de meest recente artikelen op te
+  halen.</p>
+  <p>Abonneer u op uw eigen feeds. Er zijn diverse manieren om
+  feeds te vinden. Tijdens het web browsen ziet u <img src=
+  "images/rssfeed.gif" alt="" /> of XML iconen die aangeven dat de
+  webpagina een RSS-feed heeft. Bijna alle online blog diensten
+  zoals Blogger of LiveJournal hebben RSS feeds.</p>
+  <p>Indien u de gebruikersnaam van een blogger op LiveJournal,
+  Blogger, MSN Spaces of Xanga kent, dan maakt Vienna het eenvoudig
+  om een abonnement te nemen op hun feed. Begin door <b>⌘N</b> in
+  te toetsen of door <b>Archief → Nieuw abonnement...</b> te
+  kiezen. In het <i>Neem een nieuw abonnement</i> venster, kies de
+  blog dienst uit de <i>Bron</i> lijst en voer de gebruikersnaam
+  in. Kies dan <i>Abonneer</i> en Vienna voegt het abonnement toe
+  aan de lijst. Als u verbonden bent met het internet worden direct
+  de artikelen van de feed binnen gehaald.</p>
+  <p>U kan Vienna ook gebruiken in combinatie met een Open Reader
+  account. Kies <b>Vienna → Voorkeuren → Synchroniseren</b> en vink
+  <i>Synchroniseer met Open Reader</i> aan.<br />
+  Bedenk vooraf welke feeds u via Open Reader wil lezen en welke u
+  direct wil benaderen. Vienna voorkomt duplicaten tussen de twee,
+  maar als u feeds in Open Reader heeft die Vienna al direct
+  ophaalt dan onstaan er onderlinge afwijkingen in uw lees lijsten.
+  Houd hier rekening mee bij het organiseren van uw feeds.<br />
+  Houd de volgende dingen in de gaten:</p>
+  <ul>
+    <li>Open Reader feeds kunnen synchroniseren tussen meerdere
+    programma's en apparaten die dit ondersteunen</li>
+    <li>Open Reader ondersteunt geen feeds die een gebruikersnaam
+    en wachtwoord vereisen</li>
+    <li>Feeds direct ophalen vermijdt Google als tussenpersoon.
+    Voor minder 'populaire' feeds krijgt u sneller artikelen
+    binnen.</li>
+    <li>In het algemeen geldt dat feeds direct ophalen van de
+    originele website minder netwerkverkeer oplevert. Als de server
+    geen nieuwe artikelen heeft sinds de laatste bijwerking, dan
+    voorkomt Vienna een nodeloze download.</li>
+  </ul>
+  <p>Normaal moet u in Vienna handmatig uw abonnementen bijwerken.
+  U kan dit ook automatisch laten doen met een tijd-interval. In de
+  <i>Algemeen</i> sectie van de <i>Voorkeuren</i> selecteert u de
+  gewenste interval uit de lijst <i>Zoek naar nieuwe artikelen</i>.
+  Vienna moet actief zijn om automatisch de abonnementen bij te
+  werken.</p>
+  <p>Tijdens het lezen drukt u de spatiebalk in om naar een volgend
+  ongelezen artikel te gaan. Ieder artikel wordt als gelezen
+  gemarkeerd na een korte vertraging. Als u liever heeft dat dit
+  gebeurt als u naar het volgende artikel gaat, dan kan u dit
+  aanpassen in <i>Voorkeuren → Algemeen</i>. Om een artikel als
+  ongelezen te markeren kies <b>Artikel → Markeer als ongelezen</b>
+  of druk eenvoudigweg de <b>R</b> toets in.</p>
+  <p>Tenslotte, u kunt de webpagina van een artikel of een
+  koppeling uit het artikel bekijken in Vienna. Op een koppeling
+  klikken opent de webpagina in de interne browser in een nieuwe
+  tab. Als u de voorkeur heeft om alle webpagina's in uw standaard
+  webbrowser te bekijken selecteer dan in <i>Voorkeuren →
+  Algemeen</i> de optie <i>Open koppeling in externe browser</i>.
+  Als u rechts-klikt in een artikel of webpagina dan kunt u die
+  bekijken in uw standaard ingestelde externe browser, u ziet dan
+  in het contextuele menu de optie <i>Open koppeling in xxx</i> of
+  <i>Open pagina in xxx</i> waar xxx vervangen wordt door de naam
+  van uw standaard browser.</p>
+  <p>Ontdek nog meer mogelijkheden van Vienna. U kunt de stilering
+  van de artikelen veranderen door <b>Weergave → Stijl</b> te
+  kiezen. Veel meer stijlen zijn te vinden op de <a href=
+  "http://www.vienna-rss.org/?page_id=76">Downloads</a> pagina van
+  de Vienna website samen met scripts waarmee u Vienna kan
+  integreren met andere programma's op uw computer. Of
+  experimenteer met slimme mappen om uw artikelen te organiseren
+  volgens de door u opgegeven criteria omtrent de inhoud van die
+  artikelen.</p>
+  <p>Indien u vragen heeft over Vienna of problemen ondervind,
+  stuur dan een email naar <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> of
+  ga naar het <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/nl.lproj/Vienna Help/keyboard.html
+++ b/lproj/nl.lproj/Vienna Help/keyboard.html
@@ -1,308 +1,351 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="content-type" content=
+  "text/html; charset=utf-8" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Toetscombinaties</span>
-<p>U kunt met uw toetsenbord snel veel taken uitvoeren in Vienna. U vindt de combinaties door in de menus te kijken en in de onderstaande lijst.
-Vele items in Vienna hebben ook een contextueel menu. Om een contextueel menu te openen klikt u op een item terwijl u de Control toets ingedrukt houd.</p>
-
-<p>Om een commando uit te voeren, druk de onderstaande toetsen in.</p>
-<p><b>Toets legenda</b></p>
-<p>  &#x2326;&nbsp;=&nbsp;Delete,  &#x232B;&nbsp;=&nbsp;Backspace,  &#x2305;&nbsp;=&nbsp;Enter,  &#x21A9;&nbsp;=&nbsp;Return,  &#8997;&nbsp;=&nbsp;Alt,  &#8679;&nbsp;=&nbsp;Shift,  &#8984;&nbsp;=&nbsp;Command,  &#x2303;&nbsp;=&nbsp;Control</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="200" bgcolor="#C0C0C0"><b>Toets(en)</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Actie</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Enkelvoudige toetsen</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">b</td>
-    <td>Ga naar het eerste ongelezen artikel.</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Activeer het zoek venster.</td>
-  </tr>
-  <tr>
-    <td>h</td>
-    <td>Plaats de cursor in het 'Zoek in artikelen' veld.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Markeer de huidige map als gelezen.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Schakel de geselecteerde artikelen tussen &#9873; markering aan of uit.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Ga naar het volgende ongelezen artikel.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Schakel de geselecteerde artikelen tussen gelezen en ongelezen.</td>
-  </tr>
-  <tr>
-    <td>u</td>
-    <td>Schakel de geselecteerde artikelen tussen gelezen en ongelezen.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Markeer de huidige map als gelezen en springt naar de volgende map met ongelezen artikelen.</td>
-  </tr>
-  <tr>
-    <td>&lt;&nbsp;&nbsp;of&nbsp;&nbsp;,</td>
-    <td>Toon het vorige bekeken artikel of webpagina.</td>
-  </tr>
-  <tr>
-    <td>&gt;&nbsp;&nbsp;of&nbsp;&nbsp;.</td>
-    <td>Toon het volgende bekeken artikel of webpagina.</td>
-  </tr>
-  <tr>
-    <td>Spatiebalk</td>
-    <td>Ga naar het volgende ongelezen artikel, tenzij er meer tekst in het huidige artikel is dan schuift de volgende pagina in beeld.</td>
-  </tr>
-  <tr>
-    <td>&#x2305;&nbsp;&nbsp;of&nbsp;&nbsp;&#x21A9;</td>
-    <td>Open de webpagina van het geselecteerde artikel.</td>
-  </tr>
-  <tr>
-    <td>&#x2326;&nbsp;&nbsp;of&nbsp;&nbsp;&#x232B;</td>
-    <td>Verplaats geselecteerde artikelen naar de prullenmand. Als deze toets wordt gebruikt in de prullenmand, dan worden de artikelen definitief verwijderd.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>Algemeen</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>&#8997;Klik</td>
-    <td>Open de geklikte koppeling, en negeer de voorkeurinstelling voor openen in externe browser.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;B</td>
-    <td>Open de filterbalk.</td>
-  </tr>
-  <tr>
-    <td>&#8984;N</td>
-    <td>Maak een nieuw abonnement aan.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;F</td>
-    <td>Maak een slimme map.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;E</td>
-    <td>Bewerk de URL voor de geselecteerde map of bewerk slimme map criteria.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;D</td>
-    <td>Verwijder de geselecteerde map.</td>
-  </tr>
-  <tr>
-    <td>&#8984;C</td>
-    <td>Kopieer de geselecteerde tekst naar het klembord. Als de focus op een artikel ligt, dan worden de artikel details gekopieerd.</td>
-  </tr>
-  <tr>
-    <td>&#8984;H</td>
-    <td>Verberg het Vienna venster.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;H</td>
-    <td>Verberg alle vensters, behalve die van Vienna.</td>
-  </tr>
-  <tr>
-    <td>&#8984;I</td>
-    <td>Toon het Info venster voor de geselecteerde map.</td>
-  </tr>
-  <tr>
-    <td>&#8984;L</td>
-    <td>Plaats de cursor in de adresbalk van de huidige tab. Indien er geen browser geopend is, dan wordt er een nieuwe tab geopend en de cursor in de adresbalk geplaatst.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;N</td>
-    <td>Wijzig de naam van de geselecteerde map.</td>
-  </tr>
-  <tr>
-    <td>&#8984;R</td>
-    <td>Werk alle abonnementen bij.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;R</td>
-    <td>Werk alleen de geselecteerde abonnementen bij.</td>
-  </tr>
-  <tr>
-    <td>&#x2303;&#8984;S</td>
-    <td>Stop bijwerken abonnementen.</td>
-  </tr>
-  <tr>
-    <td>&#8984;P</td>
-    <td>Druk geselecteerde artikelen af.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;P</td>
-    <td>Toon het Pagina-instelling venster.</td>
-  </tr>
-  <tr>
-    <td>&#8984;Q</td>
-    <td>Stop Vienna.</td>
-  </tr>
-  <tr>
-    <td>&#8984;T</td>
-    <td>Open een nieuwe tab en plaats de cursor in de adresbalk.</td>
-  </tr>
-  <tr>
-    <td>&#8984;U</td>
-    <td>Ga naar het volgende ongelezen artikel.</td>
-  </tr>
-  <tr>
-    <td>&#8984;Z</td>
-    <td>Herstel de laatste actie indien mogelijk.</td>
-  </tr>
-  <tr>
-    <td>&#8984;/</td>
-    <td>Toon/verberg de status balk.</td>
-  </tr>
-  <tr>
-    <td>&#8984;+</td>
-    <td>Maak de tekst groter in huidige artikel of webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;-</td>
-    <td>Maak de tekst kleiner in huidige artikel of webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;,</td>
-    <td>Open het Voorkeuren venster.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;&#x232B;</td>
-    <td>Leeg de prullenmand en vraag om bevestiging.</td>
-  </tr>
-  <tr>
-    <td>&#8984;?</td>
-    <td>Toon het Vienna Help bestand, (Mac OS X 10.5 en later, activeer de zoek functie in het Help bestand).</td>
-  </tr>
-  <tr>
-    <td><b>Artikelen</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#x2305;&nbsp;&nbsp;of&nbsp;&nbsp;&#8997;&#x21A9;</td>
-    <td>Open de webpagina van het artikel en negeer de voorkeurinstelling voor openen in externe browser.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;Z</td>
-    <td>Doe de laatse actie opnieuw als die was hersteld.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;M</td>
-    <td>Markeer de geselecteerde artikelen met een &#9873; en plaatst het in de map Gemarkeerde artikelen.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;U</td>
-    <td>Markeer geselecteerde artikel als gelezen.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;S</td>
-    <td>Stuur een email met een koppeling naar het huidige artikel.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;S</td>
-    <td>Markeer de huidige map als gelezen en ga naar de volgende map met ongelezen artikelen.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;O</td>
-    <td>Haal artikel uit prullenmand en zet terug in originele map.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;K</td>
-    <td>Markeer alle artikelen in geselecteerde map als gelezen.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;K</td>
-    <td>Markeer alle artikelen in alle mappen als gelezen.</td>
-  </tr>
-  <tr>
-    <td><b>Vensters</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>&#8984;W</td>
-    <td>Sluit de actieve tab als er een open is. Indien dat niet het geval is, dan sluit het Vienna venster.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;W</td>
-    <td>Sluit alle tab vensters. Opmerking: Dit commando vervangt de <b>Sluit tab</b> in het <b>Archief</b> menu als de alt (&#8997;) toets is ingedrukt.</td>
-  </tr>
-  <tr>
-    <td>&#8679;&#8984;W</td>
-    <td>Sluit het Vienna venster maar laat Vienna in de achtergrond werken.
-	U kan het venster weer openen door op het Vienna icoon in de Dock te klikken of
-	door &#8984;1 in te toetsen.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;&larr;</td>
-    <td>Toon het vorige tab venster.</td>
-  </tr>
-  <tr>
-    <td>&#8997;&#8984;&rarr;</td>
-    <td>Toon het volgende tab venster.</td>
-  </tr>
-  <tr>
-    <td>&#8984;M</td>
-    <td>Minimaliseer het Vienna venster naar de Dock.</td>
-  </tr>
-  <tr>
-    <td>&#8984;0</td>
-    <td>Toon het Activiteitenoverzicht log venster.</td>
-  </tr>
-  <tr>
-    <td>&#8984;1</td>
-    <td>Open het Vienna venster indien het was gesloten.</td>
-  </tr>
-  <tr>
-    <td>&#8984;2</td>
-    <td>Toon het Downloads venster.</td>
-  </tr>
-  <tr>
-    <td><b>Browser venster</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>&#8997;R</td>
-    <td>Ververs de huidige webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;.</td>
-    <td>Annuleer het laden van de huidige webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;[&nbsp;&nbsp;of&nbsp;&nbsp;&#8984;&larr;</td>
-    <td>Ga naar de vorige webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;]&nbsp;&nbsp;of&nbsp;&nbsp;&#8984;&rarr;</td>
-    <td>Ga naar de volgende webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;F</td>
-    <td>Activeer het zoek veld in de knoppenbalk. Voer hier tekst in en druk op Enter en er wordt gezocht in de huidige webpagina.</td>
-  </tr>
-  <tr>
-    <td>&#8984;G</td>
-    <td>Kijk of de zoekterm voorkomt verderop in de webpagina.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class=
+  "header">Toetscombinaties</span>
+  <p>U kunt met uw toetsenbord snel veel taken uitvoeren in Vienna.
+  U vindt de combinaties door in de menus te kijken en in de
+  onderstaande lijst. Vele items in Vienna hebben ook een
+  contextueel menu. Om een contextueel menu te openen klikt u op
+  een item terwijl u de Control toets ingedrukt houd.</p>
+  <p>Om een commando uit te voeren, druk de onderstaande toetsen
+  in.</p>
+  <p><b>Toets legenda</b></p>
+  <p>⌦&nbsp;=&nbsp;Delete, ⌫&nbsp;=&nbsp;Backspace,
+  ⌅&nbsp;=&nbsp;Enter, ↩&nbsp;=&nbsp;Return, ⌥&nbsp;=&nbsp;Alt,
+  ⇧&nbsp;=&nbsp;Shift, ⌘&nbsp;=&nbsp;Command,
+  ⌃&nbsp;=&nbsp;Control</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="200" bgcolor="#C0C0C0"><b>Toets(en)</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Actie</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Enkelvoudige toetsen</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">b</td>
+      <td>Ga naar het eerste ongelezen artikel.</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Activeer het zoek venster.</td>
+    </tr>
+    <tr>
+      <td>h</td>
+      <td>Plaats de cursor in het 'Zoek in artikelen' veld.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Markeer de huidige map als gelezen.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Schakel de geselecteerde artikelen tussen ⚑ markering aan
+      of uit.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Ga naar het volgende ongelezen artikel.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Schakel de geselecteerde artikelen tussen gelezen en
+      ongelezen.</td>
+    </tr>
+    <tr>
+      <td>u</td>
+      <td>Schakel de geselecteerde artikelen tussen gelezen en
+      ongelezen.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Markeer de huidige map als gelezen en springt naar de
+      volgende map met ongelezen artikelen.</td>
+    </tr>
+    <tr>
+      <td>&lt;&nbsp;&nbsp;of&nbsp;&nbsp;,</td>
+      <td>Toon het vorige bekeken artikel of webpagina.</td>
+    </tr>
+    <tr>
+      <td>&gt;&nbsp;&nbsp;of&nbsp;&nbsp;.</td>
+      <td>Toon het volgende bekeken artikel of webpagina.</td>
+    </tr>
+    <tr>
+      <td>Spatiebalk</td>
+      <td>Ga naar het volgende ongelezen artikel, tenzij er meer
+      tekst in het huidige artikel is dan schuift de volgende
+      pagina in beeld.</td>
+    </tr>
+    <tr>
+      <td>⌅&nbsp;&nbsp;of&nbsp;&nbsp;↩</td>
+      <td>Open de webpagina van het geselecteerde artikel.</td>
+    </tr>
+    <tr>
+      <td>⌦&nbsp;&nbsp;of&nbsp;&nbsp;⌫</td>
+      <td>Verplaats geselecteerde artikelen naar de prullenmand.
+      Als deze toets wordt gebruikt in de prullenmand, dan worden
+      de artikelen definitief verwijderd.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>Algemeen</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>⌥Klik</td>
+      <td>Open de geklikte koppeling, en negeer de
+      voorkeurinstelling voor openen in externe browser.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘B</td>
+      <td>Open de filterbalk.</td>
+    </tr>
+    <tr>
+      <td>⌘N</td>
+      <td>Maak een nieuw abonnement aan.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘F</td>
+      <td>Maak een slimme map.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘E</td>
+      <td>Bewerk de URL voor de geselecteerde map of bewerk slimme
+      map criteria.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘D</td>
+      <td>Verwijder de geselecteerde map.</td>
+    </tr>
+    <tr>
+      <td>⌘C</td>
+      <td>Kopieer de geselecteerde tekst naar het klembord. Als de
+      focus op een artikel ligt, dan worden de artikel details
+      gekopieerd.</td>
+    </tr>
+    <tr>
+      <td>⌘H</td>
+      <td>Verberg het Vienna venster.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘H</td>
+      <td>Verberg alle vensters, behalve die van Vienna.</td>
+    </tr>
+    <tr>
+      <td>⌘I</td>
+      <td>Toon het Info venster voor de geselecteerde map.</td>
+    </tr>
+    <tr>
+      <td>⌘L</td>
+      <td>Plaats de cursor in de adresbalk van de huidige tab.
+      Indien er geen browser geopend is, dan wordt er een nieuwe
+      tab geopend en de cursor in de adresbalk geplaatst.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘N</td>
+      <td>Wijzig de naam van de geselecteerde map.</td>
+    </tr>
+    <tr>
+      <td>⌘R</td>
+      <td>Werk alle abonnementen bij.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘R</td>
+      <td>Werk alleen de geselecteerde abonnementen bij.</td>
+    </tr>
+    <tr>
+      <td>⌃⌘S</td>
+      <td>Stop bijwerken abonnementen.</td>
+    </tr>
+    <tr>
+      <td>⌘P</td>
+      <td>Druk geselecteerde artikelen af.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘P</td>
+      <td>Toon het Pagina-instelling venster.</td>
+    </tr>
+    <tr>
+      <td>⌘Q</td>
+      <td>Stop Vienna.</td>
+    </tr>
+    <tr>
+      <td>⌘T</td>
+      <td>Open een nieuwe tab en plaats de cursor in de
+      adresbalk.</td>
+    </tr>
+    <tr>
+      <td>⌘U</td>
+      <td>Ga naar het volgende ongelezen artikel.</td>
+    </tr>
+    <tr>
+      <td>⌘Z</td>
+      <td>Herstel de laatste actie indien mogelijk.</td>
+    </tr>
+    <tr>
+      <td>⌘/</td>
+      <td>Toon/verberg de status balk.</td>
+    </tr>
+    <tr>
+      <td>⌘+</td>
+      <td>Maak de tekst groter in huidige artikel of
+      webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘-</td>
+      <td>Maak de tekst kleiner in huidige artikel of
+      webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘,</td>
+      <td>Open het Voorkeuren venster.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘⌫</td>
+      <td>Leeg de prullenmand en vraag om bevestiging.</td>
+    </tr>
+    <tr>
+      <td>⌘?</td>
+      <td>Toon het Vienna Help bestand, (Mac OS X 10.5 en later,
+      activeer de zoek functie in het Help bestand).</td>
+    </tr>
+    <tr>
+      <td><b>Artikelen</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>⌥⌅&nbsp;&nbsp;of&nbsp;&nbsp;⌥↩</td>
+      <td>Open de webpagina van het artikel en negeer de
+      voorkeurinstelling voor openen in externe browser.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘Z</td>
+      <td>Doe de laatse actie opnieuw als die was hersteld.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘M</td>
+      <td>Markeer de geselecteerde artikelen met een ⚑ en plaatst
+      het in de map Gemarkeerde artikelen.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘U</td>
+      <td>Markeer geselecteerde artikel als gelezen.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘S</td>
+      <td>Stuur een email met een koppeling naar het huidige
+      artikel.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘S</td>
+      <td>Markeer de huidige map als gelezen en ga naar de volgende
+      map met ongelezen artikelen.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘O</td>
+      <td>Haal artikel uit prullenmand en zet terug in originele
+      map.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘K</td>
+      <td>Markeer alle artikelen in geselecteerde map als
+      gelezen.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘K</td>
+      <td>Markeer alle artikelen in alle mappen als gelezen.</td>
+    </tr>
+    <tr>
+      <td><b>Vensters</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>⌘W</td>
+      <td>Sluit de actieve tab als er een open is. Indien dat niet
+      het geval is, dan sluit het Vienna venster.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘W</td>
+      <td>Sluit alle tab vensters. Opmerking: Dit commando vervangt
+      de <b>Sluit tab</b> in het <b>Archief</b> menu als de alt (⌥)
+      toets is ingedrukt.</td>
+    </tr>
+    <tr>
+      <td>⇧⌘W</td>
+      <td>Sluit het Vienna venster maar laat Vienna in de
+      achtergrond werken. U kan het venster weer openen door op het
+      Vienna icoon in de Dock te klikken of door ⌘1 in te
+      toetsen.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘←</td>
+      <td>Toon het vorige tab venster.</td>
+    </tr>
+    <tr>
+      <td>⌥⌘→</td>
+      <td>Toon het volgende tab venster.</td>
+    </tr>
+    <tr>
+      <td>⌘M</td>
+      <td>Minimaliseer het Vienna venster naar de Dock.</td>
+    </tr>
+    <tr>
+      <td>⌘0</td>
+      <td>Toon het Activiteitenoverzicht log venster.</td>
+    </tr>
+    <tr>
+      <td>⌘1</td>
+      <td>Open het Vienna venster indien het was gesloten.</td>
+    </tr>
+    <tr>
+      <td>⌘2</td>
+      <td>Toon het Downloads venster.</td>
+    </tr>
+    <tr>
+      <td><b>Browser venster</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>⌥R</td>
+      <td>Ververs de huidige webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘.</td>
+      <td>Annuleer het laden van de huidige webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘[&nbsp;&nbsp;of&nbsp;&nbsp;⌘←</td>
+      <td>Ga naar de vorige webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘]&nbsp;&nbsp;of&nbsp;&nbsp;⌘→</td>
+      <td>Ga naar de volgende webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘F</td>
+      <td>Activeer het zoek veld in de knoppenbalk. Voer hier tekst
+      in en druk op Enter en er wordt gezocht in de huidige
+      webpagina.</td>
+    </tr>
+    <tr>
+      <td>⌘G</td>
+      <td>Kijk of de zoekterm voorkomt verderop in de
+      webpagina.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/pt.lproj/Vienna Help/advanced.html
+++ b/lproj/pt.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/pt.lproj/Vienna Help/faq.html
+++ b/lproj/pt.lproj/Vienna Help/faq.html
@@ -1,190 +1,218 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-What do the green dots mean in the list of articles?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.php">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Send an email to <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or post a message over in the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a> and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen. There is a sticky note in
-the forum with tips on how to write a good bug report.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.php">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.php">Vienna Downloads page</a> and view 
-it in the AppleScript editor.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">What do
-the green dots mean in the list of articles?</a></h2>
-<p>The blue dots are for new articles, and the green dots are for updated articles:
-articles whose text has changed since they were last downloaded.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the
-&quot;Move articles to Trash&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Send an email to <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or
+  post a message over in the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> and somebody will investigate. Provide as much
+  information about the problem as you can including: the build of
+  Vienna (obtained from the About Vienna panel), repro steps and
+  what you expected to happen. There is a sticky note in the forum
+  with tips on how to write a good bug report.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.php">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Vienna Downloads
+  page</a> and view it in the AppleScript editor.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">What do
+  the green dots mean in the list of articles?</a></h2>
+  <p>The blue dots are for new articles, and the green dots are for
+  updated articles: articles whose text has changed since they were
+  last downloaded.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Move articles to Trash" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/pt.lproj/Vienna Help/index.html
+++ b/lproj/pt.lproj/Vienna Help/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-
-		<p class="header">Advanced Settings</p>
-		<p><a href="advanced.html">Explains the settings in the Advanced Preferences.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+          <p class="header">Advanced Settings</p>
+          <p><a href="advanced.html">Explains the settings in the
+          Advanced Preferences.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/pt.lproj/Vienna Help/intro.html
+++ b/lproj/pt.lproj/Vienna Help/intro.html
@@ -1,55 +1,98 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the <a href="http://www.vienna-rss.org/vienna_files.php">Downloads</a> page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, send an email to <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OS X computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+R or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Downloads</a> page
+  on the Vienna web site along with custom scripts that allow you
+  to integrate Vienna with other applications on your machine. Or
+  experiment with smart folders to organise articles according to
+  criteria based on the contents of each article. For example, you
+  can easily set up a smart folder to group together all articles
+  that mention "Joss Whedon" and "Firefly" to find references to
+  the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  send an email to <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/pt.lproj/Vienna Help/keyboard.html
+++ b/lproj/pt.lproj/Vienna Help/keyboard.html
@@ -1,307 +1,346 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Opens the filter bar and puts the focus on the filter search field.</td>
-  </tr>
-  <tr>
-    <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Toggles the selected articles flagged or unflagged.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Toggles the selected articles read and unread.</td>
-  </tr>
-  <tr>
-    <td>u</td>
-    <td>Toggles the selected articles read and unread.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Left</td>
-    <td>Moves the focus to the folder list if it is currently in the article list.</td>
-  </tr>
-  <tr>
-    <td>Right</td>
-    <td>Moves the focus to the article list if it is currently in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-B</td>
-    <td>Opens the filter bar.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-C</td>
-    <td>Copies the selected text to the clipboard. If the focus is on an article, it copies the article details to the clipboard.</td>
-  </tr>
-  <tr>
-    <td>Command-H</td>
-    <td>Hides the Vienna main window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-H</td>
-    <td>Hides all other application windows but keeps the Vienna main window visible.</td>
-  </tr>
-  <tr>
-    <td>Command-I</td>
-    <td>Displays the Info window for the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-L</td>
-    <td>Puts the focus on the address bar of the current tab. Or if no browser is open and has the focus, opens a new tab and puts the focus on the address bar.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-S</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Command-Q</td>
-    <td>Exit Vienna.</td>
-  </tr>
-  <tr>
-    <td>Command-T</td>
-    <td>Opens a new tab and puts the focus on the address bar.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Command-Z</td>
-    <td>Undoes the last action, if it can be undone.</td>
-  </tr>
-  <tr>
-    <td>Command-/</td>
-    <td>Toggles the status bar on or off.</td>
-  </tr>
-  <tr>
-    <td>Command-+</td>
-    <td>Increases the size of the text in the current article or web page.</td>
-  </tr>
-  <tr>
-    <td>Command--</td>
-    <td>Decreases the size of the text in the current article or web page.</td>
-  </tr>
-  <tr>
-    <td>Command-,</td>
-    <td>Opens the Vienna preferences panel.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Backspace</td>
-    <td>Empties the trash folder after prompting for confirmation.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-Z</td>
-    <td>Redo the last action, if it was previously undone.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-S</td>
-    <td>Uses your default mail application to send a link to the current article by e-mail.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Opens the filter bar and puts the focus on the filter
+      search field.</td>
+    </tr>
+    <tr>
+      <td>h</td>
+      <td>Puts the focus on the search articles field.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Toggles the selected articles flagged or unflagged.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Toggles the selected articles read and unread.</td>
+    </tr>
+    <tr>
+      <td>u</td>
+      <td>Toggles the selected articles read and unread.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Left</td>
+      <td>Moves the focus to the folder list if it is currently in
+      the article list.</td>
+    </tr>
+    <tr>
+      <td>Right</td>
+      <td>Moves the focus to the article list if it is currently in
+      the folder list.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-B</td>
+      <td>Opens the filter bar.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-C</td>
+      <td>Copies the selected text to the clipboard. If the focus
+      is on an article, it copies the article details to the
+      clipboard.</td>
+    </tr>
+    <tr>
+      <td>Command-H</td>
+      <td>Hides the Vienna main window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-H</td>
+      <td>Hides all other application windows but keeps the Vienna
+      main window visible.</td>
+    </tr>
+    <tr>
+      <td>Command-I</td>
+      <td>Displays the Info window for the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-L</td>
+      <td>Puts the focus on the address bar of the current tab. Or
+      if no browser is open and has the focus, opens a new tab and
+      puts the focus on the address bar.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-S</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Command-Q</td>
+      <td>Exit Vienna.</td>
+    </tr>
+    <tr>
+      <td>Command-T</td>
+      <td>Opens a new tab and puts the focus on the address
+      bar.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Command-Z</td>
+      <td>Undoes the last action, if it can be undone.</td>
+    </tr>
+    <tr>
+      <td>Command-/</td>
+      <td>Toggles the status bar on or off.</td>
+    </tr>
+    <tr>
+      <td>Command-+</td>
+      <td>Increases the size of the text in the current article or
+      web page.</td>
+    </tr>
+    <tr>
+      <td>Command--</td>
+      <td>Decreases the size of the text in the current article or
+      web page.</td>
+    </tr>
+    <tr>
+      <td>Command-,</td>
+      <td>Opens the Vienna preferences panel.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Backspace</td>
+      <td>Empties the trash folder after prompting for
+      confirmation.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-Z</td>
+      <td>Redo the last action, if it was previously undone.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-S</td>
+      <td>Uses your default mail application to send a link to the
+      current article by e-mail.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/pt_BR.lproj/Vienna Help/advanced.html
+++ b/lproj/pt_BR.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/pt_BR.lproj/Vienna Help/faq.html
+++ b/lproj/pt_BR.lproj/Vienna Help/faq.html
@@ -1,181 +1,208 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.html">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the Support forum and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.html">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.html">Vienna Downloads page</a> and view 
-it in the AppleScript editor. Also take a look at the
-<a href="http://www.vienna-rss.org/vienna_scripting.html">Scripts page</a> for more details of the 
-Vienna scripting dictionary and examples of what you can accomplish.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the &quot;Expire articles older 
-than&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.html">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the Support forum and somebody will
+  investigate. Provide as much information about the problem as you
+  can including: the build of Vienna (obtained from the About
+  Vienna panel), repro steps and what you expected to happen.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.html">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.html">Vienna Downloads
+  page</a> and view it in the AppleScript editor. Also take a look
+  at the <a href=
+  "http://www.vienna-rss.org/vienna_scripting.html">Scripts
+  page</a> for more details of the Vienna scripting dictionary and
+  examples of what you can accomplish.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Expire articles older than" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/pt_BR.lproj/Vienna Help/index.html
+++ b/lproj/pt_BR.lproj/Vienna Help/index.html
@@ -1,34 +1,40 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/pt_BR.lproj/Vienna Help/intro.html
+++ b/lproj/pt_BR.lproj/Vienna Help/intro.html
@@ -1,55 +1,95 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OSX computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+T or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt=""> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the Downloads page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OSX computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+T or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="" /> or XML icons
+  indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the Downloads
+  page on the Vienna web site along with custom scripts that allow
+  you to integrate Vienna with other applications on your machine.
+  Or experiment with smart folders to organise articles according
+  to criteria based on the contents of each article. For example,
+  you can easily set up a smart folder to group together all
+  articles that mention "Joss Whedon" and "Firefly" to find
+  references to the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/pt_BR.lproj/Vienna Help/keyboard.html
+++ b/lproj/pt_BR.lproj/Vienna Help/keyboard.html
@@ -1,225 +1,248 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Command-Minus</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-V</td>
-    <td>Validate the selected feed.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-W</td>
-    <td>Closes the Vienna window but leaves Vienna running in the background. 
-	You can bring the window back by clicking on the Vienna dock icon or 
-	pressing Command-1.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Command-Minus</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-V</td>
+      <td>Validate the selected feed.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-W</td>
+      <td>Closes the Vienna window but leaves Vienna running in the
+      background. You can bring the window back by clicking on the
+      Vienna dock icon or pressing Command-1.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/ru.lproj/Vienna Help/advanced.html
+++ b/lproj/ru.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/ru.lproj/Vienna Help/faq.html
+++ b/lproj/ru.lproj/Vienna Help/faq.html
@@ -1,190 +1,216 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-What do the green dots mean in the list of articles?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.php">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a> and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen. There is a sticky note in
-the forum with tips on how to write a good bug report.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.php">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.php">Vienna Downloads page</a> and view 
-it in the AppleScript editor.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">What do
-the green dots mean in the list of articles?</a></h2>
-<p>The blue dots are for new articles, and the green dots are for updated articles:
-articles whose text has changed since they were last downloaded.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the
-&quot;Move articles to Trash&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> and somebody will investigate. Provide as much
+  information about the problem as you can including: the build of
+  Vienna (obtained from the About Vienna panel), repro steps and
+  what you expected to happen. There is a sticky note in the forum
+  with tips on how to write a good bug report.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.php">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Vienna Downloads
+  page</a> and view it in the AppleScript editor.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">What do
+  the green dots mean in the list of articles?</a></h2>
+  <p>The blue dots are for new articles, and the green dots are for
+  updated articles: articles whose text has changed since they were
+  last downloaded.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Move articles to Trash" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/ru.lproj/Vienna Help/index.html
+++ b/lproj/ru.lproj/Vienna Help/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-
-		<p class="header">Advanced Settings</p>
-		<p><a href="advanced.html">Explains the settings in the Advanced Preferences.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+          <p class="header">Advanced Settings</p>
+          <p><a href="advanced.html">Explains the settings in the
+          Advanced Preferences.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/ru.lproj/Vienna Help/intro.html
+++ b/lproj/ru.lproj/Vienna Help/intro.html
@@ -1,55 +1,96 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the <a href="http://www.vienna-rss.org/vienna_files.php">Downloads</a> page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OS X computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+R or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Downloads</a> page
+  on the Vienna web site along with custom scripts that allow you
+  to integrate Vienna with other applications on your machine. Or
+  experiment with smart folders to organise articles according to
+  criteria based on the contents of each article. For example, you
+  can easily set up a smart folder to group together all articles
+  that mention "Joss Whedon" and "Firefly" to find references to
+  the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/ru.lproj/Vienna Help/keyboard.html
+++ b/lproj/ru.lproj/Vienna Help/keyboard.html
@@ -1,227 +1,253 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-S</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-S</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/sv.lproj/Vienna Help/advanced.html
+++ b/lproj/sv.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/sv.lproj/Vienna Help/faq.html
+++ b/lproj/sv.lproj/Vienna Help/faq.html
@@ -1,181 +1,208 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.html">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the Support forum and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.html">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.html">Vienna Downloads page</a> and view 
-it in the AppleScript editor. Also take a look at the
-<a href="http://www.vienna-rss.org/vienna_scripting.html">Scripts page</a> for more details of the 
-Vienna scripting dictionary and examples of what you can accomplish.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the &quot;Expire articles older 
-than&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.html">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the Support forum and somebody will
+  investigate. Provide as much information about the problem as you
+  can including: the build of Vienna (obtained from the About
+  Vienna panel), repro steps and what you expected to happen.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.html">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.html">Vienna Downloads
+  page</a> and view it in the AppleScript editor. Also take a look
+  at the <a href=
+  "http://www.vienna-rss.org/vienna_scripting.html">Scripts
+  page</a> for more details of the Vienna scripting dictionary and
+  examples of what you can accomplish.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Expire articles older than" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/sv.lproj/Vienna Help/index.html
+++ b/lproj/sv.lproj/Vienna Help/index.html
@@ -1,34 +1,40 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/sv.lproj/Vienna Help/intro.html
+++ b/lproj/sv.lproj/Vienna Help/intro.html
@@ -1,55 +1,95 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OSX computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+T or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the Downloads page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OSX computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+T or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the Downloads
+  page on the Vienna web site along with custom scripts that allow
+  you to integrate Vienna with other applications on your machine.
+  Or experiment with smart folders to organise articles according
+  to criteria based on the contents of each article. For example,
+  you can easily set up a smart folder to group together all
+  articles that mention "Joss Whedon" and "Firefly" to find
+  references to the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/sv.lproj/Vienna Help/keyboard.html
+++ b/lproj/sv.lproj/Vienna Help/keyboard.html
@@ -1,233 +1,259 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Command-Minus</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-V</td>
-    <td>Validate the selected feed.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Enter/Shift-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-W</td>
-    <td>Closes the Vienna window but leaves Vienna running in the background. 
-	You can bring the window back by clicking on the Vienna dock icon or 
-	pressing Command-1.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Command-Minus</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-V</td>
+      <td>Validate the selected feed.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Enter/Shift-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-W</td>
+      <td>Closes the Vienna window but leaves Vienna running in the
+      background. You can bring the window back by clicking on the
+      Vienna dock icon or pressing Command-1.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/tr.lproj/Vienna Help/advanced.html
+++ b/lproj/tr.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/tr.lproj/Vienna Help/faq.html
+++ b/lproj/tr.lproj/Vienna Help/faq.html
@@ -1,190 +1,218 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-What do the green dots mean in the list of articles?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.php">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Send an email to <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or post a message over in the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a> and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen. There is a sticky note in
-the forum with tips on how to write a good bug report.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.php">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.php">Vienna Downloads page</a> and view 
-it in the AppleScript editor.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">What do
-the green dots mean in the list of articles?</a></h2>
-<p>The blue dots are for new articles, and the green dots are for updated articles:
-articles whose text has changed since they were last downloaded.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the
-&quot;Move articles to Trash&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Send an email to <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or
+  post a message over in the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> and somebody will investigate. Provide as much
+  information about the problem as you can including: the build of
+  Vienna (obtained from the About Vienna panel), repro steps and
+  what you expected to happen. There is a sticky note in the forum
+  with tips on how to write a good bug report.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.php">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Vienna Downloads
+  page</a> and view it in the AppleScript editor.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">What do
+  the green dots mean in the list of articles?</a></h2>
+  <p>The blue dots are for new articles, and the green dots are for
+  updated articles: articles whose text has changed since they were
+  last downloaded.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Move articles to Trash" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/tr.lproj/Vienna Help/index.html
+++ b/lproj/tr.lproj/Vienna Help/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-
-		<p class="header">Advanced Settings</p>
-		<p><a href="advanced.html">Explains the settings in the Advanced Preferences.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+          <p class="header">Advanced Settings</p>
+          <p><a href="advanced.html">Explains the settings in the
+          Advanced Preferences.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/tr.lproj/Vienna Help/intro.html
+++ b/lproj/tr.lproj/Vienna Help/intro.html
@@ -1,55 +1,98 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the <a href="http://www.vienna-rss.org/vienna_files.php">Downloads</a> page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, send an email to <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OS X computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+R or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Downloads</a> page
+  on the Vienna web site along with custom scripts that allow you
+  to integrate Vienna with other applications on your machine. Or
+  experiment with smart folders to organise articles according to
+  criteria based on the contents of each article. For example, you
+  can easily set up a smart folder to group together all articles
+  that mention "Joss Whedon" and "Firefly" to find references to
+  the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  send an email to <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/tr.lproj/Vienna Help/keyboard.html
+++ b/lproj/tr.lproj/Vienna Help/keyboard.html
@@ -1,307 +1,346 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Opens the filter bar and puts the focus on the filter search field.</td>
-  </tr>
-  <tr>
-    <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Toggles the selected articles flagged or unflagged.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Toggles the selected articles read and unread.</td>
-  </tr>
-  <tr>
-    <td>u</td>
-    <td>Toggles the selected articles read and unread.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Left</td>
-    <td>Moves the focus to the folder list if it is currently in the article list.</td>
-  </tr>
-  <tr>
-    <td>Right</td>
-    <td>Moves the focus to the article list if it is currently in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-B</td>
-    <td>Opens the filter bar.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-C</td>
-    <td>Copies the selected text to the clipboard. If the focus is on an article, it copies the article details to the clipboard.</td>
-  </tr>
-  <tr>
-    <td>Command-H</td>
-    <td>Hides the Vienna main window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-H</td>
-    <td>Hides all other application windows but keeps the Vienna main window visible.</td>
-  </tr>
-  <tr>
-    <td>Command-I</td>
-    <td>Displays the Info window for the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-L</td>
-    <td>Puts the focus on the address bar of the current tab. Or if no browser is open and has the focus, opens a new tab and puts the focus on the address bar.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-S</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Command-Q</td>
-    <td>Exit Vienna.</td>
-  </tr>
-  <tr>
-    <td>Command-T</td>
-    <td>Opens a new tab and puts the focus on the address bar.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Command-Z</td>
-    <td>Undoes the last action, if it can be undone.</td>
-  </tr>
-  <tr>
-    <td>Command-/</td>
-    <td>Toggles the status bar on or off.</td>
-  </tr>
-  <tr>
-    <td>Command-+</td>
-    <td>Increases the size of the text in the current article or web page.</td>
-  </tr>
-  <tr>
-    <td>Command--</td>
-    <td>Decreases the size of the text in the current article or web page.</td>
-  </tr>
-  <tr>
-    <td>Command-,</td>
-    <td>Opens the Vienna preferences panel.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Backspace</td>
-    <td>Empties the trash folder after prompting for confirmation.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-Z</td>
-    <td>Redo the last action, if it was previously undone.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-S</td>
-    <td>Uses your default mail application to send a link to the current article by e-mail.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Opens the filter bar and puts the focus on the filter
+      search field.</td>
+    </tr>
+    <tr>
+      <td>h</td>
+      <td>Puts the focus on the search articles field.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Toggles the selected articles flagged or unflagged.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Toggles the selected articles read and unread.</td>
+    </tr>
+    <tr>
+      <td>u</td>
+      <td>Toggles the selected articles read and unread.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Left</td>
+      <td>Moves the focus to the folder list if it is currently in
+      the article list.</td>
+    </tr>
+    <tr>
+      <td>Right</td>
+      <td>Moves the focus to the article list if it is currently in
+      the folder list.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-B</td>
+      <td>Opens the filter bar.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-C</td>
+      <td>Copies the selected text to the clipboard. If the focus
+      is on an article, it copies the article details to the
+      clipboard.</td>
+    </tr>
+    <tr>
+      <td>Command-H</td>
+      <td>Hides the Vienna main window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-H</td>
+      <td>Hides all other application windows but keeps the Vienna
+      main window visible.</td>
+    </tr>
+    <tr>
+      <td>Command-I</td>
+      <td>Displays the Info window for the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-L</td>
+      <td>Puts the focus on the address bar of the current tab. Or
+      if no browser is open and has the focus, opens a new tab and
+      puts the focus on the address bar.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-S</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Command-Q</td>
+      <td>Exit Vienna.</td>
+    </tr>
+    <tr>
+      <td>Command-T</td>
+      <td>Opens a new tab and puts the focus on the address
+      bar.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Command-Z</td>
+      <td>Undoes the last action, if it can be undone.</td>
+    </tr>
+    <tr>
+      <td>Command-/</td>
+      <td>Toggles the status bar on or off.</td>
+    </tr>
+    <tr>
+      <td>Command-+</td>
+      <td>Increases the size of the text in the current article or
+      web page.</td>
+    </tr>
+    <tr>
+      <td>Command--</td>
+      <td>Decreases the size of the text in the current article or
+      web page.</td>
+    </tr>
+    <tr>
+      <td>Command-,</td>
+      <td>Opens the Vienna preferences panel.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Backspace</td>
+      <td>Empties the trash folder after prompting for
+      confirmation.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-Z</td>
+      <td>Redo the last action, if it was previously undone.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-S</td>
+      <td>Uses your default mail application to send a link to the
+      current article by e-mail.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/uk.lproj/Vienna Help/advanced.html
+++ b/lproj/uk.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/uk.lproj/Vienna Help/faq.html
+++ b/lproj/uk.lproj/Vienna Help/faq.html
@@ -1,190 +1,218 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-What do the green dots mean in the list of articles?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.php">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Send an email to <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or post a message over in the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a> and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen. There is a sticky note in
-the forum with tips on how to write a good bug report.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.php">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.php">Vienna Downloads page</a> and view 
-it in the AppleScript editor.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">What do
-the green dots mean in the list of articles?</a></h2>
-<p>The blue dots are for new articles, and the green dots are for updated articles:
-articles whose text has changed since they were last downloaded.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the
-&quot;Move articles to Trash&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Send an email to <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or
+  post a message over in the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> and somebody will investigate. Provide as much
+  information about the problem as you can including: the build of
+  Vienna (obtained from the About Vienna panel), repro steps and
+  what you expected to happen. There is a sticky note in the forum
+  with tips on how to write a good bug report.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.php">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Vienna Downloads
+  page</a> and view it in the AppleScript editor.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">What do
+  the green dots mean in the list of articles?</a></h2>
+  <p>The blue dots are for new articles, and the green dots are for
+  updated articles: articles whose text has changed since they were
+  last downloaded.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Move articles to Trash" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/uk.lproj/Vienna Help/index.html
+++ b/lproj/uk.lproj/Vienna Help/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-
-		<p class="header">Advanced Settings</p>
-		<p><a href="advanced.html">Explains the settings in the Advanced Preferences.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+          <p class="header">Advanced Settings</p>
+          <p><a href="advanced.html">Explains the settings in the
+          Advanced Preferences.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/uk.lproj/Vienna Help/intro.html
+++ b/lproj/uk.lproj/Vienna Help/intro.html
@@ -1,55 +1,98 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the <a href="http://www.vienna-rss.org/vienna_files.php">Downloads</a> page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, send an email to <a href="mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OS X computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+R or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Downloads</a> page
+  on the Vienna web site along with custom scripts that allow you
+  to integrate Vienna with other applications on your machine. Or
+  experiment with smart folders to organise articles according to
+  criteria based on the contents of each article. For example, you
+  can easily set up a smart folder to group together all articles
+  that mention "Joss Whedon" and "Firefly" to find references to
+  the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  send an email to <a href=
+  "mailto:vienna-rss-help@lists.sourceforge.net">Vienna Help</a> or
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/uk.lproj/Vienna Help/keyboard.html
+++ b/lproj/uk.lproj/Vienna Help/keyboard.html
@@ -1,307 +1,346 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Opens the filter bar and puts the focus on the filter search field.</td>
-  </tr>
-  <tr>
-    <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Toggles the selected articles flagged or unflagged.</td>
-  </tr>
-  <tr>
-    <td>n</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Toggles the selected articles read and unread.</td>
-  </tr>
-  <tr>
-    <td>u</td>
-    <td>Toggles the selected articles read and unread.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Left</td>
-    <td>Moves the focus to the folder list if it is currently in the article list.</td>
-  </tr>
-  <tr>
-    <td>Right</td>
-    <td>Moves the focus to the article list if it is currently in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-B</td>
-    <td>Opens the filter bar.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-C</td>
-    <td>Copies the selected text to the clipboard. If the focus is on an article, it copies the article details to the clipboard.</td>
-  </tr>
-  <tr>
-    <td>Command-H</td>
-    <td>Hides the Vienna main window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-H</td>
-    <td>Hides all other application windows but keeps the Vienna main window visible.</td>
-  </tr>
-  <tr>
-    <td>Command-I</td>
-    <td>Displays the Info window for the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-L</td>
-    <td>Puts the focus on the address bar of the current tab. Or if no browser is open and has the focus, opens a new tab and puts the focus on the address bar.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-S</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Command-Q</td>
-    <td>Exit Vienna.</td>
-  </tr>
-  <tr>
-    <td>Command-T</td>
-    <td>Opens a new tab and puts the focus on the address bar.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Command-Z</td>
-    <td>Undoes the last action, if it can be undone.</td>
-  </tr>
-  <tr>
-    <td>Command-/</td>
-    <td>Toggles the status bar on or off.</td>
-  </tr>
-  <tr>
-    <td>Command-+</td>
-    <td>Increases the size of the text in the current article or web page.</td>
-  </tr>
-  <tr>
-    <td>Command--</td>
-    <td>Decreases the size of the text in the current article or web page.</td>
-  </tr>
-  <tr>
-    <td>Command-,</td>
-    <td>Opens the Vienna preferences panel.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Backspace</td>
-    <td>Empties the trash folder after prompting for confirmation.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-Z</td>
-    <td>Redo the last action, if it was previously undone.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-S</td>
-    <td>Uses your default mail application to send a link to the current article by e-mail.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Opens the filter bar and puts the focus on the filter
+      search field.</td>
+    </tr>
+    <tr>
+      <td>h</td>
+      <td>Puts the focus on the search articles field.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Toggles the selected articles flagged or unflagged.</td>
+    </tr>
+    <tr>
+      <td>n</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Toggles the selected articles read and unread.</td>
+    </tr>
+    <tr>
+      <td>u</td>
+      <td>Toggles the selected articles read and unread.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Left</td>
+      <td>Moves the focus to the folder list if it is currently in
+      the article list.</td>
+    </tr>
+    <tr>
+      <td>Right</td>
+      <td>Moves the focus to the article list if it is currently in
+      the folder list.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-B</td>
+      <td>Opens the filter bar.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-C</td>
+      <td>Copies the selected text to the clipboard. If the focus
+      is on an article, it copies the article details to the
+      clipboard.</td>
+    </tr>
+    <tr>
+      <td>Command-H</td>
+      <td>Hides the Vienna main window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-H</td>
+      <td>Hides all other application windows but keeps the Vienna
+      main window visible.</td>
+    </tr>
+    <tr>
+      <td>Command-I</td>
+      <td>Displays the Info window for the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-L</td>
+      <td>Puts the focus on the address bar of the current tab. Or
+      if no browser is open and has the focus, opens a new tab and
+      puts the focus on the address bar.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-S</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Command-Q</td>
+      <td>Exit Vienna.</td>
+    </tr>
+    <tr>
+      <td>Command-T</td>
+      <td>Opens a new tab and puts the focus on the address
+      bar.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Command-Z</td>
+      <td>Undoes the last action, if it can be undone.</td>
+    </tr>
+    <tr>
+      <td>Command-/</td>
+      <td>Toggles the status bar on or off.</td>
+    </tr>
+    <tr>
+      <td>Command-+</td>
+      <td>Increases the size of the text in the current article or
+      web page.</td>
+    </tr>
+    <tr>
+      <td>Command--</td>
+      <td>Decreases the size of the text in the current article or
+      web page.</td>
+    </tr>
+    <tr>
+      <td>Command-,</td>
+      <td>Opens the Vienna preferences panel.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Backspace</td>
+      <td>Empties the trash folder after prompting for
+      confirmation.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-Z</td>
+      <td>Redo the last action, if it was previously undone.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-S</td>
+      <td>Uses your default mail application to send a link to the
+      current article by e-mail.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/zh_CN.lproj/Vienna Help/advanced.html
+++ b/lproj/zh_CN.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/zh_CN.lproj/Vienna Help/faq.html
+++ b/lproj/zh_CN.lproj/Vienna Help/faq.html
@@ -1,190 +1,216 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>How Do I?</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>How Do I?</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">How Do I?</span>
-<p>Below are some of the more common questions asked about Vienna while it was being pre-release tested.
-See the <a href="http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ Page</a> for these
-and the latest hints and tips for using Vienna.
-</p>
-<ul>
-<li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I get 
-the Vienna source code?</a></li>
-<li><a href="#I_found_a_problem_with_Vienna._How_do_I_report_it">I 
-found a problem with Vienna. How do I report it?</a></li>
-<li><a href="#How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></li>
-<li><a href="#How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></li>
-
-<li>
-<a href="#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></li>
-<li>
-<a href="#How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></li>
-<li>
-<a href="#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. 
-What does this mean?</a></li>
-
-<li>
-<a href="#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></li>
-<li>
-<a href="#What_do_the_green_dots_mean_in_the_list_of_articles">
-What do the green dots mean in the list of articles?</a></li>
-<li>
-<a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></li>
-<li>
-<a href="#How_do_I_request_an_enhancement_in_Vienna">How do I 
-request an enhancement in Vienna?</a></li>
-
-</ul>
-<h2><a name="Where_do_I_get_the_Vienna_source_code">Where do I get the 
-Vienna source code?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_dev.php">Development page</a> for 
-instructions for getting the source code for Vienna. The source code is 
-freely available if you're interested in learning how Vienna works, if 
-you want to build your own copy of Vienna from scratch on your own 
-machine or if you want to borrow portions for inclusion in your own 
-project. The source is provided under the
-<a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 
-license</a>.</p>
-<h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it">I found 
-a problem with Vienna. How do I report it?</a></h2>
-<p>Post a message over in the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a> and somebody will 
-investigate. Provide as much information about the problem as you can 
-including: the build of Vienna (obtained from the About Vienna panel), 
-repro steps and what you expected to happen. There is a sticky note in
-the forum with tips on how to write a good bug report.</p>
-
-<p>Make sure you're always running the most recent build of Vienna. The 
-Check for Updates command will report if there's a newer build available 
-than the one you have.</p>
-<p>Fixes for bugs take priority over new features so if your problem is 
-confirmed to be a bug with high impact and no simple workaround then 
-I'll look at making a fix available as soon as reasonably possible.</p>
-<h2><a name="How_do_I_create_my_own_styles">How do I create my own 
-styles?</a></h2>
-<p>See the <a href="http://www.vienna-rss.org/vienna_styles.php">Custom Styles page</a> for 
-instructions.</p>
-<h2><a name="How_do_I_create_my_own_scripts">How do I create my own 
-scripts?</a></h2>
-
-<p>Vienna's scripts are written using AppleScript. See the
-<a href="http://www.apple.com/macosx/features/applescript/resources.html">
-Apple resource page</a> for more details.</p>
-<p>One way to get started is to download one of the existing scripts 
-from the <a href="http://www.vienna-rss.org/vienna_files.php">Vienna Downloads page</a> and view 
-it in the AppleScript editor.</p>
-
-<p>To submit your own script, send it to
-<a href="mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a> 
-and after it has been reviewed, it will be made available on the 
-Downloads page.</p>
-<h2>
-<a name="How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
-How can I see what happened when my subscriptions are refreshed?</a></h2>
-<p>Open the Activity Window from the Window menu. The activity window 
-shows all subscriptions and the status of the last time they were 
-refreshed in that session. The bottom of the activity window shows more 
-details include the HTTP headers and may be useful for debugging. (If 
-the details pane is not visible, grab the split bar at the bottom of the 
-Activity Window and drag it up to uncover the pane).</p>
-<h2><a name="How_do_I_move_my_Vienna_database_to_another_folder">How do 
-I move my Vienna database to another folder?</a></h2>
-
-<p>By default, your Vienna database is the messages.db file which is 
-located at ~/Library/Application Support/Vienna. You can move this to 
-another folder if you wish. The following steps show how:</p>
-<ol>
-<li>Shut down Vienna.</li>
-<li>Open a console window and enter:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '&lt;path to new messages.db&gt;'</font><br>
-
-<br>
-where &lt;path to new messages.db&gt; is the name of the folder that 
-contains the messages.db file. The path itself should have the 
-messages.db filename at the end. For example:<br>
-<br>
-<font face="Courier New">defaults write uk.co.opencommunity.vienna2 
-&quot;DefaultDatabase&quot; '/Users/steve/mydata/messages.db'</font><br>
-</li>
-
-<li>Restart Vienna.</li>
-</ol>
-<h2>
-<a name="One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
-One of my subscriptions reports &quot;Error parsing XML data in feed&quot;. What 
-does this mean?</a></h2>
-<p>It means that Vienna got a feed back from the subscription that it 
-couldn't interpret. There are several reasons for this:</p>
-
-<ol>
-<li>The URL of the feed may not be pointing to an RSS or Atom feed 
-but to a web page. Check the URL of the offending feed carefully.</li>
-<li>The feed itself may contain malformed XML. Some subscriptions 
-make a mistake in putting together the XML that makes up the feed 
-and Vienna cannot interpret malformed XML. Use the Validate Feed 
-command on the File menu to see if this is the case. Unfortunately 
-you cannot do much about this in Vienna except wait for the feed 
-itself to be corrected by the site.</li>
-<li>The feed may be incomplete. If the refresh was interrupted then 
-the XML data will be incomplete and will appear malformed in Vienna. 
-A second refresh may correct this problem.</li>
-</ol>
-<p>If none of the above explain the problem, post a message on the 
-support forum with the URL of the feed exhibiting the problem. </p>
-<h2>
-
-<a name="Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
-Is there a shortcut key for going to the next article, marking read, 
-etc?</a></h2>
-<p>Probably. There are single key equivalents for some of the menu 
-commands such as:</p>
-<p>Spacebar - goes to the next unread article. If the current article is 
-several pages long, it will scroll through that article first. If you're 
-at the end of the current article it will then go to the next unread 
-article. By contrast the Next Unread command (Cmd+U) always goes 
-straight to the next unread article.</p>
-<p>R - marks the current article read if it is unread, or unread if it 
-is read.</p>
-<p>F - flags the current article if it isn't already flagged, or removes 
-the existing flag if it is not.</p>
-
-<p>Look in the Vienna Help file for more shortcuts.</p>
-
-<h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles">What do
-the green dots mean in the list of articles?</a></h2>
-<p>The blue dots are for new articles, and the green dots are for updated articles:
-articles whose text has changed since they were last downloaded.</p>
-
-<h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use 
-Auto Expire and what does it do?</a></h2>
-<p>Auto-expire moves articles older than a certain number of days to the 
-Trash folder. It allows you to keep your folders manageable by only 
-retaining articles that are recent. The auto-expire runs both when 
-Vienna starts and after you have refreshed any subscriptions. To control 
-the age of articles to auto-expire, change the
-&quot;Move articles to Trash&quot; option in Preferences.</p>
-<p>Auto-expire will NOT remove unread or flagged articles. It assumes 
-that you haven't read these articles and thus leaves them alone.</p>
-<h2><a name="How_do_I_request_an_enhancement_in_Vienna">How do I request 
-an enhancement in Vienna?</a></h2>
-
-<p>Post a message over at the
-<a href="http://forums.cocoaforge.com/viewforum.php?f=18">support forum</a>. All 
-requested enhancements are logged in the TODO file that is included with 
-the source code as a guidance for future developers.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">How Do I?</span>
+  <p>Below are some of the more common questions asked about Vienna
+  while it was being pre-release tested. See the <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Official Vienna FAQ
+  Page</a> for these and the latest hints and tips for using
+  Vienna.</p>
+  <ul>
+    <li><a href="#Where_do_I_get_the_Vienna_source_code">Where do I
+    get the Vienna source code?</a></li>
+    <li><a href=
+    "#I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+    problem with Vienna. How do I report it?</a></li>
+    <li><a href="#How_do_I_create_my_own_styles">How do I create my
+    own styles?</a></li>
+    <li><a href="#How_do_I_create_my_own_scripts">How do I create
+    my own scripts?</a></li>
+    <li><a href=
+    "#How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+    How can I see what happened when my subscriptions are
+    refreshed?</a></li>
+    <li><a href=
+    "#How_do_I_move_my_Vienna_database_to_another_folder">How do I
+    move my Vienna database to another folder?</a></li>
+    <li><a href=
+    "#One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+    One of my subscriptions reports "Error parsing XML data in
+    feed". What does this mean?</a></li>
+    <li><a href=
+    "#Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+    Is there a shortcut key for going to the next article, marking
+    read, etc?</a></li>
+    <li><a href=
+    "#What_do_the_green_dots_mean_in_the_list_of_articles">What do
+    the green dots mean in the list of articles?</a></li>
+    <li><a href="#How_do_I_use_Auto_Expire_and_what_does_it_do">How
+    do I use Auto Expire and what does it do?</a></li>
+    <li><a href="#How_do_I_request_an_enhancement_in_Vienna">How do
+    I request an enhancement in Vienna?</a></li>
+  </ul>
+  <h2><a name="Where_do_I_get_the_Vienna_source_code" id=
+  "Where_do_I_get_the_Vienna_source_code">Where do I get the Vienna
+  source code?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_dev.php">Development page</a>
+  for instructions for getting the source code for Vienna. The
+  source code is freely available if you're interested in learning
+  how Vienna works, if you want to build your own copy of Vienna
+  from scratch on your own machine or if you want to borrow
+  portions for inclusion in your own project. The source is
+  provided under the <a href=
+  "http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0
+  license</a>.</p>
+  <h2><a name="I_found_a_problem_with_Vienna._How_do_I_report_it"
+  id="I_found_a_problem_with_Vienna._How_do_I_report_it">I found a
+  problem with Vienna. How do I report it?</a></h2>
+  <p>Post a message over in the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a> and somebody will investigate. Provide as much
+  information about the problem as you can including: the build of
+  Vienna (obtained from the About Vienna panel), repro steps and
+  what you expected to happen. There is a sticky note in the forum
+  with tips on how to write a good bug report.</p>
+  <p>Make sure you're always running the most recent build of
+  Vienna. The Check for Updates command will report if there's a
+  newer build available than the one you have.</p>
+  <p>Fixes for bugs take priority over new features so if your
+  problem is confirmed to be a bug with high impact and no simple
+  workaround then I'll look at making a fix available as soon as
+  reasonably possible.</p>
+  <h2><a name="How_do_I_create_my_own_styles" id=
+  "How_do_I_create_my_own_styles">How do I create my own
+  styles?</a></h2>
+  <p>See the <a href=
+  "http://www.vienna-rss.org/vienna_styles.php">Custom Styles
+  page</a> for instructions.</p>
+  <h2><a name="How_do_I_create_my_own_scripts" id=
+  "How_do_I_create_my_own_scripts">How do I create my own
+  scripts?</a></h2>
+  <p>Vienna's scripts are written using AppleScript. See the
+  <a href=
+  "http://www.apple.com/macosx/features/applescript/resources.html">
+  Apple resource page</a> for more details.</p>
+  <p>One way to get started is to download one of the existing
+  scripts from the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Vienna Downloads
+  page</a> and view it in the AppleScript editor.</p>
+  <p>To submit your own script, send it to <a href=
+  "mailto:steve@opencommunity.co.uk">steve@opencommunity.co.uk</a>
+  and after it has been reviewed, it will be made available on the
+  Downloads page.</p>
+  <h2><a name=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed"
+  id=
+  "How_can_I_see_what_happened_when_my_subscriptions_are_refreshed">
+  How can I see what happened when my subscriptions are
+  refreshed?</a></h2>
+  <p>Open the Activity Window from the Window menu. The activity
+  window shows all subscriptions and the status of the last time
+  they were refreshed in that session. The bottom of the activity
+  window shows more details include the HTTP headers and may be
+  useful for debugging. (If the details pane is not visible, grab
+  the split bar at the bottom of the Activity Window and drag it up
+  to uncover the pane).</p>
+  <h2><a name="How_do_I_move_my_Vienna_database_to_another_folder"
+  id="How_do_I_move_my_Vienna_database_to_another_folder">How do I
+  move my Vienna database to another folder?</a></h2>
+  <p>By default, your Vienna database is the messages.db file which
+  is located at ~/Library/Application Support/Vienna. You can move
+  this to another folder if you wish. The following steps show
+  how:</p>
+  <ol>
+    <li>Shut down Vienna.</li>
+    <li>Open a console window and enter:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase" '&lt;path to new
+    messages.db&gt;'</font><br />
+    <br />
+    where &lt;path to new messages.db&gt; is the name of the folder
+    that contains the messages.db file. The path itself should have
+    the messages.db filename at the end. For example:<br />
+    <br />
+    <font face="Courier New">defaults write
+    uk.co.opencommunity.vienna2 "DefaultDatabase"
+    '/Users/steve/mydata/messages.db'</font><br /></li>
+    <li>Restart Vienna.</li>
+  </ol>
+  <h2><a name=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean"
+  id=
+  "One_of_my_subscriptions_reports_Error_parsing_XML_data_in_feed._What_does_this_mean">
+  One of my subscriptions reports "Error parsing XML data in feed".
+  What does this mean?</a></h2>
+  <p>It means that Vienna got a feed back from the subscription
+  that it couldn't interpret. There are several reasons for
+  this:</p>
+  <ol>
+    <li>The URL of the feed may not be pointing to an RSS or Atom
+    feed but to a web page. Check the URL of the offending feed
+    carefully.</li>
+    <li>The feed itself may contain malformed XML. Some
+    subscriptions make a mistake in putting together the XML that
+    makes up the feed and Vienna cannot interpret malformed XML.
+    Use the Validate Feed command on the File menu to see if this
+    is the case. Unfortunately you cannot do much about this in
+    Vienna except wait for the feed itself to be corrected by the
+    site.</li>
+    <li>The feed may be incomplete. If the refresh was interrupted
+    then the XML data will be incomplete and will appear malformed
+    in Vienna. A second refresh may correct this problem.</li>
+  </ol>
+  <p>If none of the above explain the problem, post a message on
+  the support forum with the URL of the feed exhibiting the
+  problem.</p>
+  <h2><a name=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_"
+  id=
+  "Is_there_a_shortcut_key_for_going_to_the_next_article_marking_read_etc_">
+  Is there a shortcut key for going to the next article, marking
+  read, etc?</a></h2>
+  <p>Probably. There are single key equivalents for some of the
+  menu commands such as:</p>
+  <p>Spacebar - goes to the next unread article. If the current
+  article is several pages long, it will scroll through that
+  article first. If you're at the end of the current article it
+  will then go to the next unread article. By contrast the Next
+  Unread command (Cmd+U) always goes straight to the next unread
+  article.</p>
+  <p>R - marks the current article read if it is unread, or unread
+  if it is read.</p>
+  <p>F - flags the current article if it isn't already flagged, or
+  removes the existing flag if it is not.</p>
+  <p>Look in the Vienna Help file for more shortcuts.</p>
+  <h2><a name="What_do_the_green_dots_mean_in_the_list_of_articles"
+  id="What_do_the_green_dots_mean_in_the_list_of_articles">What do
+  the green dots mean in the list of articles?</a></h2>
+  <p>The blue dots are for new articles, and the green dots are for
+  updated articles: articles whose text has changed since they were
+  last downloaded.</p>
+  <h2><a name="How_do_I_use_Auto_Expire_and_what_does_it_do" id=
+  "How_do_I_use_Auto_Expire_and_what_does_it_do">How do I use Auto
+  Expire and what does it do?</a></h2>
+  <p>Auto-expire moves articles older than a certain number of days
+  to the Trash folder. It allows you to keep your folders
+  manageable by only retaining articles that are recent. The
+  auto-expire runs both when Vienna starts and after you have
+  refreshed any subscriptions. To control the age of articles to
+  auto-expire, change the "Move articles to Trash" option in
+  Preferences.</p>
+  <p>Auto-expire will NOT remove unread or flagged articles. It
+  assumes that you haven't read these articles and thus leaves them
+  alone.</p>
+  <h2><a name="How_do_I_request_an_enhancement_in_Vienna" id=
+  "How_do_I_request_an_enhancement_in_Vienna">How do I request an
+  enhancement in Vienna?</a></h2>
+  <p>Post a message over at the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">support
+  forum</a>. All requested enhancements are logged in the TODO file
+  that is included with the source code as a guidance for future
+  developers.</p>
 </body>
 </html>

--- a/lproj/zh_CN.lproj/Vienna Help/index.html
+++ b/lproj/zh_CN.lproj/Vienna Help/index.html
@@ -1,34 +1,40 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna Help</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna Help</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Introduction to Vienna</p>
-		<p><a href="intro.html">Learn how to get started with Vienna.</a></p>
-
-		<p class="header">Keyboard Shortcuts</p>
-		<p><a href="keyboard.html">Discover keyboard shortcuts for common commands</a></p>
-
-		<p class="header">How Do I?</p>
-		<p><a href="faq.html">Frequently Asked Questions, getting support and troubleshooting steps.</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna Help</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Introduction to Vienna</p>
+          <p><a href="intro.html">Learn how to get started with
+          Vienna.</a></p>
+          <p class="header">Keyboard Shortcuts</p>
+          <p><a href="keyboard.html">Discover keyboard shortcuts
+          for common commands</a></p>
+          <p class="header">How Do I?</p>
+          <p><a href="faq.html">Frequently Asked Questions, getting
+          support and troubleshooting steps.</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/zh_CN.lproj/Vienna Help/intro.html
+++ b/lproj/zh_CN.lproj/Vienna Help/intro.html
@@ -1,55 +1,96 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
   <title>Introduction to Vienna</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Introduction to Vienna</span>
-<p>Vienna is an application that allows you to read RSS or Atom news feeds on your Mac OS X computer. It automates the
-job of retrieving news articles from all subscribed feeds and storing them in a local database for reading off-line. It
-provides features that allow you to search feeds for keywords or phrases, tag articles with a flag for future reference
-and organise related feeds together under groups. You can create smart folders that make it easy to dynamically retrieve
-and view all articles in the database that match a search criteria. The built-in web browser allows you to go to the
-articles web page or view links in the article directly in Vienna in separate tabs.</p>
-<p>Vienna is designed to be simple and easy to use. A clean, uncluttered, interface maximises the space for articles and
-just a few controls are needed to perform the most common actions in the user interface.</p>
-<b>Getting Started</b>
-<p>If this is the first time that you have used Vienna then it will have created a new database for you
-and added some sample news subscriptions. So go ahead and press Command+R or choose Refresh All Subscriptions
-from the File menu to grab the latest articles from those subscriptions.</p>
-<p>Alternatively, subscribe to your own news feeds. There are various ways to find feeds. When browsing
-the web, look out for the <img src="images/rssfeed.gif" alt="RSS feed icon"> or XML icons indicating that the page has a feed associated
-with it. Alternatively almost all online blogging services such as LiveJournal or Blogger provide RSS feeds as
-an alternative to reading the postings online.</p>
-<p>If you know the user name of a blogger on LiveJournal, Blogger, MSN Spaces or Xanga then Vienna makes it easier
-to subscribe to their news feed. Start by pressing Command+N or from the File menu, choose the New Subscription command.
-In the "Create a new RSS subscription" panel, pick the blogging service from the drop down list and enter the
-user name in the input field below. Then choose Subscribe and Vienna will add the subscription to the folder list. If
-you are connected to the internet at the time, it will also immediately start collecting articles from the feed.</p>
-<p>Normally you need to manually tell Vienna when to refresh all your subscriptions. However you can opt to ask Vienna
-to automatically refresh at time intervals. In the General section of the Preferences, pick the desired time interval
-from the drop down list next to 'Check for new articles'. Vienna needs to be running for it to automatically refresh
-subscriptions.</p>
-<p>To read articles, press the Spacebar to skip to the next unread article in any subscription. Each article is marked
-as read automatically after a short delay. If you prefer to wait until you move to the next unread article before the
-current one is marked read you can adjust the behaviour in the General tab of the Preferences. To mark an article as
-unread again, choose the Mark Unread command from the Article menu or simply press the 'R' key.</p>
-<p>Finally, you can view the article web page or any web page links in an article within Vienna. By default clicking
-on a web link within Vienna will open the web page in a new tab. Vienna provides a lot of basic web browsing support
-itself but there may be times when you will prefer to open links in your default web browser. If you prefer to view
-all web pages outside of Vienna then enable the 'Open links in external browser' option in the General section of the
-Preferences. However if you prefer to view the current link or page in your external browser, right click on the page
-and choose the "Open Link in XXX" or "Open Page in XXX" option where XXX will be the name of your default browser.</p>
-<p>Once you've got comfortable using Vienna, go ahead and explore the various options. You can change the style in
-which the articles are displayed through the Style drop down list in the View menu. You can find many more custom
-styles at the <a href="http://www.vienna-rss.org/vienna_files.php">Downloads</a> page on the Vienna web site along with custom scripts that allow you to integrate Vienna with
-other applications on your machine. Or experiment with smart folders to organise articles according to criteria based
-on the contents of each article. For example, you can easily set up a smart folder to group together all articles that
-mention "Joss Whedon" and "Firefly" to find references to the Firefly cult series or the spin-off movie.</p>
-<p>If you have any questions about Vienna or run into problems, head over to the <a href="http://forums.cocoaforge.com/viewforum.php?f=18">
-Support forum</a>.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Introduction to
+  Vienna</span>
+  <p>Vienna is an application that allows you to read RSS or Atom
+  news feeds on your Mac OS X computer. It automates the job of
+  retrieving news articles from all subscribed feeds and storing
+  them in a local database for reading off-line. It provides
+  features that allow you to search feeds for keywords or phrases,
+  tag articles with a flag for future reference and organise
+  related feeds together under groups. You can create smart folders
+  that make it easy to dynamically retrieve and view all articles
+  in the database that match a search criteria. The built-in web
+  browser allows you to go to the articles web page or view links
+  in the article directly in Vienna in separate tabs.</p>
+  <p>Vienna is designed to be simple and easy to use. A clean,
+  uncluttered, interface maximises the space for articles and just
+  a few controls are needed to perform the most common actions in
+  the user interface.</p><b>Getting Started</b>
+  <p>If this is the first time that you have used Vienna then it
+  will have created a new database for you and added some sample
+  news subscriptions. So go ahead and press Command+R or choose
+  Refresh All Subscriptions from the File menu to grab the latest
+  articles from those subscriptions.</p>
+  <p>Alternatively, subscribe to your own news feeds. There are
+  various ways to find feeds. When browsing the web, look out for
+  the <img src="images/rssfeed.gif" alt="RSS feed icon" /> or XML
+  icons indicating that the page has a feed associated with it.
+  Alternatively almost all online blogging services such as
+  LiveJournal or Blogger provide RSS feeds as an alternative to
+  reading the postings online.</p>
+  <p>If you know the user name of a blogger on LiveJournal,
+  Blogger, MSN Spaces or Xanga then Vienna makes it easier to
+  subscribe to their news feed. Start by pressing Command+N or from
+  the File menu, choose the New Subscription command. In the
+  "Create a new RSS subscription" panel, pick the blogging service
+  from the drop down list and enter the user name in the input
+  field below. Then choose Subscribe and Vienna will add the
+  subscription to the folder list. If you are connected to the
+  internet at the time, it will also immediately start collecting
+  articles from the feed.</p>
+  <p>Normally you need to manually tell Vienna when to refresh all
+  your subscriptions. However you can opt to ask Vienna to
+  automatically refresh at time intervals. In the General section
+  of the Preferences, pick the desired time interval from the drop
+  down list next to 'Check for new articles'. Vienna needs to be
+  running for it to automatically refresh subscriptions.</p>
+  <p>To read articles, press the Spacebar to skip to the next
+  unread article in any subscription. Each article is marked as
+  read automatically after a short delay. If you prefer to wait
+  until you move to the next unread article before the current one
+  is marked read you can adjust the behaviour in the General tab of
+  the Preferences. To mark an article as unread again, choose the
+  Mark Unread command from the Article menu or simply press the 'R'
+  key.</p>
+  <p>Finally, you can view the article web page or any web page
+  links in an article within Vienna. By default clicking on a web
+  link within Vienna will open the web page in a new tab. Vienna
+  provides a lot of basic web browsing support itself but there may
+  be times when you will prefer to open links in your default web
+  browser. If you prefer to view all web pages outside of Vienna
+  then enable the 'Open links in external browser' option in the
+  General section of the Preferences. However if you prefer to view
+  the current link or page in your external browser, right click on
+  the page and choose the "Open Link in XXX" or "Open Page in XXX"
+  option where XXX will be the name of your default browser.</p>
+  <p>Once you've got comfortable using Vienna, go ahead and explore
+  the various options. You can change the style in which the
+  articles are displayed through the Style drop down list in the
+  View menu. You can find many more custom styles at the <a href=
+  "http://www.vienna-rss.org/vienna_files.php">Downloads</a> page
+  on the Vienna web site along with custom scripts that allow you
+  to integrate Vienna with other applications on your machine. Or
+  experiment with smart folders to organise articles according to
+  criteria based on the contents of each article. For example, you
+  can easily set up a smart folder to group together all articles
+  that mention "Joss Whedon" and "Firefly" to find references to
+  the Firefly cult series or the spin-off movie.</p>
+  <p>If you have any questions about Vienna or run into problems,
+  head over to the <a href=
+  "http://forums.cocoaforge.com/viewforum.php?f=18">Support
+  forum</a>.</p>
 </body>
 </html>

--- a/lproj/zh_CN.lproj/Vienna Help/keyboard.html
+++ b/lproj/zh_CN.lproj/Vienna Help/keyboard.html
@@ -1,223 +1,249 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Keyboard Shortcuts</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Keyboard Shortcuts</span>
-<p>You can use your keyboard to quickly accomplish many tasks in Vienna. To find the shortcuts for common commands, look in the menus
-(or see the list at the bottom of this page). Many items in Vienna such as the folder pane and the article list pane also have contextual
-menus. To see a contextual menu, press the Control key and click the item.</p>
-<p>To do an action, press the shortcut keys indicated below.</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>Single Key Shortcuts</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>Sets the input focus to the search window.</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>k</td>
-    <td>Marks the current folder read.</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>Displays the previous viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>Displays the next viewed article or web page.</td>
-  </tr>
-  <tr>
-    <td>Spacebar</td>
-    <td>Moves to the next unread article unless the current article has more text to scroll in which case it scrolls the current article up one page.</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>Opens the selected article's original web page.</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>Moves the selected articles to the Trash folder. If this key is used in the Trash folder, the selected articles are permanently deleted.</td>
-  </tr>
-  <tr>
-    <td width="200"><b>General Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Click</td>
-    <td>Open the clicked link, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>Create a new subscription.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-F</td>
-    <td>Create a smart folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-E</td>
-    <td>Edit the selected folder URL or edit a smart folder criteria.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-D</td>
-    <td>Delete the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-N</td>
-    <td>Rename the selected folder.</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>Refreshes all subscriptions.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>Refresh only those subscriptions selected in the folder list.</td>
-  </tr>
-  <tr>
-    <td>Control-Command-S</td>
-    <td>Stops any active refresh.</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>Print the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>Brings up the Page Setup panel.</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>Displays the Vienna help book.</td>
-  </tr>
-  <tr>
-    <td><b>Articles Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-Enter/Alt-Return</td>
-    <td>Opens the selected article's original web page, overriding your preference for opening links in external browser.</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>Moves to the next unread article.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>Flags the selected articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-U</td>
-    <td>Marks the selected articles read.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-S</td>
-    <td>Marks the current folder read then skips to the next folder with unread articles.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-O</td>
-    <td>Restores an article from the trash back to its original folder.</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>Marks all articles in the selected folders read.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-K</td>
-    <td>Marks all articles in all folders read.</td>
-  </tr>
-  <tr>
-    <td><b>Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>Closes the active tab window if one is open. Otherwise if no
-	tabs are open, this closes the Vienna window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>Closes all tab windows. Note that this command replaces the Close Tab
-	command on the File menu when the Alt key is held down.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Left</td>
-    <td>Displays the previous tab window.</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-Right</td>
-    <td>Displays the next tab window.</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>Minimizes the Vienna window to the dock.</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>Displays the activity log viewer window.</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>Reopens the Vienna window if it was previously closed.</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>Displays the Downloads window.</td>
-  </tr>
-  <tr>
-    <td><b>Browser Window Shortcuts</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Alt-R</td>
-    <td>Reloads the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>Cancels loading of the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-[/Command-Left</td>
-    <td>Goes back to the previous web page.</td>
-  </tr>
-  <tr>
-    <td>Command-]/Command-Right</td>
-    <td>Goes forward to the next web page.</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>Puts the input focus in the search field. Entering some text here and 
-	pressing Enter will search for that text on the current web page.</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>Searches for the next occurrence of the search text on the web page.</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Keyboard
+  Shortcuts</span>
+  <p>You can use your keyboard to quickly accomplish many tasks in
+  Vienna. To find the shortcuts for common commands, look in the
+  menus (or see the list at the bottom of this page). Many items in
+  Vienna such as the folder pane and the article list pane also
+  have contextual menus. To see a contextual menu, press the
+  Control key and click the item.</p>
+  <p>To do an action, press the shortcut keys indicated below.</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="215" bgcolor="#C0C0C0"><b>Key</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>Action</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>Single Key Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>Sets the input focus to the search window.</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>k</td>
+      <td>Marks the current folder read.</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>Displays the previous viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>Displays the next viewed article or web page.</td>
+    </tr>
+    <tr>
+      <td>Spacebar</td>
+      <td>Moves to the next unread article unless the current
+      article has more text to scroll in which case it scrolls the
+      current article up one page.</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>Opens the selected article's original web page.</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>Moves the selected articles to the Trash folder. If this
+      key is used in the Trash folder, the selected articles are
+      permanently deleted.</td>
+    </tr>
+    <tr>
+      <td width="200"><b>General Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Click</td>
+      <td>Open the clicked link, overriding your preference for
+      opening links in external browser.</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>Create a new subscription.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-F</td>
+      <td>Create a smart folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-E</td>
+      <td>Edit the selected folder URL or edit a smart folder
+      criteria.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-D</td>
+      <td>Delete the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-N</td>
+      <td>Rename the selected folder.</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>Refreshes all subscriptions.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>Refresh only those subscriptions selected in the folder
+      list.</td>
+    </tr>
+    <tr>
+      <td>Control-Command-S</td>
+      <td>Stops any active refresh.</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>Print the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>Brings up the Page Setup panel.</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>Displays the Vienna help book.</td>
+    </tr>
+    <tr>
+      <td><b>Articles Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-Enter/Alt-Return</td>
+      <td>Opens the selected article's original web page,
+      overriding your preference for opening links in external
+      browser.</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>Moves to the next unread article.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>Flags the selected articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-U</td>
+      <td>Marks the selected articles read.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-S</td>
+      <td>Marks the current folder read then skips to the next
+      folder with unread articles.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-O</td>
+      <td>Restores an article from the trash back to its original
+      folder.</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>Marks all articles in the selected folders read.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-K</td>
+      <td>Marks all articles in all folders read.</td>
+    </tr>
+    <tr>
+      <td><b>Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>Closes the active tab window if one is open. Otherwise if
+      no tabs are open, this closes the Vienna window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>Closes all tab windows. Note that this command replaces
+      the Close Tab command on the File menu when the Alt key is
+      held down.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Left</td>
+      <td>Displays the previous tab window.</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-Right</td>
+      <td>Displays the next tab window.</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>Minimizes the Vienna window to the dock.</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>Displays the activity log viewer window.</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>Reopens the Vienna window if it was previously
+      closed.</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>Displays the Downloads window.</td>
+    </tr>
+    <tr>
+      <td><b>Browser Window Shortcuts</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Alt-R</td>
+      <td>Reloads the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>Cancels loading of the current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-[/Command-Left</td>
+      <td>Goes back to the previous web page.</td>
+    </tr>
+    <tr>
+      <td>Command-]/Command-Right</td>
+      <td>Goes forward to the next web page.</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>Puts the input focus in the search field. Entering some
+      text here and pressing Enter will search for that text on the
+      current web page.</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>Searches for the next occurrence of the search text on
+      the web page.</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/lproj/zh_TW.lproj/Vienna Help/advanced.html
+++ b/lproj/zh_TW.lproj/Vienna Help/advanced.html
@@ -1,20 +1,31 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<title>Advanced Settings</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=iso-8859-1" />
+  <title>Advanced Settings</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">Advanced Settings</span>
-<p>The Advanced section of the Preferences provides options to change very specific settings in Vienna that are
-not essential for normal use but may resolve some issues as advised by the support forum. This page details the
-advanced settings and their function.
-</p>
-<h2><b>Enable JavaScript in internal browser</b></h2>
-<p>Enables or disables support for JavaScript scripting in the Vienna internal browser. By default this is enabled. By
-turning this setting off, JavaScript code on web pages will not be allowed to run. This may resolve problems with pages
-that use scripting to pop up windows or other unexpected behaviour but turning the setting off may also cause some web
-pages to appear incomplete or fail to function correctly.</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">Advanced
+  Settings</span>
+  <p>The Advanced section of the Preferences provides options to
+  change very specific settings in Vienna that are not essential
+  for normal use but may resolve some issues as advised by the
+  support forum. This page details the advanced settings and their
+  function.</p>
+  <h2><b>Enable JavaScript in internal browser</b></h2>
+  <p>Enables or disables support for JavaScript scripting in the
+  Vienna internal browser. By default this is enabled. By turning
+  this setting off, JavaScript code on web pages will not be
+  allowed to run. This may resolve problems with pages that use
+  scripting to pop up windows or other unexpected behaviour but
+  turning the setting off may also cause some web pages to appear
+  incomplete or fail to function correctly.</p>
 </body>
 </html>

--- a/lproj/zh_TW.lproj/Vienna Help/faq.html
+++ b/lproj/zh_TW.lproj/Vienna Help/faq.html
@@ -1,12 +1,19 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-	<title>我該怎麼做？</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <title>我該怎麼做？</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">我該怎麼做？</span>
-<p>您可以瀏覽 <a href="http://www.vienna-rss.org/vienna_faq.html">Vienna 官方 FAQ 網頁</a>，查看最新的 Vienna 使用技巧。</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">我該怎麼做？</span>
+  <p>您可以瀏覽 <a href=
+  "http://www.vienna-rss.org/vienna_faq.html">Vienna 官方 FAQ
+  網頁</a>，查看最新的 Vienna 使用技巧。</p>
 </body>
 </html>

--- a/lproj/zh_TW.lproj/Vienna Help/index.html
+++ b/lproj/zh_TW.lproj/Vienna Help/index.html
@@ -1,34 +1,36 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name="AppleTitle" content="Vienna Help">
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <meta name="AppleTitle" content="Vienna Help" />
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
   <title>Vienna 輔助說明</title>
 </head>
 <body>
-<table border="0" cellspacing="10" width="100%">
-  <tbody>
-    <tr>
-      <td width="130">
-		<p align="center"><img src="images/Vienna-Logo.jpg" height="128" width="128" alt=""></p>
-		<p class="title" align="center">Vienna 輔助說明</p>
-      </td>
-      <td width="42">
-		<img src="images/Vertical-Line.jpg" height="270" width="36" alt="">
-      </td>
-      <td width="300">
-		<p class="header">Vienna 簡介</p>
-		<p><a href="intro.html">教您如何快速上手</a></p>
-
-		<p class="header">鍵盤快速鍵</p>
-		<p><a href="keyboard.html">一般使用時的常用快速鍵</a></p>
-
-		<p class="header">我該怎麼做？</p>
-		<p><a href="faq.html">常見問題、以及如何取得技術支援</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table border="0" cellspacing="10" width="100%">
+    <tbody>
+      <tr>
+        <td width="130">
+          <p align="center"><img src="images/Vienna-Logo.jpg"
+          height="128" width="128" alt="" /></p>
+          <p class="title" align="center">Vienna 輔助說明</p>
+        </td>
+        <td width="42"><img src="images/Vertical-Line.jpg" height=
+        "270" width="36" alt="" /></td>
+        <td width="300">
+          <p class="header">Vienna 簡介</p>
+          <p><a href="intro.html">教您如何快速上手</a></p>
+          <p class="header">鍵盤快速鍵</p>
+          <p><a href="keyboard.html">一般使用時的常用快速鍵</a></p>
+          <p class="header">我該怎麼做？</p>
+          <p><a href="faq.html">常見問題、以及如何取得技術支援</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>

--- a/lproj/zh_TW.lproj/Vienna Help/intro.html
+++ b/lproj/zh_TW.lproj/Vienna Help/intro.html
@@ -1,14 +1,21 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
   <title>Vienna 簡介</title>
-  <link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span>
-<span class="header">Vienna 簡介</span>
-<p>Vienna 是一套讓您可以在 Mac OS X 環境下，閱讀 RSS 或 Atom 檔案訂閱格式的應用程式。這套程式會自動從您所訂閱的站台中取得文章，並且在您的本機電腦中建立一個資料庫，儲存文章資料，讓您可以方便地離線閱讀。這套程式並且提供您以關鍵字或是詞彙搜尋文章、將文章加上旗標標示、以及透過群組檔案夾將相關訂閱頻道組織在一起…等功能。您也可以透過建立智慧型檔案夾，這套程式將會以動態的方式，讓您輕鬆地查閱某些搜尋條件的文章。Vienna 內建的網頁瀏覽器，也可以讓您在分頁介面中，直接瀏覽文章的原始網頁。</p>
-<p>我們將 Vienna 設計得簡單好用。我們透過簡潔、毫不凌亂的介面，盡可能放大閱讀文章的版面空間，同時在這樣的介面中，也只需要幾個簡單的指令，就可以完成大部份需要使用的功能。</p>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span> <span class="header">Vienna 簡介</span>
+  <p>Vienna 是一套讓您可以在 Mac OS X 環境下，閱讀 RSS 或 Atom
+  檔案訂閱格式的應用程式。這套程式會自動從您所訂閱的站台中取得文章，並且在您的本機電腦中建立一個資料庫，儲存文章資料，讓您可以方便地離線閱讀。這套程式並且提供您以關鍵字或是詞彙搜尋文章、將文章加上旗標標示、以及透過群組檔案夾將相關訂閱頻道組織在一起…等功能。您也可以透過建立智慧型檔案夾，這套程式將會以動態的方式，讓您輕鬆地查閱某些搜尋條件的文章。Vienna
+  內建的網頁瀏覽器，也可以讓您在分頁介面中，直接瀏覽文章的原始網頁。</p>
+  <p>我們將 Vienna
+  設計得簡單好用。我們透過簡潔、毫不凌亂的介面，盡可能放大閱讀文章的版面空間，同時在這樣的介面中，也只需要幾個簡單的指令，就可以完成大部份需要使用的功能。</p>
 </body>
 </html>

--- a/lproj/zh_TW.lproj/Vienna Help/keyboard.html
+++ b/lproj/zh_TW.lproj/Vienna Help/keyboard.html
@@ -1,182 +1,191 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-	<title>鍵盤快速鍵</title>
-	<link rel="stylesheet" href="helpstyle.css" type="text/css">
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Mac OS X version 4.9.35" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=utf-8" />
+  <title>鍵盤快速鍵</title>
+  <link rel="stylesheet" href="helpstyle.css" type="text/css" />
 </head>
 <body>
-<span><img src="images/Small-Vienna-Logo.jpg" alt="">&nbsp;&nbsp;</span><span class="header">鍵盤快速鍵</span>
-<p>您以使用以下鍵盤快速鍵，在 Vienna 中快速完成許多工作。您可以在選單中、或是在下表中查閱相關鍵盤快速鍵。而在 Vienna 的許多項目—例如檔案夾列表或文章列表中，有都有右鍵下拉選單的設計，您只要按住 Ctrl 然後點選這些項目，就可以看到這些選單。</p>
-<p>鍵盤快速鍵如下：</p>
-<table width="662" border="0" cellspacing="0" id="table1" cellpadding="8">
-  <tr>
-    <td width="200" bgcolor="#C0C0C0"><b>按鍵</b></td>
-    <td width="462" bgcolor="#C0C0C0"><b>指令</b></td>
-  </tr>
-</table>
-<table width="662" border="0" cellspacing="10">
-  <tr>
-    <td width="200"><b>單鍵快速鍵</b>
-	</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td width="115">f</td>
-    <td>將輸入焦點移動到搜尋視窗中</td>
-  </tr>
-  <tr>
-    <td>r</td>
-    <td>將選擇的文章標為已讀</td>
-  </tr>
-  <tr>
-    <td>s</td>
-    <td>將正在閱讀的檔案夾標為已讀，並且跳過目前的檔案夾，跳至下一個包含未讀文章的檔案夾中。</td>
-  </tr>
-  <tr>
-    <td>m</td>
-    <td>將目前選擇的文章加上圖標標示。</td>
-  </tr>
-  <tr>
-    <td>&lt;</td>
-    <td>顯示上一個讀過的文章或是網頁。</td>
-  </tr>
-  <tr>
-    <td>&gt;</td>
-    <td>顯示下一個讀過的文章或是網頁。</td>
-  </tr>
-  <tr>
-    <td>空白鍵</td>
-    <td>如果目前的文章的下方還有沒讀完的內容，則會向下捲動一頁。如果已經讀完，就會移動到下一個未讀的文章。</td>
-  </tr>
-  <tr>
-    <td>Command-U</td>
-    <td>移動到下一篇未讀的文章</td>
-  </tr>
-  <tr>
-    <td>Enter/Return</td>
-    <td>開啟所選擇的文章的原始網頁。</td>
-  </tr>
-  <tr>
-    <td>Delete/Backspace</td>
-    <td>將所選擇的文章移到垃圾桶中。如果您是對在垃圾桶中的文章使用這個指令，就會將文章永久刪除。</td>
-  </tr>
-  <tr>
-    <td width="200"><b>一般快速鍵</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-N</td>
-    <td>建立新的訂閱頻道。</td>
-  </tr>
-  <tr>
-    <td>Command-T</td>
-    <td>更新全部的訂閱頻道。</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-T</td>
-    <td>更新全部在檔案夾列表中所選擇的訂閱頻道。</td>
-  </tr>
-  <tr>
-    <td>Command-減號</td>
-    <td>停止更新。</td>
-  </tr>
-  <tr>
-    <td>Command-P</td>
-    <td>列印所選擇的文章。</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-P</td>
-    <td>打開頁面設定控制視窗</td>
-  </tr>
-  <tr>
-    <td>Command-?</td>
-    <td>顯示 Vienna 輔助說明</td>
-  </tr>
-  <tr>
-    <td><b>文章快速鍵</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-M</td>
-    <td>將選擇的文章加上旗標標記。</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-R</td>
-    <td>將選擇的文章標示為已讀。</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-K</td>
-    <td>將選擇的檔案夾中的所有文章標示為已讀。</td>
-  </tr>
-  <tr>
-    <td><b>視窗快速鍵</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-W</td>
-    <td>關閉目前所在的分頁。如果沒有開啟任何分頁，就會關閉 Vienna 主視窗。</td>
-  </tr>
-  <tr>
-    <td>Alt-Command-W</td>
-    <td>關閉所有的分頁。請注意，當您按下 Alt 鍵的時候，這個指令會置換「檔案」選單上的「關閉分頁」選項。</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Left</td>
-    <td>顯示前一個分頁視窗。</td>
-  </tr>
-  <tr>
-    <td>Control-Command-Right</td>
-    <td>顯示下一個分頁視窗。</td>
-  </tr>
-  <tr>
-    <td>Shift-Command-W</td>
-    <td>關閉 Vienna 主視窗，但是讓 Vienna 在背景中執行。您可以透過點選在 Dock 上的 Vienna 圖示，或是使用 Command-1 按鍵，重新叫出 Vienna 主視窗。</td>
-  </tr>
-  <tr>
-    <td>Command-M</td>
-    <td>將 Vienna 視窗縮到最小，縮到 Dock 上。</td>
-  </tr>
-  <tr>
-    <td>Command-0</td>
-    <td>顯示活動紀錄檢視視窗。</td>
-  </tr>
-  <tr>
-    <td>Command-1</td>
-    <td>如果之前關閉了 Vienna 主視窗，會將 Vienna 主視窗重新開啟。</td>
-  </tr>
-  <tr>
-    <td>Command-2</td>
-    <td>顯示下載視窗。</td>
-  </tr>
-  <tr>
-    <td><b>瀏覽視窗快速鍵</b></td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>Command-R</td>
-    <td>重新載入目前所在的網頁。</td>
-  </tr>
-  <tr>
-    <td>Command-Period</td>
-    <td>取消載入目前所在的網頁。</td>
-  </tr>
-  <tr>
-    <td>Command-[</td>
-    <td>移動到前一個瀏覽過的網頁。</td>
-  </tr>
-  <tr>
-    <td>Command-]</td>
-    <td>移動到下一個網頁。</td>
-  </tr>
-  <tr>
-    <td>Command-F</td>
-    <td>將輸入焦點移動到搜尋輸入方塊上。如果在搜尋輸入方塊上輸入文字並且按下 Enter，就會以此為關鍵字搜尋目前網頁上的內容。</td>
-  </tr>
-  <tr>
-    <td>Command-G</td>
-    <td>根據搜尋輸入方塊中的關鍵字，繼續搜尋符合的內容。</td>
-  </tr>
-</table>
+  <span><img src="images/Small-Vienna-Logo.jpg" alt=
+  "" />&nbsp;&nbsp;</span><span class="header">鍵盤快速鍵</span>
+  <p>您以使用以下鍵盤快速鍵，在 Vienna 中快速完成許多工作。您可以在選單中、或是在下表中查閱相關鍵盤快速鍵。而在
+  Vienna 的許多項目—例如檔案夾列表或文章列表中，有都有右鍵下拉選單的設計，您只要按住 Ctrl
+  然後點選這些項目，就可以看到這些選單。</p>
+  <p>鍵盤快速鍵如下：</p>
+  <table width="662" border="0" cellspacing="0" id="table1"
+  cellpadding="8">
+    <tr>
+      <td width="200" bgcolor="#C0C0C0"><b>按鍵</b></td>
+      <td width="462" bgcolor="#C0C0C0"><b>指令</b></td>
+    </tr>
+  </table>
+  <table width="662" border="0" cellspacing="10">
+    <tr>
+      <td width="200"><b>單鍵快速鍵</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td width="115">f</td>
+      <td>將輸入焦點移動到搜尋視窗中</td>
+    </tr>
+    <tr>
+      <td>r</td>
+      <td>將選擇的文章標為已讀</td>
+    </tr>
+    <tr>
+      <td>s</td>
+      <td>將正在閱讀的檔案夾標為已讀，並且跳過目前的檔案夾，跳至下一個包含未讀文章的檔案夾中。</td>
+    </tr>
+    <tr>
+      <td>m</td>
+      <td>將目前選擇的文章加上圖標標示。</td>
+    </tr>
+    <tr>
+      <td>&lt;</td>
+      <td>顯示上一個讀過的文章或是網頁。</td>
+    </tr>
+    <tr>
+      <td>&gt;</td>
+      <td>顯示下一個讀過的文章或是網頁。</td>
+    </tr>
+    <tr>
+      <td>空白鍵</td>
+      <td>如果目前的文章的下方還有沒讀完的內容，則會向下捲動一頁。如果已經讀完，就會移動到下一個未讀的文章。</td>
+    </tr>
+    <tr>
+      <td>Command-U</td>
+      <td>移動到下一篇未讀的文章</td>
+    </tr>
+    <tr>
+      <td>Enter/Return</td>
+      <td>開啟所選擇的文章的原始網頁。</td>
+    </tr>
+    <tr>
+      <td>Delete/Backspace</td>
+      <td>將所選擇的文章移到垃圾桶中。如果您是對在垃圾桶中的文章使用這個指令，就會將文章永久刪除。</td>
+    </tr>
+    <tr>
+      <td width="200"><b>一般快速鍵</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-N</td>
+      <td>建立新的訂閱頻道。</td>
+    </tr>
+    <tr>
+      <td>Command-T</td>
+      <td>更新全部的訂閱頻道。</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-T</td>
+      <td>更新全部在檔案夾列表中所選擇的訂閱頻道。</td>
+    </tr>
+    <tr>
+      <td>Command-減號</td>
+      <td>停止更新。</td>
+    </tr>
+    <tr>
+      <td>Command-P</td>
+      <td>列印所選擇的文章。</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-P</td>
+      <td>打開頁面設定控制視窗</td>
+    </tr>
+    <tr>
+      <td>Command-?</td>
+      <td>顯示 Vienna 輔助說明</td>
+    </tr>
+    <tr>
+      <td><b>文章快速鍵</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-M</td>
+      <td>將選擇的文章加上旗標標記。</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-R</td>
+      <td>將選擇的文章標示為已讀。</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-K</td>
+      <td>將選擇的檔案夾中的所有文章標示為已讀。</td>
+    </tr>
+    <tr>
+      <td><b>視窗快速鍵</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-W</td>
+      <td>關閉目前所在的分頁。如果沒有開啟任何分頁，就會關閉 Vienna 主視窗。</td>
+    </tr>
+    <tr>
+      <td>Alt-Command-W</td>
+      <td>關閉所有的分頁。請注意，當您按下 Alt 鍵的時候，這個指令會置換「檔案」選單上的「關閉分頁」選項。</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Left</td>
+      <td>顯示前一個分頁視窗。</td>
+    </tr>
+    <tr>
+      <td>Control-Command-Right</td>
+      <td>顯示下一個分頁視窗。</td>
+    </tr>
+    <tr>
+      <td>Shift-Command-W</td>
+      <td>關閉 Vienna 主視窗，但是讓 Vienna 在背景中執行。您可以透過點選在 Dock 上的 Vienna
+      圖示，或是使用 Command-1 按鍵，重新叫出 Vienna 主視窗。</td>
+    </tr>
+    <tr>
+      <td>Command-M</td>
+      <td>將 Vienna 視窗縮到最小，縮到 Dock 上。</td>
+    </tr>
+    <tr>
+      <td>Command-0</td>
+      <td>顯示活動紀錄檢視視窗。</td>
+    </tr>
+    <tr>
+      <td>Command-1</td>
+      <td>如果之前關閉了 Vienna 主視窗，會將 Vienna 主視窗重新開啟。</td>
+    </tr>
+    <tr>
+      <td>Command-2</td>
+      <td>顯示下載視窗。</td>
+    </tr>
+    <tr>
+      <td><b>瀏覽視窗快速鍵</b></td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>Command-R</td>
+      <td>重新載入目前所在的網頁。</td>
+    </tr>
+    <tr>
+      <td>Command-Period</td>
+      <td>取消載入目前所在的網頁。</td>
+    </tr>
+    <tr>
+      <td>Command-[</td>
+      <td>移動到前一個瀏覽過的網頁。</td>
+    </tr>
+    <tr>
+      <td>Command-]</td>
+      <td>移動到下一個網頁。</td>
+    </tr>
+    <tr>
+      <td>Command-F</td>
+      <td>將輸入焦點移動到搜尋輸入方塊上。如果在搜尋輸入方塊上輸入文字並且按下
+      Enter，就會以此為關鍵字搜尋目前網頁上的內容。</td>
+    </tr>
+    <tr>
+      <td>Command-G</td>
+      <td>根據搜尋輸入方塊中的關鍵字，繼續搜尋符合的內容。</td>
+    </tr>
+  </table>
 </body>
 </html>


### PR DESCRIPTION
Fixes the htiutil errors when running the build script.
e.g.

```
faq.html -- Parse error: The operation couldn’t be completed. (NSXMLParserErrorDomain error 65.)
advanced.html -- Parse error: The operation couldn’t be completed. (NSXMLParserErrorDomain error 65.)
intro.html -- Parse error: The operation couldn’t be completed. (NSXMLParserErrorDomain error 9.)
keyboard.html -- Parse error: The operation couldn’t be completed. (NSXMLParserErrorDomain error 65.)
```