### PR TITLE
Fiddling again with internal browser’s user agent string

### DIFF
--- a/src/Constants.m
+++ b/src/Constants.m
@@ -19,7 +19,7 @@
 //
 
 NSString * MA_DefaultUserAgentString = @"Mozilla/5.0 Vienna/%@";
-NSString * MA_BrowserUserAgentString = @"Vienna/%@ Safari/%@";
+NSString * MA_BrowserUserAgentString = @"Vienna/%@ Version/%@ Safari/%@";
 
 NSString * MAPref_ArticleListFont = @"MessageListFont";
 NSString * MAPref_AutoSortFoldersTree = @"AutomaticallySortFoldersTree";

--- a/src/TabbedWebView.m
+++ b/src/TabbedWebView.m
@@ -36,16 +36,25 @@
 	-(void)handleMinimumFontSizeChange:(NSNotification *)nc;
 @end
 
+static NSString * _userAgent ;
+
 @implementation TabbedWebView
 
 +(NSString *)userAgent
 {
-	NSString * safariVersion = [[[NSBundle bundleWithPath:@"/Applications/Safari.app"] infoDictionary] objectForKey:@"CFBundleVersion"];
-	if (safariVersion)
-		safariVersion = [safariVersion substringFromIndex:2];
-	else
-		safariVersion = @"532.22";
-	return [NSString stringWithFormat:MA_BrowserUserAgentString, [[((ViennaApp *)NSApp) applicationVersion] firstWord], safariVersion];
+	if(!_userAgent)
+	{
+        NSString * webkitVersion = [[[NSBundle bundleWithIdentifier:@"com.apple.WebKit"] infoDictionary] objectForKey:@"CFBundleVersion"];
+        if (webkitVersion)
+            webkitVersion = [webkitVersion substringFromIndex:2];
+        else
+            webkitVersion = @"536.30";
+        NSString * shortSafariVersion = [[[NSBundle bundleWithPath:@"/Applications/Safari.app"] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+        if (!shortSafariVersion)
+            shortSafariVersion = @"6.0";
+        _userAgent = [NSString stringWithFormat:MA_BrowserUserAgentString, [[((ViennaApp *)NSApp) applicationVersion] firstWord], shortSafariVersion, webkitVersion];
+	}
+	return _userAgent;
 }
 
 /* initWithFrame


### PR DESCRIPTION
The user agent string will look like :
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Vienna/3.0.7 Version/8.0.7 Safari/600.7.12`

The addition of "Version/…" should help some sites consider that we support modern Safari features.