### PR TITLE
Fix responder chain

### DIFF
--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -859,6 +859,11 @@ static const CGFloat MA_Minimum_Article_Pane_Dimension = 80;
 	[[NSApp mainWindow] makeFirstResponder:([self selectedArticle] != nil) ? articleList : [foldersTree mainView]];
 }
 
+- (BOOL)acceptsFirstResponder
+{
+	return YES;
+};
+
 /* handleKeyDown [delegate]
  * Support special key codes. If we handle the key, return YES otherwise
  * return NO to allow the framework to pass it on for default processing.

--- a/src/UnifiedDisplayView.m
+++ b/src/UnifiedDisplayView.m
@@ -1102,8 +1102,14 @@
 
 - (BOOL)acceptsFirstResponder
 {
-	return NO;
+	return YES;
 };
+
+-(BOOL)becomeFirstResponder
+{
+    [self ensureSelectedArticle:NO];
+    return YES;
+}
 
 /* keyDown
  * Here is where we handle special keys when this view


### PR DESCRIPTION
When the primary tab is getting selected, the focus should be on articles list, not on the filter field.
This fix allows a more consistent behavior regarding response to keyboard shortcuts.