### PR TITLE
Fixed the header file for TabbedWebView.h

### DIFF
--- a/src/TabbedWebView.h
+++ b/src/TabbedWebView.h
@@ -42,4 +42,7 @@
 -(BOOL)isDownload;
 -(void)scrollToTop;
 -(void)scrollToBottom;
+-(void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request newFrameName:(NSString *)frameName decisionListener:(id<WebPolicyDecisionListener>)listener;
+-(void)webView:(WebView *)sender decidePolicyForNavigationAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request frame:(WebFrame *)frame decisionListener:(id<WebPolicyDecisionListener>)listener;
+
 @end


### PR DESCRIPTION
Xcode 7 was failing to build due to missing definitions in TabbedWebView