### PR TITLE
Safety measures for parsing feeds

### DIFF
--- a/src/RichXMLParser.m
+++ b/src/RichXMLParser.m
@@ -98,7 +98,7 @@
 	{
 		unsigned char ch = *srcPtr++;
 		// most C0 control characters are illegal in XML 1.0 (and highly discouraged in XML 1.1)
-		if ( (ch >= 0x01 && ch <= 0x08) || (ch == 0x0B || ch == 0x0C) || (ch >= 0x0E && ch <= 0x1F) )
+		if (ch < 0x20 && ch != 0x09 && ch != 0x0A && ch != 0x0D)
 		{
 		    destPtr[destIndex++] = ' ';
 		}


### PR DESCRIPTION
- Workaround for issue #507 : we reintroduce a preFlightValidation routine (much simpler than the one deleted in commit 67d1817)
- Apple recommends that in case of parsing failure, one tries to recover by initializing the document with the NSXMLDocumentTidyXML option