### PR TITLE
Fixed deadlocks on OS X 10.8.5

### DIFF
--- a/src/NSDate+Vienna.m
+++ b/src/NSDate+Vienna.m
@@ -52,7 +52,7 @@ static BOOL threadSafe;
 @implementation NSDate (Vienna)
 
 
-+ (void) initialize
++ (void)load
 {
 	// Initializes the date formatters
 	enUSLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
@@ -76,6 +76,8 @@ static BOOL threadSafe;
         threadSafe=NO;
     }
 }
+
+
 
 /* parseXMLDate
  * Parse a date in an XML header into an NSCalendarDate.


### PR DESCRIPTION
Fixes issue #574

This was caused by custom locking code put in +(void)initialize
in NSDate+Vienna.m.

from: https://developer.apple.com/library/prerelease/mac/documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/#//apple_ref/occ/clm/NSObject/initialize

"Because initialize is called in a thread-safe manner and the order of initialize being called on different classes is not guaranteed, it’s important to do the minimum amount of work necessary in initialize methods. Specifically, any code that takes locks that might be required by other classes in their initialize methods is liable to lead to deadlocks."