### PR TITLE
Fix assertion failure

### DIFF
--- a/src/AppController.m
+++ b/src/AppController.m
@@ -2496,9 +2496,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
             }
 		}
 		[self openURLs:urls inPreferredBrowser:usePreferredBrowser];
-		
-		if (!db.readOnly)
-            [articleController markReadByArray:articlesWithLinks readFlag:YES];
 	}
 }
 

--- a/src/RichXMLParser.m
+++ b/src/RichXMLParser.m
@@ -57,7 +57,7 @@
         xmlDocument = [[NSXMLDocument alloc] initWithData:xmlData
                                                         options:NSXMLNodeOptionsNone
                                                         error:&error];
-        if (error) {
+        if (xmlDocument == nil && error != nil) {
             if (error.code == 73) return NO;
             xmlDocument = [[NSXMLDocument alloc] initWithData:xmlData
                                                   options: NSXMLDocumentTidyXML

--- a/src/RichXMLParser.m
+++ b/src/RichXMLParser.m
@@ -58,7 +58,14 @@
                                                         options:NSXMLNodeOptionsNone
                                                         error:&error];
         if (xmlDocument == nil && error != nil) {
-            if (error.code == 73) return NO;
+			if ([error.domain isEqualToString:NSXMLParserErrorDomain]) {
+				if (error.code == NSXMLParserGTRequiredError)
+					return NO;
+				if (error.code == NSXMLParserPrematureDocumentEndError)
+					return NO;
+			}
+			// Do we even want to try this?
+			// We get assertion failures with the above 2 cases, so we'll probably get them with other cases too.
             xmlDocument = [[NSXMLDocument alloc] initWithData:xmlData
                                                   options: NSXMLDocumentTidyXML
                                                   error:&error];


### PR DESCRIPTION
I was getting an assertion failure from http://brockerhoff.net/blog/feed/ in -[NSXMLDocument insertChild:atIndex:], /SourceCache/Foundation/Foundation-1154/XML.subproj/XMLTypes.subproj/NSXMLDocument.m:802

The error code was NSXMLParserPrematureDocumentEndError.

Pasting the current raw feed source did not work well, so I won't do that.

This issue seems similar to https://github.com/ViennaRSS/vienna-rss/issues/619