### PR TITLE
Exception thrown when refreshing if rssTitle or folderName are nil

### DIFF
--- a/src/GoogleReader.m
+++ b/src/GoogleReader.m
@@ -776,11 +776,12 @@ enum GoogleReaderStatus {
 		
 		if (![localFeeds containsObject:feedURL])
 		{
-			NSString *rssTitle = nil;
+			NSString *rssTitle = @"";
 			if (feed[@"title"]) {
 				rssTitle = feed[@"title"];
 			}
-			NSArray * params = @[feedURL, rssTitle, folderName];
+			// folderName could be nil
+			NSArray * params = folderName ? @[feedURL, rssTitle, folderName] : @[feedURL, rssTitle];
 			[self createNewSubscription:params];
 		}
 		else


### PR DESCRIPTION
For example, when trying to fetch the subscription "The Old Reader Sponsored Posts" the folderName is nil and the following exception is thrown.

`*** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[2]`

Afterwards the queue is stuck an no new articles are fetched.
