### PR TITLE
Fix warning over invalid NSError instance

### DIFF
--- a/src/BitlyAPIHelper.m
+++ b/src/BitlyAPIHelper.m
@@ -52,7 +52,7 @@ static NSString * BitlyApiBaseUrl = @"http://api.bit.ly/%@?version=2.0.1&login=%
 	
 	// ... which is then finally sent to bit.ly's servers.
 	NSHTTPURLResponse* urlResponse = nil;  	
-	NSError *error = [[NSError alloc] init];
+	NSError *error = nil;
 	NSData * data = [NSURLConnection sendSynchronousRequest:request returningResponse:&urlResponse error:&error];	
 	
 	// If the response is OK, use Vienna's XML parser stuff to get the data we need.


### PR DESCRIPTION
Error was:
`-[NSError init] called; this results in an invalid NSError instance. It will raise an exception in a future release. Please call errorWithDomain:code:userInfo: or initWithDomain:code:userInfo:. This message shown only once.`