### PR TITLE
Updated unit tests and added contrib notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to Vienna
+
+## Writing code
+
+The current version of Vienna requires Xcode 7 and Mac OS X 10.11 SDK. We will be officially moving to Xcode 8 and macOS Sierra SDK once it has been released. Currently the Unit Tests require Xcode 8 and Swift 3.
+
+Vienna uses [cocoapods](http://cocoapods.org) for managing dependencies. When building, make sure to always open the Xcode workspace `Viennna.xcworkspace` instead of a project file.
+
+You should have a basic knowledge of Git and read this [advice on workflow](https://github.com/ViennaRSS/vienna-rss/wiki/Good-manners-with-Git).
+
+As a starting point, search for any [issues with the *help-wanted* label](https://github.com/ViennaRSS/vienna-rss/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted).
+
+Please let us know what you are working on by posting an issue on Vienna's github and assigning it to yourself.
+
+## Code style guidelines
+
+For Objective-C code, please try to follow the [Spotify Objective-C Coding Style](https://github.com/spotify/ios-style).
+
+For Swift code, please try to follow the [GitHub Swift Style Guide](https://github.com/github/swift-style-guide).

--- a/README.md
+++ b/README.md
@@ -75,21 +75,20 @@ You can write plugins by referring to [this document](http://www.vienna-rss.org/
 
 ### Writing code
 
-The current version of Vienna requires Xcode 7.
+The current version of Vienna requires Xcode 7 and Mac OS X 10.11 SDK. We will be officially moving to Xcode 8 and macOS Sierra SDK once it has been released. Currently the Unit Tests require Xcode 8 and Swift 3.
 
 Vienna uses [cocoapods](http://cocoapods.org) for managing dependencies. When building, make sure to always open the Xcode workspace `Viennna.xcworkspace` instead of a project file.
 
 You should have a basic knowledge of Git and read these [advices on workflow](https://github.com/ViennaRSS/vienna-rss/wiki/Good-manners-with-Git).
 
+As a starting point, search for any [issues with the *help-wanted* label](https://github.com/ViennaRSS/vienna-rss/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted).
+
 Please let us know what you are working on by posting an issue on Vienna's github and assigning it to yourself.
+
+For more information please check [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 
 Licensing
 ---------
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
-
-
-
-
-
-

--- a/Vienna Tests/BitlyAPIHelperTests.swift
+++ b/Vienna Tests/BitlyAPIHelperTests.swift
@@ -22,8 +22,8 @@ class BitlyAPIHelperTests: XCTestCase {
 
     func testShortenURL() {
         let bitlyHelper = BitlyAPIHelper.init(login: "viennarss", andAPIKey: "R_852929122e82d2af45fe9e238f1012d3")
-        let shortURL = bitlyHelper.shortenURL("http://www.vienna-rss.org")
-        XCTAssertTrue(shortURL.containsString("bit.ly"))
+        let shortURL = bitlyHelper?.shortenURL("http://www.vienna-rss.org")
+        XCTAssertTrue((shortURL?.contains("bit.ly"))!)
     }
 
 }

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -3010,6 +3010,7 @@
 				TargetAttributes = {
 					035B703419E0E4AE00197334 = {
 						CreatedOnToolsVersion = 6.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -7021,6 +7022,7 @@
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna Tests/Vienna Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Development;
 		};
@@ -7080,6 +7082,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna Tests/Vienna Tests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Deployment;
 		};
@@ -7136,6 +7139,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna Tests/Vienna Tests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = StaticAnalyzer;
 		};


### PR DESCRIPTION
- Converted unit tests to Swift 3 syntax to stop Xcode 8 complaining.
- Updated README to include a node about Swift 3 requirement for tests.
- Added CONTRIBUTING guidelines in a file so they show up [as per GitHub instructions](https://help.github.com/articles/setting-guidelines-for-repository-contributors/).