### PR TITLE
Add support for delta feeds (RFC3229+feed)

### DIFF
--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -486,6 +486,7 @@
         if (![theLastUpdateString isEqualToString:@""])
         {
             [myRequest addRequestHeader:@"If-Modified-Since" value:theLastUpdateString];
+            [myRequest addRequestHeader:@"A-IM" value:@"feed"];
         }
 		myRequest.userInfo = @{@"folder": folder, @"log": aItem, @"type": @(MA_Refresh_Feed)};
 		if (![folder.username isEqualToString:@""])
@@ -745,7 +746,7 @@
 		[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_FoldersUpdated"
                                                                             object:@(folderId)];
 	}
-	else if (responseStatusCode == 200)
+	else if (responseStatusCode == 200 || responseStatusCode == 226)
 	{
 				
 		NSData * receivedData = [connector responseData];


### PR DESCRIPTION
Supporting servers will return a delta feed instead of a full feed; meaning Vienna will only be served entries that have been added or modified since the `If-Modified-Since` timestamp. Saves bandwidth for users and servers alike, and eases processing and speeds up feed updates for feed readers.

Supported in a a growing lists of feed readers and content management systems. I’m actively working on adding support to more clients and feed servers.