### PR TITLE
Separate preferences window controller from AppController

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -367,7 +367,7 @@
                             </menuItem>
                             <menuItem title="Preferences…" keyEquivalent="," id="129">
                                 <connections>
-                                    <action selector="showPreferencePanel:" target="233" id="234"/>
+                                    <action selector="showWindow:" target="HLa-Gy-vMd" id="Fid-tD-rC8"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Check for Updates" id="1104">
@@ -1469,6 +1469,7 @@ CA
             </connections>
         </customObject>
         <customObject id="HRR-OU-3yj" customClass="ArticleListView"/>
+        <customObject id="HLa-Gy-vMd" customClass="PreferencesWindowController"/>
     </objects>
     <resources>
         <image name="filter-icon" width="16" height="16"/>

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		F6D572B41E26AA9900CDA909 /* InfoWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572B61E26AA9900CDA909 /* InfoWindow.xib */; };
 		F6D572B71E26AAA100CDA909 /* RSSFeed.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572B91E26AAA100CDA909 /* RSSFeed.xib */; };
 		F6D572BA1E26AAA900CDA909 /* SearchFolder.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572BC1E26AAA900CDA909 /* SearchFolder.xib */; };
+		F6EB261C1E5BA59300570B22 /* PreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F6EB261B1E5BA59300570B22 /* PreferencesWindowController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1342,6 +1343,8 @@
 		F6D5739F1E2706B500CDA909 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoWindow.strings; sourceTree = "<group>"; };
 		F6D573A01E2706BA00CDA909 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoWindow.strings; sourceTree = "<group>"; };
 		F6D573A11E2706BC00CDA909 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoWindow.strings; sourceTree = "<group>"; };
+		F6EB261A1E5BA59300570B22 /* PreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PreferencesWindowController.h; path = src/Preferences/PreferencesWindowController.h; sourceTree = "<group>"; };
+		F6EB261B1E5BA59300570B22 /* PreferencesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PreferencesWindowController.m; path = src/Preferences/PreferencesWindowController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1934,6 +1937,8 @@
 			children = (
 				AA9FE2EB08BC133600A9E977 /* Preferences.h */,
 				AA9FE2EC08BC133600A9E977 /* Preferences.m */,
+				F6EB261A1E5BA59300570B22 /* PreferencesWindowController.h */,
+				F6EB261B1E5BA59300570B22 /* PreferencesWindowController.m */,
 				0349813C1A206FD900014F29 /* GeneralPreferencesViewController.h */,
 				0349813D1A206FD900014F29 /* GeneralPreferencesViewController.m */,
 				0379E2361A2082E600D58BFE /* AppearancePreferencesViewController.h */,
@@ -2773,6 +2778,7 @@
 				4350289B165DE9E00018EDB7 /* ArticleView.m in Sources */,
 				4350289C165DE9E00018EDB7 /* BrowserPane.m in Sources */,
 				4350289D165DE9E00018EDB7 /* BrowserPaneTemplate.m in Sources */,
+				F6EB261C1E5BA59300570B22 /* PreferencesWindowController.m in Sources */,
 				4350289E165DE9E00018EDB7 /* BrowserView.m in Sources */,
 				4350289F165DE9E00018EDB7 /* Constants.m in Sources */,
 				034981411A20701600014F29 /* AdvancedPreferencesViewController.m in Sources */,

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -33,7 +33,6 @@
 #define APPCONTROLLER ((AppController *)[NSApp delegate])
 #define APP ((ViennaApp *)NSApp)
 
-@class NewPreferencesController;
 @class FoldersTree;
 @class SmartFolder;
 @class NewSubscription;
@@ -103,13 +102,11 @@
 	BOOL didCompleteInitialisation;
 	NSString * searchString;
     
-    NSWindowController *_preferencesWindowController;
     NewSubscription * _rssFeed;
     CDEvents * _events;
     ViennaSparkleDelegate * _sparkleDelegate;
 }
 
-@property (weak, nonatomic, readonly) NSWindowController *preferencesWindowController;
 @property(nonatomic, strong) NewSubscription *rssFeed;
 @property(nonatomic, strong) IBOutlet FoldersTree * foldersTree;
 
@@ -117,7 +114,6 @@
 -(IBAction)handleAbout:(id)sender;
 -(IBAction)exitVienna:(id)sender;
 -(IBAction)reindexDatabase:(id)sender;
--(IBAction)showPreferencePanel:(id)sender;
 -(IBAction)deleteMessage:(id)sender;
 -(IBAction)deleteFolder:(id)sender;
 -(IBAction)searchUsingToolbarTextField:(id)sender;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -20,12 +20,6 @@
 
 #import "AppController.h"
 
-#import "MASPreferencesWindowController.h"
-#import "GeneralPreferencesViewController.h"
-#import "AppearancePreferencesViewController.h"
-#import "SyncingPreferencesViewController.h"
-#import "AdvancedPreferencesViewController.h"
-
 #import "FoldersTree.h"
 #import "Import.h"
 #import "Export.h"
@@ -1961,7 +1955,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(refreshAllSubscriptions:))];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(markAllSubscriptionsRead:))];
 		[statusBarMenu addItem:[NSMenuItem separatorItem]];
-		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(showPreferencePanel:))];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(handleAbout:))];
 		[statusBarMenu addItem:[NSMenuItem separatorItem]];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(exitVienna:))];
@@ -4427,47 +4420,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			 @"NextButton"]
 			 arrayByAddingObjectsFromArray:pluginManager.toolbarItems
 			 ];
-}
-
-#pragma mark - MASPreferences
-
-- (NSWindowController *)preferencesWindowController
-{
-    if (_preferencesWindowController == nil)
-    {
-        NSViewController *generalViewController = [[GeneralPreferencesViewController alloc] init];
-        NSViewController *appearanceViewController = [[AppearancePreferencesViewController alloc] init];
-        NSViewController *syncingViewController = [[SyncingPreferencesViewController alloc] init];
-        NSViewController *advancedViewController = [[AdvancedPreferencesViewController alloc] init];
-        NSArray *controllers = @[generalViewController, appearanceViewController, syncingViewController, advancedViewController];
-        
-        // To add a flexible space between General and Advanced preference panes insert [NSNull null]:
-        //     NSArray *controllers = [[NSArray alloc] initWithObjects:generalViewController, [NSNull null], advancedViewController, nil];
-        
-        
-        NSString *title = NSLocalizedString(@"Preferences", @"Common title for Preferences window");
-        _preferencesWindowController = [[MASPreferencesWindowController alloc] initWithViewControllers:controllers title:title];
-    }
-    return _preferencesWindowController;
-}
-
-#pragma mark - MASPreferences Actions
-
-- (IBAction)showPreferencePanel:(id)sender
-{
-    [self.preferencesWindowController showWindow:nil];
-}
-
-NSString *const kFocusedAdvancedControlIndex = @"FocusedAdvancedControlIndex";
-
-- (NSInteger)focusedAdvancedControlIndex
-{
-    return [[NSUserDefaults standardUserDefaults] integerForKey:kFocusedAdvancedControlIndex];
-}
-
-- (void)setFocusedAdvancedControlIndex:(NSInteger)focusedAdvancedControlIndex
-{
-    [[NSUserDefaults standardUserDefaults] setInteger:focusedAdvancedControlIndex forKey:kFocusedAdvancedControlIndex];
 }
 
 /* dealloc

--- a/src/Preferences/PreferencesWindowController.h
+++ b/src/Preferences/PreferencesWindowController.h
@@ -1,0 +1,26 @@
+//
+//  PreferencesWindowController.h
+//  Vienna
+//
+//  Copyright 2017
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@import Cocoa;
+
+#import "MASPreferencesWindowController.h"
+
+@interface PreferencesWindowController : MASPreferencesWindowController
+
+@end

--- a/src/Preferences/PreferencesWindowController.m
+++ b/src/Preferences/PreferencesWindowController.m
@@ -1,0 +1,44 @@
+//
+//  PreferencesWindowController.m
+//  Vienna
+//
+//  Copyright 2017
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "PreferencesWindowController.h"
+
+#import "GeneralPreferencesViewController.h"
+#import "AppearancePreferencesViewController.h"
+#import "SyncingPreferencesViewController.h"
+#import "AdvancedPreferencesViewController.h"
+
+@implementation PreferencesWindowController
+
+/*
+ This initializer is called by -initWithWindow.
+ */
+- (instancetype)init {
+    NSViewController *general = [GeneralPreferencesViewController new];
+    NSViewController *appearance = [AppearancePreferencesViewController new];
+    NSViewController *syncing = [SyncingPreferencesViewController new];
+    NSViewController *advanced = [AdvancedPreferencesViewController new];
+
+    NSArray *controllers = @[general, appearance, syncing, advanced];
+    NSString *title = NSLocalizedString(@"Preferences", @"Title of the Preferences window");
+
+    return [self initWithViewControllers:controllers title:title];
+}
+
+@end


### PR DESCRIPTION
Question: Do I need to assign the return value of `initWithViewControllers:title:` to `self` first? i.e. instead of
```objc
return [self initWithViewControllers:controllers title:title];
```

This:
```objc
return self = [self initWithViewControllers:controllers title:title];
```