### PR TITLE
Legacy db url update

### DIFF
--- a/src/Database.m
+++ b/src/Database.m
@@ -50,7 +50,7 @@
 
 // The current database version number
 const NSInteger MA_Min_Supported_DB_Version = 12;
-const NSInteger MA_Current_DB_Version = 18;
+const NSInteger MA_Current_DB_Version = 19;
 
 
 @implementation Database

--- a/src/VNADatabaseMigration.m
+++ b/src/VNADatabaseMigration.m
@@ -123,7 +123,7 @@
                  @"http://www.vienna-rss.com",
                  @(viennaFolderId)];
             }
-            
+            [results close];
             [db setUserVersion:(uint32_t)19];
             NSLog(@"Updated database schema to version 19.");
         }

--- a/src/VNADatabaseMigration.m
+++ b/src/VNADatabaseMigration.m
@@ -110,6 +110,23 @@
 
             NSLog(@"Updated database schema to version 18.");
         }
+        case 19: {
+            // Upgrade to rev 19.
+            // Update the Vienna Developer's blog RSS URL after we changed from .org to .com
+
+            FMResultSet *results = [db executeQuery:@"SELECT folder_id FROM rss_folders WHERE feed_url LIKE ?", @"%%vienna-rss.org%%"];
+
+            if([results next]) {
+                int viennaFolderId = [results intForColumn:@"folder_id"];
+                [db executeUpdate:@"UPDATE rss_folders SET feed_url=?, home_page=? WHERE folder_id=?",
+                 @"http://www.vienna-rss.com/?feed=rss2",
+                 @"http://www.vienna-rss.com",
+                 @(viennaFolderId)];
+            }
+            
+            [db setUserVersion:(uint32_t)19];
+            NSLog(@"Updated database schema to version 19.");
+        }
     }
     
 }


### PR DESCRIPTION
The simplest solution was incrementing the db schema by 1 and adding a new migration case to db version 19.

The new migration case finds an existing Vienna Developer's blog entry in rss_folders
and updates both the feed_url and the home_page columns with the correct vienna-rss.com based urls.

Closes #808