### PR TITLE
Move PreferencesWindowController back to resolve potential memory leak

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -1463,7 +1463,6 @@ CA
                 <outlet property="outlineView" destination="Kk7-ax-B3r" id="O2z-Mf-33v"/>
             </connections>
         </customObject>
-        <customObject id="HRR-OU-3yj" customClass="ArticleListView"/>
         <customObject id="HLa-Gy-vMd" customClass="PreferencesWindowController"/>
     </objects>
     <resources>

--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -367,7 +367,7 @@
                             </menuItem>
                             <menuItem title="Preferences…" keyEquivalent="," id="129">
                                 <connections>
-                                    <action selector="showWindow:" target="HLa-Gy-vMd" id="Fid-tD-rC8"/>
+                                    <action selector="showPreferences:" target="-1" id="UuH-UI-a6l"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Check for Updates" id="1104">
@@ -1463,7 +1463,6 @@ CA
                 <outlet property="outlineView" destination="Kk7-ax-B3r" id="O2z-Mf-33v"/>
             </connections>
         </customObject>
-        <customObject id="HLa-Gy-vMd" customClass="PreferencesWindowController"/>
     </objects>
     <resources>
         <image name="filter-icon" width="16" height="16"/>

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -60,7 +60,7 @@
 #import "Database.h"
 #import "BJRWindowWithToolbar.h"
 #import "NSURL+Utils.h"
-
+#import "PreferencesWindowController.h"
 
 @interface AppController (Private)
 	@property (nonatomic, readonly, copy) NSMenu *searchFieldMenu;
@@ -110,6 +110,12 @@
 	-(void)searchArticlesWithString:(NSString *)searchString;
 	-(void)sourceWindowWillClose:(NSNotification *)notification;
 	-(IBAction)cancelAllRefreshesToolbar:(id)sender;
+@end
+
+@interface AppController ()
+
+@property (nonatomic) PreferencesWindowController *preferencesWindowController;
+
 @end
 
 // Static constant strings that are typically never tweaked
@@ -4386,6 +4392,22 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			 arrayByAddingObjectsFromArray:pluginManager.toolbarItems
 			 ];
 }
+
+#pragma mark Preferences
+
+- (PreferencesWindowController *)preferencesWindowController {
+    if (!_preferencesWindowController) {
+        _preferencesWindowController = [PreferencesWindowController new];
+    }
+
+    return _preferencesWindowController;
+}
+
+- (IBAction)showPreferences:(id)sender {
+    [self.preferencesWindowController showWindow:self];
+}
+
+#pragma mark Dealloc
 
 /* dealloc
  * Clean up and release resources.


### PR DESCRIPTION
Per #826. Xcode seems to mark this as a memory leak, even though it does not seem to have any functional impact. It will also remove the unused ArticleListView object from MainMenu.xib.