### PR TITLE
Decouple ActivityViewer from AppController

### DIFF
--- a/Interfaces/Base.lproj/ActivityViewer.xib
+++ b/Interfaces/Base.lproj/ActivityViewer.xib
@@ -6,7 +6,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="ActivityViewer">
+        <customObject id="-2" userLabel="File's Owner" customClass="ActivityPanelController">
             <connections>
                 <outlet property="activityDetail" destination="35" id="37"/>
                 <outlet property="activityTable" destination="17" id="22"/>

--- a/Interfaces/Base.lproj/ActivityViewer.xib
+++ b/Interfaces/Base.lproj/ActivityViewer.xib
@@ -8,55 +8,41 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ActivityPanelController">
             <connections>
-                <outlet property="activityDetail" destination="35" id="37"/>
-                <outlet property="activityTable" destination="17" id="22"/>
-                <outlet property="activityWindow" destination="8" id="11"/>
-                <outlet property="splitView" destination="36" id="38"/>
+                <outlet property="tableView" destination="17" id="9PO-Zp-e9d"/>
+                <outlet property="textView" destination="35" id="wga-pe-AJT"/>
                 <outlet property="window" destination="8" id="15"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Activity" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="activityViewer" animationBehavior="default" tabbingMode="disallowed" id="8" userLabel="Panel" customClass="NSPanel">
+        <window title="Activity" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="activityWindow" animationBehavior="default" tabbingMode="disallowed" id="8" userLabel="Panel" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="150" y="449" width="646" height="563"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1080"/>
-            <value key="minSize" type="size" width="213" height="113"/>
-            <view key="contentView" id="7">
-                <rect key="frame" x="0.0" y="0.0" width="646" height="563"/>
+            <rect key="contentRect" x="150" y="449" width="450" height="360"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <value key="minSize" type="size" width="200" height="140"/>
+            <view key="contentView" wantsLayer="YES" id="7">
+                <rect key="frame" x="0.0" y="0.0" width="450" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <splitView dividerStyle="paneSplitter" translatesAutoresizingMaskIntoConstraints="NO" id="36">
-                        <rect key="frame" x="0.0" y="0.0" width="646" height="564"/>
+                    <splitView identifier="activityWindowSplitViewIdentifier" autosaveName="activityWindowSplitView" dividerStyle="paneSplitter" translatesAutoresizingMaskIntoConstraints="NO" id="36">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="361"/>
                         <subviews>
-                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="16">
-                                <rect key="frame" x="0.0" y="0.0" width="646" height="363"/>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="17" horizontalPageScroll="10" verticalLineScroll="17" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="16" userLabel="Master View">
+                                <rect key="frame" x="0.0" y="0.0" width="450" height="278"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <clipView key="contentView" id="vuC-mn-Vhc">
-                                    <rect key="frame" x="0.0" y="0.0" width="646" height="363"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="450" height="278"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" headerView="44" id="17" customClass="ExtendedTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="646" height="340"/>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" emptySelection="NO" autosaveName="activityWindowTableView" rowHeight="15" headerView="44" id="17">
+                                            <rect key="frame" x="0.0" y="0.0" width="450" height="255"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <size key="intercellSpacing" width="4" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="19" minWidth="10" maxWidth="1000" id="33">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                    </tableHeaderCell>
-                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" id="42">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </tableColumn>
-                                                <tableColumn identifier="name" editable="NO" width="309" minWidth="40" maxWidth="1000" id="18">
+                                                <tableColumn identifier="name" editable="NO" width="270" minWidth="80" maxWidth="1000" id="18">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Source">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -69,8 +55,15 @@
                                                     </textFieldCell>
                                                     <sortDescriptor key="sortDescriptorPrototype" selector="caseInsensitiveCompare:" sortKey="name"/>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <connections>
+                                                        <binding destination="ngT-qn-tsD" name="value" keyPath="arrangedObjects.name" id="Oc6-o7-IYc">
+                                                            <dictionary key="options">
+                                                                <bool key="NSConditionallySetsEditable" value="YES"/>
+                                                            </dictionary>
+                                                        </binding>
+                                                    </connections>
                                                 </tableColumn>
-                                                <tableColumn identifier="status" editable="NO" width="308.66162109375" minWidth="40.66162109375" maxWidth="1000" id="19">
+                                                <tableColumn identifier="status" editable="NO" width="172" minWidth="100" maxWidth="1000" id="19">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Status">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -83,11 +76,29 @@
                                                     </textFieldCell>
                                                     <sortDescriptor key="sortDescriptorPrototype" selector="caseInsensitiveCompare:" sortKey="status"/>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <connections>
+                                                        <binding destination="ngT-qn-tsD" name="value" keyPath="arrangedObjects.status" id="V20-kf-aVQ">
+                                                            <dictionary key="options">
+                                                                <bool key="NSConditionallySetsEditable" value="YES"/>
+                                                            </dictionary>
+                                                        </binding>
+                                                    </connections>
                                                 </tableColumn>
                                             </tableColumns>
                                             <connections>
-                                                <outlet property="dataSource" destination="-2" id="32"/>
-                                                <outlet property="delegate" destination="-2" id="24"/>
+                                                <binding destination="ngT-qn-tsD" name="content" keyPath="arrangedObjects" id="z5x-op-hLm"/>
+                                                <binding destination="ngT-qn-tsD" name="doubleClickArgument" keyPath="selection.self" id="vh1-HZ-8jB">
+                                                    <dictionary key="options">
+                                                        <string key="NSSelectorName">showFolderForItem:</string>
+                                                    </dictionary>
+                                                </binding>
+                                                <binding destination="ngT-qn-tsD" name="selectionIndexes" keyPath="selectionIndexes" previousBinding="z5x-op-hLm" id="bPS-SD-icO"/>
+                                                <binding destination="-2" name="doubleClickTarget" keyPath="self" previousBinding="vh1-HZ-8jB" id="B2a-16-hPt">
+                                                    <dictionary key="options">
+                                                        <string key="NSSelectorName">showFolderForItem:</string>
+                                                    </dictionary>
+                                                </binding>
+                                                <binding destination="ngT-qn-tsD" name="sortDescriptors" keyPath="sortDescriptors" previousBinding="bPS-SD-icO" id="SRV-SI-VSq"/>
                                             </connections>
                                         </tableView>
                                     </subviews>
@@ -96,7 +107,7 @@
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="0mm-3Z-4qd"/>
                                 </constraints>
                                 <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="43">
-                                    <rect key="frame" x="0.0" y="353" width="632" height="16"/>
+                                    <rect key="frame" x="0.0" y="262" width="450" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="45">
@@ -104,44 +115,57 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <tableHeaderView key="headerView" id="44">
-                                    <rect key="frame" x="0.0" y="0.0" width="646" height="23"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="450" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
-                            <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="34">
-                                <rect key="frame" x="0.0" y="373" width="646" height="191"/>
+                            <scrollView fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="34" userLabel="Detail View">
+                                <rect key="frame" x="0.0" y="288" width="450" height="73"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <clipView key="contentView" id="fSJ-fr-xBI">
-                                    <rect key="frame" x="0.0" y="0.0" width="646" height="191"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="450" height="73"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textView editable="NO" importsGraphics="NO" richText="NO" usesFontPanel="YES" findStyle="panel" usesRuler="YES" quoteSubstitution="YES" dashSubstitution="YES" textReplacement="YES" smartInsertDelete="YES" id="35">
-                                            <rect key="frame" x="0.0" y="0.0" width="646" height="191"/>
+                                        <textView editable="NO" importsGraphics="NO" richText="NO" usesFontPanel="YES" findStyle="panel" usesRuler="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" smartInsertDelete="YES" id="35">
+                                            <rect key="frame" x="0.0" y="0.0" width="450" height="73"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <size key="minSize" width="646" height="191"/>
+                                            <size key="minSize" width="450" height="73"/>
                                             <size key="maxSize" width="646" height="10000000"/>
+                                            <attributedString key="textStorage">
+                                                <fragment content=" ">
+                                                    <attributes>
+                                                        <font key="NSFont" metaFont="smallSystem"/>
+                                                        <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                    </attributes>
+                                                </fragment>
+                                            </attributedString>
                                             <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <connections>
+                                                <binding destination="ngT-qn-tsD" name="value" keyPath="selection.details" id="1do-fJ-mAk">
+                                                    <dictionary key="options">
+                                                        <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                        <bool key="NSConditionallySetsEditable" value="NO"/>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
                                         </textView>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </clipView>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="RRg-fO-ewk"/>
-                                </constraints>
                                 <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="46">
                                     <rect key="frame" x="-100" y="-100" width="87" height="18"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="47">
-                                    <rect key="frame" x="630" y="0.0" width="16" height="191"/>
+                                    <rect key="frame" x="434" y="0.0" width="16" height="73"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
                         </subviews>
                         <holdingPriorities>
                             <real value="250"/>
-                            <real value="250"/>
+                            <real value="251"/>
                         </holdingPriorities>
                     </splitView>
                 </subviews>
@@ -155,7 +179,16 @@
             <connections>
                 <outlet property="delegate" destination="-2" id="14"/>
             </connections>
-            <point key="canvasLocation" x="141" y="186.5"/>
+            <point key="canvasLocation" x="50.5" y="85"/>
         </window>
+        <arrayController objectClassName="ActivityItem" editable="NO" automaticallyPreparesContent="YES" id="ngT-qn-tsD" userLabel="Activity Log">
+            <connections>
+                <binding destination="-2" name="contentArray" keyPath="activityLog.allItems" id="zXg-ws-9lx">
+                    <dictionary key="options">
+                        <bool key="NSConditionallySetsEditable" value="NO"/>
+                    </dictionary>
+                </binding>
+            </connections>
+        </arrayController>
     </objects>
 </document>

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		F6A7DE4F1E471A7F0017BE5E /* Vienna.help in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DDCA1E470E980017BE5E /* Vienna.help */; };
 		F6A7DEC71E47233C0017BE5E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DEC51E47233C0017BE5E /* InfoPlist.strings */; };
 		F6C5CEFA1E39D88500B44F3A /* PSMTabBarControl+IntrinsicContentSize.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C5CEF91E39D88500B44F3A /* PSMTabBarControl+IntrinsicContentSize.m */; };
+		F6CE47131E7E3DCB0045EAD7 /* ActivityItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F6CE47121E7E3DCB0045EAD7 /* ActivityItem.m */; };
 		F6D572AB1E26AA8200CDA909 /* EmptyTrashWarning.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572AD1E26AA8200CDA909 /* EmptyTrashWarning.xib */; };
 		F6D572AE1E26AA8A00CDA909 /* FeedCredentials.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572B01E26AA8A00CDA909 /* FeedCredentials.xib */; };
 		F6D572B11E26AA9000CDA909 /* GroupFolder.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572B31E26AA9000CDA909 /* GroupFolder.xib */; };
@@ -1215,6 +1216,8 @@
 		F6B9937D1E28360D005F9FAD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AdvancedPreferencesView.strings"; sourceTree = "<group>"; };
 		F6C5CEF81E39D88500B44F3A /* PSMTabBarControl+IntrinsicContentSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "PSMTabBarControl+IntrinsicContentSize.h"; path = "src/PSMTabBarControl+IntrinsicContentSize.h"; sourceTree = "<group>"; };
 		F6C5CEF91E39D88500B44F3A /* PSMTabBarControl+IntrinsicContentSize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "PSMTabBarControl+IntrinsicContentSize.m"; path = "src/PSMTabBarControl+IntrinsicContentSize.m"; sourceTree = "<group>"; };
+		F6CE47111E7E3DBD0045EAD7 /* ActivityItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ActivityItem.h; path = src/ActivityItem.h; sourceTree = "<group>"; };
+		F6CE47121E7E3DCB0045EAD7 /* ActivityItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ActivityItem.m; path = src/ActivityItem.m; sourceTree = "<group>"; };
 		F6D573291E26B19D00CDA909 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/EmptyTrashWarning.xib; sourceTree = "<group>"; };
 		F6D5732A1E26B19E00CDA909 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/FeedCredentials.xib; sourceTree = "<group>"; };
 		F6D5732B1E26B19F00CDA909 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/GroupFolder.xib; sourceTree = "<group>"; };
@@ -1436,10 +1439,6 @@
 			children = (
 				793C952E1C3F07FC00984D4E /* TreeFilterView.h */,
 				793C952F1C3F07FC00984D4E /* TreeFilterView.m */,
-				AA0FB5E00869110300D9CB90 /* ActivityLog.h */,
-				43502848165DE9DF0018EDB7 /* ActivityLog.m */,
-				43502849165DE9DF0018EDB7 /* ActivityPanelController.h */,
-				4350284A165DE9DF0018EDB7 /* ActivityPanelController.m */,
 				4350284B165DE9DF0018EDB7 /* AppController.h */,
 				4350284C165DE9DF0018EDB7 /* AppController.m */,
 				4350284D165DE9DF0018EDB7 /* ArticleBaseView.h */,
@@ -1969,6 +1968,7 @@
 				AA8C76C006420CA800649BA2 /* Database */,
 				2A37F4ABFDCFA73011CA2CEA /* Classes */,
 				AAC5063D082A7AE00089FF70 /* Support Classes */,
+				F6CE47101E7E3D520045EAD7 /* Activity panel */,
 				AA3113EC09020E1B00E80DF1 /* Preferences */,
 				AA5AABB50C3CD68A00B2E14F /* Toolbar */,
 				AAC5063C082A7A530089FF70 /* Other Sources */,
@@ -2077,6 +2077,19 @@
 				F6A7DE491E4717970017BE5E /* shared */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		F6CE47101E7E3D520045EAD7 /* Activity panel */ = {
+			isa = PBXGroup;
+			children = (
+				AA0FB5E00869110300D9CB90 /* ActivityLog.h */,
+				43502848165DE9DF0018EDB7 /* ActivityLog.m */,
+				F6CE47111E7E3DBD0045EAD7 /* ActivityItem.h */,
+				F6CE47121E7E3DCB0045EAD7 /* ActivityItem.m */,
+				43502849165DE9DF0018EDB7 /* ActivityPanelController.h */,
+				4350284A165DE9DF0018EDB7 /* ActivityPanelController.m */,
+			);
+			name = "Activity panel";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2695,6 +2708,7 @@
 				4350283E165DE7F60018EDB7 /* NSNotificationAdditions.m in Sources */,
 				43502895165DE9E00018EDB7 /* ActivityLog.m in Sources */,
 				43502896165DE9E00018EDB7 /* ActivityPanelController.m in Sources */,
+				F6CE47131E7E3DCB0045EAD7 /* ActivityItem.m in Sources */,
 				43502897165DE9E00018EDB7 /* AppController.m in Sources */,
 				43502898165DE9E00018EDB7 /* ArticleController.m in Sources */,
 				43502899165DE9E00018EDB7 /* ArticleFilter.m in Sources */,

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -96,7 +96,7 @@
 		435026E6165DD8BE0018EDB7 /* ArticleRef.m in Sources */ = {isa = PBXBuildFile; fileRef = 435026E5165DD8BE0018EDB7 /* ArticleRef.m */; };
 		4350283E165DE7F60018EDB7 /* NSNotificationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350283D165DE7F60018EDB7 /* NSNotificationAdditions.m */; };
 		43502895165DE9E00018EDB7 /* ActivityLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 43502848165DE9DF0018EDB7 /* ActivityLog.m */; };
-		43502896165DE9E00018EDB7 /* ActivityViewer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350284A165DE9DF0018EDB7 /* ActivityViewer.m */; };
+		43502896165DE9E00018EDB7 /* ActivityPanelController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350284A165DE9DF0018EDB7 /* ActivityPanelController.m */; };
 		43502897165DE9E00018EDB7 /* AppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350284C165DE9DF0018EDB7 /* AppController.m */; };
 		43502898165DE9E00018EDB7 /* ArticleController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350284F165DE9DF0018EDB7 /* ArticleController.m */; };
 		43502899165DE9E00018EDB7 /* ArticleFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 43502851165DE9DF0018EDB7 /* ArticleFilter.m */; };
@@ -533,8 +533,8 @@
 		43502845165DE9560018EDB7 /* RenameFolder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RenameFolder.h; path = src/RenameFolder.h; sourceTree = SOURCE_ROOT; };
 		43502846165DE9560018EDB7 /* RenameFolder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RenameFolder.m; path = src/RenameFolder.m; sourceTree = SOURCE_ROOT; };
 		43502848165DE9DF0018EDB7 /* ActivityLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ActivityLog.m; path = src/ActivityLog.m; sourceTree = SOURCE_ROOT; };
-		43502849165DE9DF0018EDB7 /* ActivityViewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ActivityViewer.h; path = src/ActivityViewer.h; sourceTree = SOURCE_ROOT; };
-		4350284A165DE9DF0018EDB7 /* ActivityViewer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ActivityViewer.m; path = src/ActivityViewer.m; sourceTree = SOURCE_ROOT; };
+		43502849165DE9DF0018EDB7 /* ActivityPanelController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ActivityPanelController.h; path = src/ActivityPanelController.h; sourceTree = SOURCE_ROOT; };
+		4350284A165DE9DF0018EDB7 /* ActivityPanelController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ActivityPanelController.m; path = src/ActivityPanelController.m; sourceTree = SOURCE_ROOT; };
 		4350284B165DE9DF0018EDB7 /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppController.h; path = src/AppController.h; sourceTree = SOURCE_ROOT; };
 		4350284C165DE9DF0018EDB7 /* AppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppController.m; path = src/AppController.m; sourceTree = SOURCE_ROOT; };
 		4350284D165DE9DF0018EDB7 /* ArticleBaseView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArticleBaseView.h; path = src/ArticleBaseView.h; sourceTree = SOURCE_ROOT; };
@@ -1414,7 +1414,7 @@
 			name = Products;
 			sourceTree = SOURCE_ROOT;
 		};
-		2A37F4AAFDCFA73011CA2CEA = {
+		2A37F4AAFDCFA73011CA2CEA /* Vienna */ = {
 			isa = PBXGroup;
 			children = (
 				439824161666B1ED00FFE219 /* Documentation */,
@@ -1438,8 +1438,8 @@
 				793C952F1C3F07FC00984D4E /* TreeFilterView.m */,
 				AA0FB5E00869110300D9CB90 /* ActivityLog.h */,
 				43502848165DE9DF0018EDB7 /* ActivityLog.m */,
-				43502849165DE9DF0018EDB7 /* ActivityViewer.h */,
-				4350284A165DE9DF0018EDB7 /* ActivityViewer.m */,
+				43502849165DE9DF0018EDB7 /* ActivityPanelController.h */,
+				4350284A165DE9DF0018EDB7 /* ActivityPanelController.m */,
 				4350284B165DE9DF0018EDB7 /* AppController.h */,
 				4350284C165DE9DF0018EDB7 /* AppController.m */,
 				4350284D165DE9DF0018EDB7 /* ArticleBaseView.h */,
@@ -2198,7 +2198,7 @@
 				"zh-Hant",
 				"zh-Hans",
 			);
-			mainGroup = 2A37F4AAFDCFA73011CA2CEA;
+			mainGroup = 2A37F4AAFDCFA73011CA2CEA /* Vienna */;
 			productRefGroup = 19C28FB0FE9D524F11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -2694,7 +2694,7 @@
 				435026E6165DD8BE0018EDB7 /* ArticleRef.m in Sources */,
 				4350283E165DE7F60018EDB7 /* NSNotificationAdditions.m in Sources */,
 				43502895165DE9E00018EDB7 /* ActivityLog.m in Sources */,
-				43502896165DE9E00018EDB7 /* ActivityViewer.m in Sources */,
+				43502896165DE9E00018EDB7 /* ActivityPanelController.m in Sources */,
 				43502897165DE9E00018EDB7 /* AppController.m in Sources */,
 				43502898165DE9E00018EDB7 /* ArticleController.m in Sources */,
 				43502899165DE9E00018EDB7 /* ArticleFilter.m in Sources */,

--- a/src/ActivityItem.h
+++ b/src/ActivityItem.h
@@ -18,21 +18,38 @@
 //  limitations under the License.
 //
 
-#import <Cocoa/Cocoa.h>
+@import Foundation;
 
-@interface ActivityItem : NSObject {
-    NSString * name;
-    NSString * status;
-    NSMutableArray * details;
-}
+@interface ActivityItem : NSObject
 
 extern NSNotificationName const activityItemStatusUpdatedNotification;
 extern NSNotificationName const activityItemDetailsUpdatedNotification;
 
-// Accessor functions
-@property (nonatomic, copy) NSString *name;
-@property (nonatomic, copy) NSString *status;
-@property (nonatomic, readonly, copy) NSString *details;
--(void)appendDetail:(NSString *)aString;
--(void)clearDetails;
+/**
+ The name of the item.
+ */
+@property (copy, nonatomic) NSString *name;
+
+/**
+ The fetch status of the item.
+ */
+@property (copy, nonatomic) NSString *status;
+
+/**
+ Detailed information about the fetch status of the item.
+ */
+@property (readonly, nonatomic) NSString *details;
+
+/**
+ Appends a string to the details of the item.
+
+ @param string The string to append.
+ */
+- (void)appendDetail:(NSString *)string;
+
+/**
+ Clears all details from the item.
+ */
+- (void)clearDetails;
+
 @end

--- a/src/ActivityItem.h
+++ b/src/ActivityItem.h
@@ -1,5 +1,5 @@
 //
-//  ActivityLog.h
+//  ActivityItem.h
 //  Vienna
 //
 //  Created by Steve on 6/21/05.
@@ -20,17 +20,19 @@
 
 #import <Cocoa/Cocoa.h>
 
-#import "ActivityItem.h"
-
-@interface ActivityLog : NSObject {
-	NSMutableArray * log;
+@interface ActivityItem : NSObject {
+    NSString * name;
+    NSString * status;
+    NSMutableArray * details;
 }
 
-extern NSNotificationName const activityLogUpdatedNotification;
+extern NSNotificationName const activityItemStatusUpdatedNotification;
+extern NSNotificationName const activityItemDetailsUpdatedNotification;
 
 // Accessor functions
-+(ActivityLog *)defaultLog;
-@property (nonatomic, readonly, copy) NSArray *allItems;
--(ActivityItem *)itemByName:(NSString *)theName;
--(void)sortUsingDescriptors:(NSArray *)sortDescriptors;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *status;
+@property (nonatomic, readonly, copy) NSString *details;
+-(void)appendDetail:(NSString *)aString;
+-(void)clearDetails;
 @end

--- a/src/ActivityItem.m
+++ b/src/ActivityItem.m
@@ -18,102 +18,62 @@
 //  limitations under the License.
 //
 
-#import "ActivityLog.h"
+#import "ActivityItem.h"
+
+@interface ActivityItem ()
+
+@property NSMutableArray *detailsArray;
+
+@end
 
 @implementation ActivityItem
 
 NSNotificationName const activityItemStatusUpdatedNotification = @"Activity Item Status Updated";
 NSNotificationName const activityItemDetailsUpdatedNotification = @"Activity Item Details Updated";
 
-/* init
- * Initialise a new ActivityItem object
- */
--(instancetype)init
-{
-    if ((self = [super init]) != nil)
-    {
-        self.name = @"";
-        self.status = @"";
-        details = nil;
-    }
-    return self;
+#pragma mark Accessors
+
+- (void)setStatus:(NSString *)status {
+    _status = [status copy];
+
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center postNotificationName:activityItemStatusUpdatedNotification
+                          object:self];
 }
 
-/* name
- * Returns the object source name.
- */
--(NSString *)name
-{
-    return name;
-}
-
-/* status
- * Returns the object source status
- */
--(NSString *)status
-{
-    return status;
-}
-
-/* setName
- * Sets the source name
- */
--(void)setName:(NSString *)aName
-{
-    name = aName;
-}
-
-/* setStatus
- * Sets the item status.
- */
--(void)setStatus:(NSString *)aStatus
-{
-    status = aStatus;
-    [[NSNotificationCenter defaultCenter] postNotificationName:activityItemStatusUpdatedNotification object:self];
-}
-
-/* clearDetails
- * Empties the details log for this item.
- */
--(void)clearDetails
-{
-    [details removeAllObjects];
-}
-
-/* appendDetail
- * Appends the specified text string to the details for this item.
- */
--(void)appendDetail:(NSString *)aString
-{
-    if (details == nil)
-        details = [[NSMutableArray alloc] init];
-    [details addObject:aString];
-    [[NSNotificationCenter defaultCenter] postNotificationName:activityItemDetailsUpdatedNotification object:self];
-}
-
-/* details
- * Returns all details for this item. Caution: the return value
- * may be nil if the item has no initialised details.
- */
--(NSString *)details
-{
-    NSMutableString * detailString = [NSMutableString stringWithString:@""];
-    if (details != nil)
-    {
-        for (NSString * aString in details)
-        {
-            [detailString appendFormat:@"%@\n", aString];
+- (NSString *)details {
+    NSMutableString *detailString = [NSMutableString stringWithString:@""];
+    if (self.detailsArray) {
+        for (NSString *string in self.detailsArray) {
+            [detailString appendFormat:@"%@\n", string];
         }
     }
+
     return detailString;
 }
 
-/* description
- * Return item description for debugging.
+/*
+ Overrides the description for debugging purposes.
  */
--(NSString *)description
-{
-    return [NSString stringWithFormat:@"{'%@', '%@'}", name, status];
+- (NSString *)description {
+    return [NSString stringWithFormat:@"{'%@', '%@'}", self.name, self.status];
+}
+
+#pragma mark Methods
+
+- (void)clearDetails {
+    [self.detailsArray removeAllObjects];
+}
+
+- (void)appendDetail:(NSString *)string {
+    if (!self.detailsArray) {
+        self.detailsArray = [NSMutableArray new];
+    }
+    [self.detailsArray addObject:string];
+
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center postNotificationName:activityItemDetailsUpdatedNotification
+                          object:self];
 }
 
 @end

--- a/src/ActivityItem.m
+++ b/src/ActivityItem.m
@@ -1,0 +1,119 @@
+//
+//  ActivityItem.m
+//  Vienna
+//
+//  Created by Steve on 6/21/05.
+//  Copyright (c) 2004-2005 Steve Palmer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "ActivityLog.h"
+
+@implementation ActivityItem
+
+NSNotificationName const activityItemStatusUpdatedNotification = @"Activity Item Status Updated";
+NSNotificationName const activityItemDetailsUpdatedNotification = @"Activity Item Details Updated";
+
+/* init
+ * Initialise a new ActivityItem object
+ */
+-(instancetype)init
+{
+    if ((self = [super init]) != nil)
+    {
+        self.name = @"";
+        self.status = @"";
+        details = nil;
+    }
+    return self;
+}
+
+/* name
+ * Returns the object source name.
+ */
+-(NSString *)name
+{
+    return name;
+}
+
+/* status
+ * Returns the object source status
+ */
+-(NSString *)status
+{
+    return status;
+}
+
+/* setName
+ * Sets the source name
+ */
+-(void)setName:(NSString *)aName
+{
+    name = aName;
+}
+
+/* setStatus
+ * Sets the item status.
+ */
+-(void)setStatus:(NSString *)aStatus
+{
+    status = aStatus;
+    [[NSNotificationCenter defaultCenter] postNotificationName:activityItemStatusUpdatedNotification object:self];
+}
+
+/* clearDetails
+ * Empties the details log for this item.
+ */
+-(void)clearDetails
+{
+    [details removeAllObjects];
+}
+
+/* appendDetail
+ * Appends the specified text string to the details for this item.
+ */
+-(void)appendDetail:(NSString *)aString
+{
+    if (details == nil)
+        details = [[NSMutableArray alloc] init];
+    [details addObject:aString];
+    [[NSNotificationCenter defaultCenter] postNotificationName:activityItemDetailsUpdatedNotification object:self];
+}
+
+/* details
+ * Returns all details for this item. Caution: the return value
+ * may be nil if the item has no initialised details.
+ */
+-(NSString *)details
+{
+    NSMutableString * detailString = [NSMutableString stringWithString:@""];
+    if (details != nil)
+    {
+        for (NSString * aString in details)
+        {
+            [detailString appendFormat:@"%@\n", aString];
+        }
+    }
+    return detailString;
+}
+
+/* description
+ * Return item description for debugging.
+ */
+-(NSString *)description
+{
+    return [NSString stringWithFormat:@"{'%@', '%@'}", name, status];
+}
+
+@end

--- a/src/ActivityLog.h
+++ b/src/ActivityLog.h
@@ -26,6 +26,9 @@
 	NSMutableArray * details;
 }
 
+extern NSNotificationName const activityItemStatusUpdatedNotification;
+extern NSNotificationName const activityItemDetailsUpdatedNotification;
+
 // Accessor functions
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, copy) NSString *status;
@@ -37,6 +40,8 @@
 @interface ActivityLog : NSObject {
 	NSMutableArray * log;
 }
+
+extern NSNotificationName const activityLogUpdatedNotification;
 
 // Accessor functions
 +(ActivityLog *)defaultLog;

--- a/src/ActivityLog.h
+++ b/src/ActivityLog.h
@@ -18,19 +18,30 @@
 //  limitations under the License.
 //
 
-#import <Cocoa/Cocoa.h>
+@import Foundation;
 
 #import "ActivityItem.h"
 
-@interface ActivityLog : NSObject {
-	NSMutableArray * log;
-}
+@interface ActivityLog : NSObject
 
-extern NSNotificationName const activityLogUpdatedNotification;
+extern NSNotificationName const _Nonnull activityLogUpdatedNotification;
 
-// Accessor functions
-+(ActivityLog *)defaultLog;
-@property (nonatomic, readonly, copy) NSArray *allItems;
--(ActivityItem *)itemByName:(NSString *)theName;
--(void)sortUsingDescriptors:(NSArray *)sortDescriptors;
+/**
+ The default activity log.
+ */
+@property (readonly, class, nonnull) ActivityLog *defaultLog;
+
+/**
+ An array of activity items.
+ */
+@property (readonly, copy, nonnull) NSArray<ActivityItem *> *allItems;
+
+/**
+ Returns an activity item for the name of the item.
+
+ @param name The name of the item.
+ @return An activity item.
+ */
+- (nonnull ActivityItem *)itemByName:(nonnull NSString *)name;
+
 @end

--- a/src/ActivityLog.m
+++ b/src/ActivityLog.m
@@ -23,6 +23,9 @@
 
 @implementation ActivityItem
 
+NSNotificationName const activityItemStatusUpdatedNotification = @"Activity Item Status Updated";
+NSNotificationName const activityItemDetailsUpdatedNotification = @"Activity Item Details Updated";
+
 /* init
  * Initialise a new ActivityItem object
  */
@@ -67,7 +70,7 @@
 -(void)setStatus:(NSString *)aStatus
 {
 	status = aStatus;
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityLogChange" object:self];
+	[[NSNotificationCenter defaultCenter] postNotificationName:activityItemStatusUpdatedNotification object:self];
 }
 
 /* clearDetails
@@ -86,7 +89,7 @@
 	if (details == nil)
 		details = [[NSMutableArray alloc] init];
 	[details addObject:aString];
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityDetailChange" object:self];
+	[[NSNotificationCenter defaultCenter] postNotificationName:activityItemDetailsUpdatedNotification object:self];
 }
 
 /* details
@@ -119,6 +122,8 @@
 
 @implementation ActivityLog
 
+NSNotificationName const activityLogUpdatedNotification = @"Activity Log Updated";
+
 /* defaultLog
  * Return the default log singleton.
  */
@@ -141,7 +146,7 @@
 	if ((self = [super init]) != nil)
 	{
 		log = [[NSMutableArray alloc] init];
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleWillDeleteFolder:) name:@"MA_Notify_WillDeleteFolder" object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleWillDeleteFolder:) name:databaseWillDeleteFolderNotification object:nil];
 	}
 	return self;
 }
@@ -154,7 +159,7 @@
 	Folder * folder = [[Database sharedManager] folderFromID:[nc.object integerValue]];
 	ActivityItem * item = [self itemByName:folder.name];
 	[log removeObject:item];
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityLogChange" object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationName:activityLogUpdatedNotification object:nil];
 }
 
 /* getStatus

--- a/src/ActivityLog.m
+++ b/src/ActivityLog.m
@@ -21,105 +21,6 @@
 #import "ActivityLog.h"
 #import "Database.h"
 
-@implementation ActivityItem
-
-NSNotificationName const activityItemStatusUpdatedNotification = @"Activity Item Status Updated";
-NSNotificationName const activityItemDetailsUpdatedNotification = @"Activity Item Details Updated";
-
-/* init
- * Initialise a new ActivityItem object
- */
--(instancetype)init
-{
-	if ((self = [super init]) != nil)
-	{
-		self.name = @"";
-		self.status = @"";
-		details = nil;
-	}
-	return self;
-}
-
-/* name
- * Returns the object source name.
- */
--(NSString *)name
-{
-	return name;
-}
-
-/* status
- * Returns the object source status
- */
--(NSString *)status
-{
-	return status;
-}
-
-/* setName
- * Sets the source name
- */
--(void)setName:(NSString *)aName
-{
-	name = aName;
-}
-
-/* setStatus
- * Sets the item status.
- */
--(void)setStatus:(NSString *)aStatus
-{
-	status = aStatus;
-	[[NSNotificationCenter defaultCenter] postNotificationName:activityItemStatusUpdatedNotification object:self];
-}
-
-/* clearDetails
- * Empties the details log for this item.
- */
--(void)clearDetails
-{
-	[details removeAllObjects];
-}
-
-/* appendDetail
- * Appends the specified text string to the details for this item.
- */
--(void)appendDetail:(NSString *)aString
-{
-	if (details == nil)
-		details = [[NSMutableArray alloc] init];
-	[details addObject:aString];
-	[[NSNotificationCenter defaultCenter] postNotificationName:activityItemDetailsUpdatedNotification object:self];
-}
-
-/* details
- * Returns all details for this item. Caution: the return value
- * may be nil if the item has no initialised details.
- */
--(NSString *)details
-{
-	NSMutableString * detailString = [NSMutableString stringWithString:@""];
-	if (details != nil)
-	{
-		for (NSString * aString in details)
-		{
-			[detailString appendFormat:@"%@\n", aString];
-		}
-	}
-	return detailString;
-}
-
-/* description
- * Return item description for debugging.
- */
--(NSString *)description
-{
-	return [NSString stringWithFormat:@"{'%@', '%@'}", name, status];
-}
-
-@end
-
-
 @implementation ActivityLog
 
 NSNotificationName const activityLogUpdatedNotification = @"Activity Log Updated";
@@ -225,4 +126,5 @@ NSNotificationName const activityLogUpdatedNotification = @"Activity Log Updated
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
 @end

--- a/src/ActivityPanelController.h
+++ b/src/ActivityPanelController.h
@@ -20,8 +20,6 @@
 
 @import Cocoa;
 
-#import "TableViewExtensions.h"
-
 @class Folder;
 
 @protocol ActivityPanelDelegate
@@ -36,13 +34,7 @@
 
 @end
 
-@interface ActivityPanelController : NSWindowController <NSWindowDelegate> {
-	IBOutlet NSWindow * activityWindow;
-	IBOutlet ExtendedTableView * activityTable;
-	IBOutlet NSSplitView * splitView;
-	IBOutlet NSTextView * activityDetail;
-	NSArray * allItems;
-}
+@interface ActivityPanelController : NSWindowController
 
 /**
  The activity panel's delegate.

--- a/src/ActivityPanelController.h
+++ b/src/ActivityPanelController.h
@@ -1,5 +1,5 @@
 //
-//  ActivityViewer.h
+//  ActivityPanelController.h
 //  Vienna
 //
 //  Created by Steve on Thu Mar 18 2004.
@@ -21,7 +21,7 @@
 #import <Cocoa/Cocoa.h>
 #import "TableViewExtensions.h"
 
-@interface ActivityViewer : NSWindowController <NSWindowDelegate> {
+@interface ActivityPanelController : NSWindowController <NSWindowDelegate> {
 	IBOutlet NSWindow * activityWindow;
 	IBOutlet ExtendedTableView * activityTable;
 	IBOutlet NSSplitView * splitView;

--- a/src/ActivityPanelController.h
+++ b/src/ActivityPanelController.h
@@ -18,8 +18,23 @@
 //  limitations under the License.
 //
 
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
+
 #import "TableViewExtensions.h"
+
+@class Folder;
+
+@protocol ActivityPanelDelegate
+
+/**
+ Notifies the delegate that a folder has been selected.
+
+ @param activityPanel The panel in which the folder was selected.
+ @param folder The selected folder.
+ */
+- (void)activityPanel:(nonnull NSPanel *)activityPanel didSelectFolder:(nonnull Folder *)folder;
+
+@end
 
 @interface ActivityPanelController : NSWindowController <NSWindowDelegate> {
 	IBOutlet NSWindow * activityWindow;
@@ -28,4 +43,10 @@
 	IBOutlet NSTextView * activityDetail;
 	NSArray * allItems;
 }
+
+/**
+ The activity panel's delegate.
+ */
+@property (nullable, nonatomic) id<ActivityPanelDelegate> activityPanelDelegate;
+
 @end

--- a/src/ActivityPanelController.m
+++ b/src/ActivityPanelController.m
@@ -1,5 +1,5 @@
 //
-//  ActivityViewer.m
+//  ActivityPanelController.m
 //  Vienna
 //
 //  Created by Steve on Thu Mar 18 2004.
@@ -18,13 +18,13 @@
 //  limitations under the License.
 //
 
-#import "ActivityViewer.h"
+#import "ActivityPanelController.h"
 #import "ActivityLog.h"
 #import "AppController.h"
 #import "Preferences.h"
 #import "SplitViewExtensions.h"
 
-@implementation ActivityViewer
+@implementation ActivityPanelController
 
 /* init
  * Just init the activity window.

--- a/src/ActivityPanelController.m
+++ b/src/ActivityPanelController.m
@@ -19,8 +19,9 @@
 //
 
 #import "ActivityPanelController.h"
+
 #import "ActivityLog.h"
-#import "AppController.h"
+#import "Database.h"
 #import "Preferences.h"
 #import "SplitViewExtensions.h"
 
@@ -92,11 +93,11 @@
 		Folder * folder = [db folderFromName:selectedItem.name];
 		if (folder == nil)
 			folder = [db folderFromFeedURL:selectedItem.name];
-		if (folder != nil)
-		{
-			AppController * controller = APPCONTROLLER;
-			[controller selectFolder:folder.itemId];
-		}
+
+        // Send the folder to the delegate.
+        if (folder) {
+            [self.activityPanelDelegate activityPanel:(NSPanel *)self.window didSelectFolder:folder];
+        }
 	}
 }
 

--- a/src/ActivityViewer.m
+++ b/src/ActivityViewer.m
@@ -63,8 +63,8 @@
 
 	// Set up to receive notifications when the activity log changes
 	NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
-	[nc addObserver:self selector:@selector(handleLogChange:) name:@"MA_Notify_ActivityLogChange" object:nil];	
-	[nc addObserver:self selector:@selector(handleDetailChange:) name:@"MA_Notify_ActivityDetailChange" object:nil];	
+	[nc addObserver:self selector:@selector(handleLogChange:) name:activityLogUpdatedNotification object:nil];
+	[nc addObserver:self selector:@selector(handleDetailChange:) name:activityItemDetailsUpdatedNotification object:nil];
 }
 
 /* windowShouldClose

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -21,7 +21,7 @@
 #import <Cocoa/Cocoa.h>
 #import "Database.h"
 #import "ArticleController.h"
-#import "ActivityViewer.h"
+#import "ActivityPanelController.h"
 #import <Growl/Growl.h>
 #import "DownloadWindow.h"
 #import "FilterView.h"
@@ -79,7 +79,7 @@
 	IBOutlet NSTextField * currentFilterTextField;
 	IBOutlet NSButton * filterIconInStatusBarButton;
 
-	ActivityViewer * activityViewer;
+	ActivityPanelController * activityPanelController;
 	DownloadWindow * downloadWindow;
 	SmartFolder * smartFolder;
 	NewGroupFolder * groupFolder;

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -21,7 +21,6 @@
 #import <Cocoa/Cocoa.h>
 #import "Database.h"
 #import "ArticleController.h"
-#import "ActivityPanelController.h"
 #import <Growl/Growl.h>
 #import "DownloadWindow.h"
 #import "FilterView.h"
@@ -79,7 +78,6 @@
 	IBOutlet NSTextField * currentFilterTextField;
 	IBOutlet NSButton * filterIconInStatusBarButton;
 
-	ActivityPanelController * activityPanelController;
 	DownloadWindow * downloadWindow;
 	SmartFolder * smartFolder;
 	NewGroupFolder * groupFolder;
@@ -127,7 +125,6 @@
 -(IBAction)viewFirstUnread:(id)sender;
 -(IBAction)viewNextUnread:(id)sender;
 -(IBAction)printDocument:(id)sender;
--(IBAction)toggleActivityViewer:(id)sender;
 -(IBAction)goBack:(id)sender;
 -(IBAction)goForward:(id)sender;
 -(IBAction)newSmartFolder:(id)sender;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -603,8 +603,8 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
 		
 		// Close the activity window explicitly to force it to
 		// save its split bar position to the preferences.
-		NSWindow * activityWindow = activityViewer.window;
-		[activityWindow performClose:self];
+		NSWindow *activityPanel = activityPanelController.window;
+		[activityPanel performClose:self];
 		
 		// Put back the original app icon
 		[NSApp.dockTile setBadgeLabel:nil];
@@ -2853,13 +2853,13 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)toggleActivityViewer:(id)sender
 {	
-	if (activityViewer == nil)
-		activityViewer = [[ActivityViewer alloc] init];
-	if (activityViewer != nil)
+	if (activityPanelController == nil)
+		activityPanelController = [[ActivityPanelController alloc] init];
+	if (activityPanelController != nil)
 	{
-		NSWindow * activityWindow = activityViewer.window;
+		NSWindow * activityWindow = activityPanelController.window;
 		if (!activityWindow.visible)
-			[activityViewer showWindow:self];
+			[activityPanelController showWindow:self];
 		else
 			[activityWindow performClose:self];
 	}

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -32,7 +32,7 @@
 #import "NewGroupFolder.h"
 #import "ViennaApp.h"
 #import "XMLSourceWindow.h"
-#import "ActivityLog.h"
+#import "ActivityPanelController.h"
 #import "BrowserPaneTemplate.h"
 #import "Constants.h"
 #import "ArticleView.h"
@@ -112,8 +112,9 @@
 	-(IBAction)cancelAllRefreshesToolbar:(id)sender;
 @end
 
-@interface AppController ()
+@interface AppController () <ActivityPanelDelegate>
 
+@property (nonatomic) IBOutlet ActivityPanelController *activityPanelController;
 @property (nonatomic) PreferencesWindowController *preferencesWindowController;
 
 @end
@@ -603,7 +604,7 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
 		
 		// Close the activity window explicitly to force it to
 		// save its split bar position to the preferences.
-		NSWindow *activityPanel = activityPanelController.window;
+		NSWindow *activityPanel = self.activityPanelController.window;
 		[activityPanel performClose:self];
 		
 		// Put back the original app icon
@@ -2848,23 +2849,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[downloadWindow.window makeKeyAndOrderFront:sender];
 }
 
-/* toggleActivityViewer
- * Toggle display of the activity viewer windows.
- */
--(IBAction)toggleActivityViewer:(id)sender
-{	
-	if (activityPanelController == nil)
-		activityPanelController = [[ActivityPanelController alloc] init];
-	if (activityPanelController != nil)
-	{
-		NSWindow * activityWindow = activityPanelController.window;
-		if (!activityWindow.visible)
-			[activityPanelController showWindow:self];
-		else
-			[activityWindow performClose:self];
-	}
-}
-
 /* viewFirstUnread
  * Moves the selection to the first unread article.
  */
@@ -4405,6 +4389,37 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 
 - (IBAction)showPreferences:(id)sender {
     [self.preferencesWindowController showWindow:self];
+}
+
+#pragma mark Activity panel
+
+- (ActivityPanelController *)activityPanelController {
+    if (!_activityPanelController) {
+        _activityPanelController = [ActivityPanelController new];
+        _activityPanelController.activityPanelDelegate = self;
+    }
+
+    return _activityPanelController;
+}
+
+/**
+ Toggle the visibility of the activity panel; show when hidden and close when
+ visible.
+ */
+- (IBAction)toggleActivityViewer:(id)sender {
+    if (!self.activityPanelController.window.visible) {
+        [self.activityPanelController showWindow:self];
+    } else {
+        [self.activityPanelController.window performClose:self];
+    }
+}
+
+/**
+ This delegate method is called when the user clicks on a row in the activity
+ panel's table view. This will be used to select a correspondng folder.
+ */
+- (void)activityPanel:(NSPanel *)activityPanel didSelectFolder:(Folder *)folder {
+    [self selectFolder:folder.itemId];
 }
 
 #pragma mark Dealloc

--- a/src/Database.h
+++ b/src/Database.h
@@ -40,6 +40,9 @@
     FMDatabaseQueue *databaseQueue;
 }
 
+extern NSNotificationName const databaseWillDeleteFolderNotification;
+extern NSNotificationName const databaseDidDeleteFolderNotification;
+
 @property(nonatomic, strong) Folder * trashFolder;
 @property(nonatomic, strong) Folder * searchFolder;
 @property(nonatomic, strong) FMDatabaseQueue * databaseQueue;

--- a/src/Database.m
+++ b/src/Database.m
@@ -55,6 +55,9 @@ const NSInteger MA_Current_DB_Version = 19;
 
 @implementation Database
 
+NSNotificationName const databaseWillDeleteFolderNotification = @"Database Will Delete Folder";
+NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did Delete Folder";
+
 @synthesize trashFolder, searchFolder;
 @synthesize databaseQueue;
 
@@ -997,7 +1000,7 @@ const NSInteger MA_Current_DB_Version = 19;
 	{
 		numFolder = @(folder.itemId);
 		[arrayOfFolderIds addObject:numFolder];
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_WillDeleteFolder" object:numFolder];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:databaseWillDeleteFolderNotification object:numFolder];
 	}
 
 	// Now do the deletion.
@@ -1006,7 +1009,7 @@ const NSInteger MA_Current_DB_Version = 19;
 	// Send the post-delete notification after we're finished. Note that the folder actually corresponding to
 	// each numFolder won't exist any more and the handlers need to be aware of this.
     for (numFolder in arrayOfFolderIds) {
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_FolderDeleted" object:numFolder];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:databaseDidDeleteFolderNotification object:numFolder];
     }
 	
 	return result;

--- a/src/FoldersTree.m
+++ b/src/FoldersTree.m
@@ -152,7 +152,7 @@
 	[nc addObserver:self selector:@selector(handleFolderUpdate:) name:@"MA_Notify_FoldersUpdated" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderNameChange:) name:@"MA_Notify_FolderNameChanged" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderAdded:) name:@"MA_Notify_FolderAdded" object:nil];
-	[nc addObserver:self selector:@selector(handleFolderDeleted:) name:@"MA_Notify_FolderDeleted" object:nil];
+	[nc addObserver:self selector:@selector(handleFolderDeleted:) name:databaseDidDeleteFolderNotification object:nil];
 	[nc addObserver:self selector:@selector(handleFolderFontChange:) name:@"MA_Notify_FolderFontChange" object:nil];
 	[nc addObserver:self selector:@selector(handleShowFolderImagesChange:) name:@"MA_Notify_ShowFolderImages" object:nil];
 	[nc addObserver:self selector:@selector(handleAutoSortFoldersTreeChange:) name:@"MA_Notify_AutoSortFoldersTreeChange" object:nil];

--- a/src/InfoWindow.m
+++ b/src/InfoWindow.m
@@ -66,7 +66,7 @@
 		controllerList = [[NSMutableDictionary alloc] initWithCapacity:10];
 		
 		NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
-		[nc addObserver:self selector:@selector(handleFolderDeleted:) name:@"MA_Notify_FolderDeleted" object:nil];
+		[nc addObserver:self selector:@selector(handleFolderDeleted:) name:databaseDidDeleteFolderNotification object:nil];
 		[nc addObserver:self selector:@selector(handleFolderChange:) name:@"MA_Notify_FolderNameChanged" object:nil];
 		[nc addObserver:self selector:@selector(handleFolderChange:) name:@"MA_Notify_FoldersUpdated" object:nil];
 		[nc addObserver:self selector:@selector(handleFolderChange:) name:@"MA_Notify_LoadFullHTMLChange" object:nil];

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -82,7 +82,7 @@
 		NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
 		[nc addObserver:self selector:@selector(handleGotAuthenticationForFolder:) name:@"MA_Notify_GotAuthenticationForFolder" object:nil];
 		[nc addObserver:self selector:@selector(handleCancelAuthenticationForFolder:) name:@"MA_Notify_CancelAuthenticationForFolder" object:nil];
-		[nc addObserver:self selector:@selector(handleWillDeleteFolder:) name:@"MA_Notify_WillDeleteFolder" object:nil];
+		[nc addObserver:self selector:@selector(handleWillDeleteFolder:) name:databaseWillDeleteFolderNotification object:nil];
 		[nc addObserver:self selector:@selector(handleChangeConcurrentDownloads:) name:@"MA_Notify_CowncurrentDownloadsChange" object:nil];
 		// be notified on system wake up after sleep
 		[[NSWorkspace sharedWorkspace].notificationCenter addObserver:self selector:@selector(handleDidWake:) name:@"NSWorkspaceDidWakeNotification" object:nil];


### PR DESCRIPTION
This PR decouples the dependency on AppController in ActivityViewer by using the delegate pattern. I also refactored the relevant classes to use Interface Builder, Cocoa bindings and modern Objective-C practices.

I am not sure at all about the property attributes in: ActivityPanelController, ActivityLog and ActivityItem. I am particularly concerned about the `nonatomic` keyword. If someone could glance over those and tell me if I used them correctly.

This also needs some testing:
- that the activity window works as expected;
- the split-view divider, table columns and window position/size are restored when Vienna reopens.

Closes #767.

Note: there is also some weird bug that happens when the activity window is open and the content is refreshed (e.g. by pressing command–R). Afterwards, scrolling in the table view of the activity window will produce tonnes of messages in the log, e.g.:
```
2017-03-20 21:25:24.735189 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:24.868292 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:24.883890 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:24.901759 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:25.000617 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:25.100337 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:25.167036 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
2017-03-20 21:25:25.183675 Vienna[36966:11089287] Uncommitted CATransaction. Set CA_DEBUG_TRANSACTIONS=1 in environment to debug.
```

This is not related to this PR and happens before this too. I will open a separate issue for this.