### PR TITLE
Regenerate localization files

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -174,7 +174,7 @@
                                                         </connections>
                                                     </searchField>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="1313">
-                                                        <rect key="frame" x="633" y="9" width="12" height="13"/>
+                                                        <rect key="frame" x="633" y="10" width="12" height="13"/>
                                                         <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="smallCloseButton" imagePosition="only" alignment="center" alternateImage="pressedCloseButton" controlSize="small" inset="2" id="1379">
                                                             <behavior key="behavior" lightByContents="YES"/>
                                                             <font key="font" metaFont="smallSystem"/>
@@ -184,13 +184,13 @@
                                                         </connections>
                                                     </button>
                                                     <popUpButton horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1306">
-                                                        <rect key="frame" x="457" y="3" width="67" height="22"/>
-                                                        <popUpButtonCell key="cell" type="push" title="Item3" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1308" id="1378">
+                                                        <rect key="frame" x="457" y="4" width="67" height="22"/>
+                                                        <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1308" id="1378">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="smallSystem"/>
-                                                            <menu key="menu" title="OtherViews" id="1307">
+                                                            <menu key="menu" id="1307">
                                                                 <items>
-                                                                    <menuItem title="Item3" state="on" id="1308"/>
+                                                                    <menuItem state="on" id="1308"/>
                                                                 </items>
                                                             </menu>
                                                         </popUpButtonCell>
@@ -351,7 +351,7 @@
             <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
         </progressIndicator>
-        <menu title="MainMenu" systemMenu="main" id="29" userLabel="MainMenu">
+        <menu systemMenu="main" id="29" userLabel="MainMenu">
             <items>
                 <menuItem title="Vienna" id="56">
                     <menu key="submenu" title="Vienna" systemMenu="apple" id="57">

--- a/Interfaces/cs.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/cs.lproj/AdvancedPreferencesView.strings
@@ -1,42 +1,38 @@
-
-/* Class = "NSTextFieldCell"; title = "Čím vyšší číslo, tím rychleji se Vám budou načítat Vaše odebírání."; ObjectID = "2GQ-cu-fbh"; */
+/* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "Čím vyšší číslo, tím rychleji se Vám budou načítat Vaše odebírání.";
 
-/* Class = "NSTextFieldCell"; title = "Tato nastavení není třeba při běžném používání programu Vienna měnit. Podrobnosti k jednotlivým volbám naleznete v nápovědě.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Tato nastavení není třeba při běžném používání programu Vienna měnit. Podrobnosti k jednotlivým volbám naleznete v nápovědě.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Tato nastavení není třeba při běžném používání programu Vienna měnit. Podrobnosti k jednotlivým volbám naleznete v nápovědě.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
-/* Class = "NSTextFieldCell"; title = "Souběžná stahování:"; ObjectID = "Ngw-hP-yW4"; */
+/* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
 "Ngw-hP-yW4.title" = "Souběžná stahování:";
 
-/* Class = "NSTextFieldCell"; title = "Nicméně vyšší čísla zároveň způsobí horší odezvu počítače během aktualizování odebírání."; ObjectID = "S3T-cW-hys"; */
+/* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "Nicméně vyšší čísla zároveň způsobí horší odezvu počítače během aktualizování odebírání.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Aktivovat JavaScript v interním prohlížeči"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Aktivovat JavaScript v interním prohlížeči";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/cs.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/cs.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Při zobrazování příspěvků nebo webových stránek:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Při zobrazování příspěvků nebo webových stránek:";
 
-/* Class = "NSTextFieldCell"; title = "Písmo seznamu složek:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Písmo seznamu složek:";
 
-/* Class = "NSButtonCell"; title = "Vybrat…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Vybrat…";
 
-/* Class = "NSButtonCell"; title = "Zobrazovat v seznamu složek přizpůsobené ikonky"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Zobrazovat v seznamu složek přizpůsobené ikonky";
 
-/* Class = "NSTextFieldCell"; title = "Písmo seznamu příspěvků:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Písmo seznamu příspěvků:";
 
-/* Class = "NSTextFieldCell"; title = "(ukázka)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(ukázka)";
-
-/* Class = "NSTextFieldCell"; title = "(ukázka)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(ukázka)";
-
-/* Class = "NSButtonCell"; title = "Vybrat…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Vybrat…";
 
-/* Class = "NSButtonCell"; title = "Nepoužívat menší velikost písem než:"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Nepoužívat menší velikost písem než:";

--- a/Interfaces/cs.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/cs.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Vysypat koš"; ObjectID = "5"; */
-"5.title" = "Vysypat koš";
-
-/* Class = "NSButtonCell"; title = "Vysypat koš"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Vysypat koš";
 
-/* Class = "NSButtonCell"; title = "Nevysypávat"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Nevysypávat";
 
-/* Class = "NSTextFieldCell"; title = "V koši jsou smazané příspěvky. Chcete před ukončením programu vysypat koš?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "V koši jsou smazané příspěvky. Chcete před ukončením programu vysypat koš?";
 
-/* Class = "NSButtonCell"; title = "Příště nezobrazovat"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Příště nezobrazovat";

--- a/Interfaces/cs.lproj/FeedCredentials.strings
+++ b/Interfaces/cs.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Zrušit"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Zrušit";
 
-/* Class = "NSTextFieldCell"; title = "Jméno:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Jméno:";
 
-/* Class = "NSTextFieldCell"; title = "Přístup k položce %@ vyžaduje poskytnutí přihlašovacích údajů"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Přístup k položce %@ vyžaduje poskytnutí přihlašovacích údajů";
 
-/* Class = "NSTextFieldCell"; title = "Heslo:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Heslo:";
 
-/* Class = "NSButtonCell"; title = "Přihlásit se"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Přihlásit se";
 
-/* Class = "NSTextFieldCell"; title = "Zadané uživatelské jméno a heslo bude uchováno pro příští obnovení tohoto odebírání."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Zadané uživatelské jméno a heslo bude uchováno pro příští obnovení tohoto odebírání.";

--- a/Interfaces/cs.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/cs.lproj/GeneralPreferencesView.strings
@@ -1,108 +1,83 @@
-
-/* Class = "NSMenuItem"; title = "Každých 15 minut"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Každých 15 minut";
 
-/* Class = "NSButtonCell"; title = "Po příkazu „Další nečtený“"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Po příkazu „Další nečtený“";
 
-/* Class = "NSMenuItem"; title = "(cesta)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(cesta)";
-
-/* Class = "NSMenuItem"; title = "Každých 30 minut"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Každých 30 minut";
 
-/* Class = "NSMenuItem"; title = "Každé dvě hodiny"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Každé dvě hodiny";
 
-/* Class = "NSButtonCell"; title = "Zobrazit počet nepřečtených položek na ikoně aplikace"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Zobrazit počet nepřečtených položek na ikoně aplikace";
 
-/* Class = "NSTextFieldCell"; title = "Po přijmutí nových nepřečtených příspěvků:"; ObjectID = "BbI-0A-zEG"; */
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
 "BbI-0A-zEG.title" = "Po přijmutí nových nepřečtených příspěvků:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Jiná…"; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Jiná…";
 
-/* Class = "NSMenuItem"; title = "Žádná"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Žádná";
-
-/* Class = "NSButtonCell"; title = "Ověřovat nové aktualizace programu Vienna při spouštění"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Ověřovat nové aktualizace programu Vienna při spouštění";
 
-/* Class = "NSMenuItem"; title = "Manuálně"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manuálně";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Každých šest hodin"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Každých šest hodin";
 
-/* Class = "NSButtonCell"; title = "Po krátké prodlevě"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Po krátké prodlevě";
 
-/* Class = "NSButtonCell"; title = "Zobrazit v řádku nabídek"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Zobrazit v řádku nabídek";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Otvírat odkazy v externím prohlížeči"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Otvírat odkazy v externím prohlížeči";
 
-/* Class = "NSTextFieldCell"; title = "Ověřovat nové položky:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Ověřovat nové položky:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Složka pro zkopírované soubory:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Složka pro zkopírované soubory:";
 
-/* Class = "NSButtonCell"; title = "Upozornit poskakováním ikony aplikace"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Upozornit poskakováním ikony aplikace";
 
-/* Class = "NSMenuItem"; title = "Každé tři hodiny"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Každé tři hodiny";
 
-/* Class = "NSTextFieldCell"; title = "Přesunout příspěvky do koše:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Přesunout příspěvky do koše:";
 
-/* Class = "NSTextFieldCell"; title = "Výchozí aplikace pro RSS:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Výchozí aplikace pro RSS:";
 
-/* Class = "NSButtonCell"; title = "Označit aktualizované příspěvky jako nové"; ObjectID = "meo-78-YOl"; */
+/* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Označit aktualizované příspěvky jako nové";
 
-/* Class = "NSMenuItem"; title = "Každých 5 minut"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Každých 5 minut";
 
-/* Class = "NSButtonCell"; title = "Ověřovat nové příspěvky po spuštění"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Ověřovat nové příspěvky po spuštění";
 
-/* Class = "NSButtonCell"; title = "Otvírat nové odkazy v pozadí"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Otvírat nové odkazy v pozadí";
 
-/* Class = "NSTextFieldCell"; title = "Aktualizace:"; ObjectID = "qeb-at-hYb"; */
+/* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
 "qeb-at-hYb.title" = "Aktualizace:";
 
-/* Class = "NSButtonCell"; title = "Zahrnout anonymní systémový profil"; ObjectID = "qno-Cg-EkC"; */
+/* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Zahrnout anonymní systémový profil";
 
-/* Class = "NSTextFieldCell"; title = "Označit stávající příspěvky jako čtené:"; ObjectID = "sCl-hz-PFF"; */
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
 "sCl-hz-PFF.title" = "Označit stávající příspěvky jako čtené:";
 
-/* Class = "NSMenuItem"; title = "Každou hodinu"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Každou hodinu";

--- a/Interfaces/cs.lproj/GroupFolder.strings
+++ b/Interfaces/cs.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Nová skupinová složka"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nová skupinová složka";
 
-/* Class = "NSButtonCell"; title = "Vytvořit"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Vytvořit";
 
-/* Class = "NSButtonCell"; title = "Zrušit"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Zrušit";
 
-/* Class = "NSTextFieldCell"; title = "Zadejte jméno skupinové složky:"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Zadejte jméno skupinové složky:";

--- a/Interfaces/cs.lproj/InfoWindow.strings
+++ b/Interfaces/cs.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Okno"; ObjectID = "5"; */
-"5.title" = "Okno";
-
-/* Class = "NSTextFieldCell"; title = "(jméno složky)"; ObjectID = "104"; */
-"104.title" = "(jméno složky)";
-
-/* Class = "NSTextFieldCell"; title = "Obnoveno:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Obnoveno:";
 
-/* Class = "NSTextFieldCell"; title = "(datum poslední obnovy)"; ObjectID = "106"; */
-"106.title" = "(datum poslední obnovy)";
-
-/* Class = "NSButtonCell"; title = "Zkontrolovat"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Zkontrolovat";
 
-/* Class = "NSButtonCell"; title = "URL zdroje:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL zdroje";
-
-/* Class = "NSTextFieldCell"; title = "Jméno:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Jméno:";
 
-/* Class = "NSTextFieldCell"; title = "Heslo:"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Heslo:";
 
-/* Class = "NSButtonCell"; title = "Automaticky aktualizovat"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Automaticky aktualizovat";
 
-/* Class = "NSButtonCell"; title = "Ověření totožnosti:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Ověření totožnosti";
-
-/* Class = "NSTextFieldCell"; title = "Velikost:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Velikost:";
 
-/* Class = "NSTextFieldCell"; title = "Nečteno:"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Nečteno:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Odebíráno"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Odebíráno";
-
-/* Class = "NSButtonCell"; title = "Obecné:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Obecné";
-
-/* Class = "NSButtonCell"; title = "Popis:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "Popis";
 
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Load Full HTML Articles";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "Popis";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Ověření totožnosti";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Obecné";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL zdroje";

--- a/Interfaces/cs.lproj/MainMenu.strings
+++ b/Interfaces/cs.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Převést vše do popředí";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Opakovat akci";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Pravopis";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Pravopis";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Pravopis…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Ověřit pravopis";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Ověřovat pravopis při psaní";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Přepnout velikost";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Obnovit vybraná odebírání";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Autorská práva";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nové odebírání…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportovat vybraná odebírání";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna - webové sídlo";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Vysypat koš";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Předchozí panel";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Rozvržení";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Standardní";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Kompaktní";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Zkopírovat přílohu";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Přizpůsobit řádek nástrojů…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Skrýt stavový řádek";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Zachovat v exportovaném souboru skupiny složek";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Pravopis";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Označit jako čtené";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/cs.lproj/MainMenu.strings
+++ b/Interfaces/cs.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Okno";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Skrýt stavový řádek";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Zobrazit řádek filtru";

--- a/Interfaces/cs.lproj/RSSFeed.strings
+++ b/Interfaces/cs.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "Zdroj RSS"; ObjectID = "6"; */
-"6.title" = "Zdroj RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "Zdroj RSS"; ObjectID = "49"; */
-"49.title" = "Zdroj RSS";
-
-/* Class = "NSButtonCell"; title = "Zrušit"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Zrušit";
 
-/* Class = "NSButtonCell"; title = "Odebírat"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Odebírat";
 
-/* Class = "NSTextFieldCell"; title = "Zdroj:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Zdroj:";
 
-/* Class = "NSTextFieldCell"; title = "Vytvořit nové odebírání"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Vytvořit nové odebírání";
 
-/* Class = "NSTextFieldCell"; title = "Níže zadejte adresu novinek, které chcete odebírat, nebo vyberte ze seznamu zdroj novinek a zadejte jméno uživatele dané služby."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Níže zadejte adresu novinek, které chcete odebírat, nebo vyberte ze seznamu zdroj novinek a zadejte jméno uživatele dané služby.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Uložit"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Uložit";
 
-/* Class = "NSButtonCell"; title = "Zrušit"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Zrušit";
 
-/* Class = "NSTextFieldCell"; title = "Upravit odebírání"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Upravit odebírání";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/cs.lproj/SearchFolder.strings
+++ b/Interfaces/cs.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Zde budou textová pole"; ObjectID = "33"; */
-"33.title" = "Zde budou textová pole";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Zde budou operátory"; ObjectID = "56"; */
-"56.title" = "Zde budou operátory";
-
-/* Class = "NSMenuItem"; title = "Nic"; ObjectID = "62"; */
-"62.title" = "Nic";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nic"; ObjectID = "82"; */
-"82.title" = "Nic";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Jméno dynamické složky:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Jméno dynamické složky:";
 
-/* Class = "NSButtonCell"; title = "Uložit"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Uložit";
 
-/* Class = "NSButtonCell"; title = "Zrušit"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Zrušit";
 
-/* Class = "NSTextFieldCell"; title = "Zobrazit příspěvky odpovídající"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Zobrazit příspěvky odpovídající";
 
-/* Class = "NSTextFieldCell"; title = "následujícím shodám:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "následujícím shodám:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/cs.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/cs.lproj/SyncingPreferencesView.strings
@@ -1,35 +1,22 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Zástupce pro vysvětlení specifická pro daný server"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Zástupce pro vysvětlení specifická pro daný server";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
-/* Class = "NSButton"; ibExternalAccessibilityDescription = "Navštívit webovou stránku"; ObjectID = "Ar5-Qc-YTe"; */
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Navštívit webovou stránku";
 
-/* Class = "NSButton"; ibShadowedToolTip = "Navštívit webovou stránku"; ObjectID = "Ar5-Qc-YTe"; */
+/* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Navštívit webovou stránku";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
-/* Class = "NSButtonCell"; title = "Synchronizovat s Open Reader serverem"; ObjectID = "Lkv-md-rEW"; */
+/* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Synchronizovat s Open Reader serverem";
 
-/* Class = "NSTextFieldCell"; title = "Heslo:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Heslo:";
 
-/* Class = "NSTextFieldCell"; title = "Jméno:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Jméno:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Vyberte server podporující Open Reader API"; ObjectID = "kM0-7a-obO"; */
+/* Class = "NSTextField"; ibShadowedToolTip = "Select a server supporting the Open Reader API"; ObjectID = "kM0-7a-obO"; */
 "kM0-7a-obO.ibShadowedToolTip" = "Vyberte server podporující Open Reader API";
 
 /* Class = "NSTextFieldCell"; title = "URL: https://"; ObjectID = "tec-2d-Xej"; */
@@ -38,8 +25,8 @@
 /* Class = "NSTextFieldCell"; title = "Server:"; ObjectID = "uTl-XE-0ym"; */
 "uTl-XE-0ym.title" = "Server:";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Adresa serveru podporujícího Open Reader API"; ObjectID = "vZE-Pl-S9H"; */
+/* Class = "NSTextField"; ibShadowedToolTip = "Address of a server supporting the Open Reader API"; ObjectID = "vZE-Pl-S9H"; */
 "vZE-Pl-S9H.ibShadowedToolTip" = "Adresa serveru podporujícího Open Reader API";
 
-/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Vyberte server podporující Open Reader API"; ObjectID = "zAy-oc-zmb"; */
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Select a server supporting the Open Reader API"; ObjectID = "zAy-oc-zmb"; */
 "zAy-oc-zmb.ibExternalAccessibilityDescription" = "Vyberte server podporující Open Reader API";

--- a/Interfaces/da.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/da.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Når der læses artikler eller hjemmesider:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Når der læses artikler eller hjemmesider:";
 
-/* Class = "NSTextFieldCell"; title = "Mappeliste skrifttype:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Mappeliste skrifttype:";
 
-/* Class = "NSButtonCell"; title = "Vælg…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Vælg…";
 
-/* Class = "NSButtonCell"; title = "Vis mappeikoner i mappeliste"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Vis mappeikoner i mappeliste";
 
-/* Class = "NSTextFieldCell"; title = "Artikelliste skrifttype:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Artikelliste skrifttype:";
 
-/* Class = "NSTextFieldCell"; title = "(Prøve)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Prøve)";
-
-/* Class = "NSTextFieldCell"; title = "(Prøve)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Prøve)";
-
-/* Class = "NSButtonCell"; title = "Vælg…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Vælg…";
 
-/* Class = "NSButtonCell"; title = "Brug aldrig en skrifttype mindre end"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Brug aldrig en skrifttype mindre end";

--- a/Interfaces/da.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/da.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Empty Trash"; ObjectID = "5"; */
-"5.title" = "Empty Trash";
-
-/* Class = "NSButtonCell"; title = "Tøm Papirkurven"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Tøm Papirkurven";
 
-/* Class = "NSButtonCell"; title = "Tøm ikke Papirkurven"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Tøm ikke Papirkurven";
 
-/* Class = "NSTextFieldCell"; title = "Der er slettede artikler i Papirkurven.\nVil du tømme Papirkurven før du afslutter?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Der er slettede artikler i Papirkurven. Vil du tømme Papirkurven før du afslutter?";
 
-/* Class = "NSButtonCell"; title = "Vis ikke denne advarsel igen"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Vis ikke denne advarsel igen";

--- a/Interfaces/da.lproj/FeedCredentials.strings
+++ b/Interfaces/da.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Afbryd"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Afbryd";
 
-/* Class = "NSTextFieldCell"; title = "Navn:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Navn:";
 
-/* Class = "NSTextFieldCell"; title = "Adgang til &@ kræver at du giver dine log ind detaljer"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Adgang til &@ kræver at du giver dine log ind detaljer";
 
-/* Class = "NSTextFieldCell"; title = "Kodeord:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Kodeord:";
 
-/* Class = "NSButtonCell"; title = "Log ind"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Log ind";
 
-/* Class = "NSTextFieldCell"; title = "Brugernavnet og kodeordet du skal angive vil blive husket til næste gang du opdaterer dette abonnement."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Brugernavnet og kodeordet du skal angive vil blive husket til næste gang du opdaterer dette abonnement.";

--- a/Interfaces/da.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/da.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "Hver 15 minutter"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Hver 15 minutter";
 
-/* Class = "NSButtonCell"; title = "Efter \"Næste ulæste\" kommando"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Efter \"Næste ulæste\" kommando";
 
-/* Class = "NSMenuItem"; title = "(Sti)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Sti)";
-
-/* Class = "NSMenuItem"; title = "Hver 30 minutter"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Hver 30 minutter";
 
-/* Class = "NSMenuItem"; title = "Hver 2 timer"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Hver 2 timer";
 
-/* Class = "NSButtonCell"; title = "Vis antallet af ulæste artikler på programikonet"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Vis antallet af ulæste artikler på programikonet";
 
-/* Class = "NSTextFieldCell"; title = "Når nye ulæste artikler er modtaget:"; ObjectID = "BbI-0A-zEG"; */
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
 "BbI-0A-zEG.title" = "Når nye ulæste artikler er modtaget:";
 
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Andet..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Andet...";
 
-/* Class = "NSMenuItem"; title = "Intet"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Intet";
-
-/* Class = "NSButtonCell"; title = "Tjek for nyere versioner af Vienna ved opstart"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Tjek for nyere versioner af Vienna ved opstart";
 
-/* Class = "NSMenuItem"; title = "Manuelt"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manuelt";
 
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Hver 6 timer"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Hver 6 timer";
 
-/* Class = "NSButtonCell"; title = "Efter et kort øjeblik"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Efter et kort øjeblik";
 
 /* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Show in menu bar";
 
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "AndreOversigter";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
-
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "AndreOversigter";
-
-/* Class = "NSButtonCell"; title = "Åben henvisninger i ekstern browser"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Åben henvisninger i ekstern browser";
 
-/* Class = "NSTextFieldCell"; title = "Tjek for nye artikler:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Tjek for nye artikler:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Gem hentede filer i:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Gem hentede filer i:";
 
-/* Class = "NSButtonCell"; title = "Hop programikonet"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Hop programikonet";
 
-/* Class = "NSMenuItem"; title = "Hver 3 timer"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Hver 3 timer";
 
-/* Class = "NSTextFieldCell"; title = "Flyt artikler til Papirkurven:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Flyt artikler til Papirkurven:";
 
-/* Class = "NSTextFieldCell"; title = "Standard RSS Reader"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Standard RSS Reader";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "Hver 5 minutter"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Hver 5 minutter";
 
-/* Class = "NSButtonCell"; title = "Tjek for nye artikler ved opstart"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Tjek for nye artikler ved opstart";
 
-/* Class = "NSButtonCell"; title = "Åben nye henvisninger i baggrunden"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Åben nye henvisninger i baggrunden";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Mark current article read:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Mark current article read:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Mark current article read:";
 
-/* Class = "NSMenuItem"; title = "Hver time"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Hver time";

--- a/Interfaces/da.lproj/GroupFolder.strings
+++ b/Interfaces/da.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Ny gruppemappe"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Ny gruppemappe";
 
-/* Class = "NSButtonCell"; title = "Gem"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Gem";
 
-/* Class = "NSButtonCell"; title = "Afbryd"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Afbryd";
 
-/* Class = "NSTextFieldCell"; title = "Indtast navn på gruppemappe:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Indtast navn på gruppemappe:";

--- a/Interfaces/da.lproj/InfoWindow.strings
+++ b/Interfaces/da.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Vindue"; ObjectID = "5"; */
-"5.title" = "Vindue";
-
-/* Class = "NSTextFieldCell"; title = "(Mappenavn)"; ObjectID = "104"; */
-"104.title" = "(Mappenavn)";
-
-/* Class = "NSTextFieldCell"; title = "Sidst opdateret:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Sidst opdateret:";
 
-/* Class = "NSTextFieldCell"; title = "(Sidste opdateringsdato)"; ObjectID = "106"; */
-"106.title" = "(Sidste opdateringsdato)";
-
-/* Class = "NSButtonCell"; title = "Godkend"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Godkend";
 
-/* Class = "NSButtonCell"; title = "Feed URL:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "Feed URL";
-
-/* Class = "NSTextFieldCell"; title = "Brugernavn:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Brugernavn:";
 
-/* Class = "NSTextFieldCell"; title = "Kodeord:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Kodeord:";
 
-/* Class = "NSButtonCell"; title = "Opdater autorisering"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Opdater autorisering";
 
-/* Class = "NSButtonCell"; title = "Autorisering:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autorisering";
-
-/* Class = "NSTextFieldCell"; title = "Størrelse:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Størrelse:";
 
-/* Class = "NSTextFieldCell"; title = "Ulæst:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Ulæst:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Abonneret"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Abonneret";
 
-/* Class = "NSButtonCell"; title = "Generelt:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Generelt";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Hent fulde HTML-artikler";
 
-/* Class = "NSButtonCell"; title = "Beskrivelse:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Beskrivelse";
 
-/* Class = "NSButtonCell"; title = "Hent fulde HTML-artikler"; ObjectID = "126"; */
-"126.title" = "Hent fulde HTML-artikler";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autorisering";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Generelt";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "Feed URL";

--- a/Interfaces/da.lproj/MainMenu.strings
+++ b/Interfaces/da.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Anbring alle forrest";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Gentag";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Stavekontrol";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Stavekontrol";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Stavekontrol…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Udfør stavekontrol";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Løbende stavekontrol";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoom";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Opdater valgte abonnementer";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Tak til";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nyt abonnement…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Eksporter valgte abonnementer";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna hjemmeside";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Tøm Papirkurv";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Foregående fane";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Layout";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Rapporter";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Sammenfattet";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Hent indpakning";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Indstil værktøjslinie…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Gem statusbaren";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Navn";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Bevar gruppemapper i den eksporterede fil";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Stavekontrol";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Marker som læst";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/da.lproj/MainMenu.strings
+++ b/Interfaces/da.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Vindue";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "HovedMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Gem statusbaren";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Vis filterbaren";

--- a/Interfaces/da.lproj/RSSFeed.strings
+++ b/Interfaces/da.lproj/RSSFeed.strings
@@ -1,39 +1,29 @@
-
-/* Class = "NSWindow"; title = "RSS-Feed"; ObjectID = "6"; */
-"6.title" = "RSS-Feed";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS-Feed"; ObjectID = "49"; */
-"49.title" = "RSS-Feed";
-
-/* Class = "NSButtonCell"; title = "Afbryd"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Afbryd";
 
-/* Class = "NSButtonCell"; title = "Abonner"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Abonner";
 
-/* Class = "NSTextFieldCell"; title = "Kilde:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Kilde:";
 
-/* Class = "NSTextFieldCell"; title = "Lav nyt abonnement"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Lav nyt abonnement";
 
-/* Class = "NSTextFieldCell"; title = "Indtast henvisningen for nyhedsfeedet forneden. Eller vælg fra kildelisten for at indtaste et genvejsnavn for nyhedsfeedet udgivet af kilden."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Indtast henvisningen for nyhedsfeedet forneden. Eller vælg fra kildelisten for at indtaste et genvejsnavn for nyhedsfeedet udgivet af kilden.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Gem"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Gem";
 
-/* Class = "NSButtonCell"; title = "Afbryd"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Afbryd";
 
-/* Class = "NSTextFieldCell"; title = "Rediger abonnement"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Rediger abonnement";
 
-/* Class = "NSButtonCell"; title = "Abonner i Open Reader"; ObjectID = "116"; */
+/* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */
 "116.title" = "Abonner i Open Reader";

--- a/Interfaces/da.lproj/SearchFolder.strings
+++ b/Interfaces/da.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "32"; */
-"32.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Felt navne her"; ObjectID = "33"; */
-"33.title" = "Felt navne her";
-
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "34"; */
-"34.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Operatorer her"; ObjectID = "56"; */
-"56.title" = "Operatorer her";
-
-/* Class = "NSMenuItem"; title = "Intet"; ObjectID = "62"; */
-"62.title" = "Intet";
-
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "64"; */
-"64.title" = "AndreOversigter";
-
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "74"; */
-"74.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Emne3"; ObjectID = "75"; */
-"75.title" = "Emne3";
-
-/* Class = "NSMenuItem"; title = "Emne2"; ObjectID = "76"; */
-"76.title" = "Emne2";
-
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "80"; */
-"80.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Intet"; ObjectID = "82"; */
-"82.title" = "Intet";
-
-/* Class = "NSMenu"; title = "AndreOversigter"; ObjectID = "87"; */
-"87.title" = "AndreOversigter";
-
-/* Class = "NSMenuItem"; title = "Emne1"; ObjectID = "88"; */
-"88.title" = "Emne1";
-
-/* Class = "NSMenuItem"; title = "Emne3"; ObjectID = "89"; */
-"89.title" = "Emne3";
-
-/* Class = "NSMenuItem"; title = "Emne2"; ObjectID = "90"; */
-"90.title" = "Emne2";
-
-/* Class = "NSTextFieldCell"; title = "Smartmappenavn:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Smartmappenavn:";
 
-/* Class = "NSButtonCell"; title = "Gem"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Gem";
 
-/* Class = "NSButtonCell"; title = "Afbryd"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Afbryd";
 
-/* Class = "NSTextFieldCell"; title = "Vis alle artikler som matcher"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Vis alle artikler som matcher";
 
-/* Class = "NSTextFieldCell"; title = "under følgende forhold:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "under følgende forhold:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/da.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/da.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Kodeord:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Kodeord:";
 
-/* Class = "NSTextFieldCell"; title = "Navn:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Navn:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/de.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/de.lproj/AdvancedPreferencesView.strings
@@ -1,42 +1,38 @@
-
-/* Class = "NSTextFieldCell"; title = "Je höher die Zahl desto schneller werden die Abonnements herunter geladen."; ObjectID = "2GQ-cu-fbh"; */
+/* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "Je höher die Zahl desto schneller werden die Abonnements herunter geladen.";
 
-/* Class = "NSTextFieldCell"; title = "Diese Einstellungen muss man für den normalen Betrieb von Vienna normalerweise nicht ändern. Bitte schauen Sie in die Hilfedatei für weitere Informationen zu den einzelnen Einstellungen."; ObjectID = "GaX-8c-QaN"; */
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
 "GaX-8c-QaN.title" = "Diese Einstellungen muss man für den normalen Betrieb von Vienna normalerweise nicht ändern. Bitte schauen Sie in die Hilfedatei für weitere Informationen zu den einzelnen Einstellungen.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
-/* Class = "NSTextFieldCell"; title = "Gleichzeitige Downloads:"; ObjectID = "Ngw-hP-yW4"; */
+/* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
 "Ngw-hP-yW4.title" = "Gleichzeitige Downloads:";
 
-/* Class = "NSTextFieldCell"; title = "Höhere Zahlen werden den Computer jedoch während des Aktualisierungsvorgangs langsamer machen."; ObjectID = "S3T-cW-hys"; */
+/* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "Höhere Zahlen werden den Computer jedoch während des Aktualisierungsvorgangs langsamer machen.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
-/* Class = "NSButtonCell"; title = "Aktiviere Plugins im internen Browser"; ObjectID = "fIz-4t-Ogg"; */
+/* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Aktiviere Plugins im internen Browser";
 
-/* Class = "NSButtonCell"; title = "Aktiviere JavaScript im internen Browser"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Aktiviere JavaScript im internen Browser";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/de.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/de.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Beim Betrachten von Artikeln oder Webseiten:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Beim Betrachten von Artikeln oder Webseiten:";
 
-/* Class = "NSTextFieldCell"; title = "Ordnerliste:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Ordnerliste:";
 
-/* Class = "NSButtonCell"; title = "Auswählen…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Auswählen…";
 
-/* Class = "NSButtonCell"; title = "Abonnementenicons anzeigen"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Abonnementenicons anzeigen";
 
-/* Class = "NSTextFieldCell"; title = "Artikelliste:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Artikelliste:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Auswählen…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Auswählen…";
 
-/* Class = "NSButtonCell"; title = "Keine Schriftgrößen verwenden, die kleiner sind als"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Keine Schriftgrößen verwenden, die kleiner sind als";

--- a/Interfaces/de.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/de.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Empty Trash"; ObjectID = "5"; */
-"5.title" = "Empty Trash";
-
-/* Class = "NSButtonCell"; title = "Papierkorb leeren"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Papierkorb leeren";
 
-/* Class = "NSButtonCell"; title = "Papierkorb NICHT leeren"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Papierkorb NICHT leeren";
 
-/* Class = "NSTextFieldCell"; title = "Es gibt noch gelöschte Artikel im Papierkorb.\nMöchten Sie den Papierkorb vor Beenden leeren?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Es gibt noch gelöschte Artikel im Papierkorb. Möchten Sie den Papierkorb vor Beenden leeren?";
 
-/* Class = "NSButtonCell"; title = "Diese Warnung nicht mehr anzeigen"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Diese Warnung nicht mehr anzeigen";

--- a/Interfaces/de.lproj/FeedCredentials.strings
+++ b/Interfaces/de.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Abbrechen"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Abbrechen";
 
-/* Class = "NSTextFieldCell"; title = "Benutzername:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Benutzername:";
 
-/* Class = "NSTextFieldCell"; title = "Der Zugriff auf %@ benötigt Benutzerdaten von Ihnen"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Der Zugriff auf %@ benötigt Benutzerdaten von Ihnen";
 
-/* Class = "NSTextFieldCell"; title = "Passwort:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Passwort:";
 
-/* Class = "NSButtonCell"; title = "Anmelden"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Anmelden";
 
-/* Class = "NSTextFieldCell"; title = "Die Benutzerdaten werden für die nächsten Aktualisierungen des Abonnements gespeichert."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Die Benutzerdaten werden für die nächsten Aktualisierungen des Abonnements gespeichert.";

--- a/Interfaces/de.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/de.lproj/GeneralPreferencesView.strings
@@ -1,108 +1,83 @@
-
-/* Class = "NSMenuItem"; title = "alle 15 Minuten"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "alle 15 Minuten";
 
-/* Class = "NSButtonCell"; title = "Nach \"Nächster ungelesener Artikel\" Befehl"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Nach \"Nächster ungelesener Artikel\" Befehl";
 
-/* Class = "NSMenuItem"; title = "(Path)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Path)";
-
-/* Class = "NSMenuItem"; title = "alle 30 Minuten"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "alle 30 Minuten";
 
-/* Class = "NSMenuItem"; title = "alle 2 Stunden"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "alle 2 Stunden";
 
-/* Class = "NSButtonCell"; title = "Zeige die Anzahl der ungelesen Artikel im Docksymbol"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Zeige die Anzahl der ungelesen Artikel im Docksymbol";
 
-/* Class = "NSTextFieldCell"; title = "Wenn neue ungelesene Artikel empfangen wurden:"; ObjectID = "BbI-0A-zEG"; */
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
 "BbI-0A-zEG.title" = "Wenn neue ungelesene Artikel empfangen wurden:";
 
-/* Class = "NSMenu"; title = "Andere Ansichten"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "Andere Ansichten";
-
-/* Class = "NSMenuItem"; title = "Auswählen..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Auswählen...";
 
-/* Class = "NSMenuItem"; title = "Nichts"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Nichts";
-
-/* Class = "NSButtonCell"; title = "Beim Start nach neuer Vienna-Version suchen"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Beim Start nach neuer Vienna-Version suchen";
 
-/* Class = "NSMenuItem"; title = "nur manuell"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "nur manuell";
 
-/* Class = "NSMenu"; title = "Andere Ansichten"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "Andere Ansichten";
-
-/* Class = "NSMenuItem"; title = "alle 6 Stunden"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "alle 6 Stunden";
 
-/* Class = "NSButtonCell"; title = "Nach kurzer Zeit"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Nach kurzer Zeit";
 
-/* Class = "NSButtonCell"; title = "In der Menüleiste zeigen"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "In der Menüleiste zeigen";
 
-/* Class = "NSMenu"; title = "Andere Ansichten"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "Andere Ansichten";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
-
-/* Class = "NSButtonCell"; title = "Suche nach Betaversionen"; ObjectID = "OID-qF-Pp0"; */
+/* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Suche nach Betaversionen";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Öffne Links im externen Browser"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Öffne Links im externen Browser";
 
-/* Class = "NSTextFieldCell"; title = "Neue Artikel abrufen:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Neue Artikel abrufen:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Sichere geladene Dateien in:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Sichere geladene Dateien in:";
 
-/* Class = "NSButtonCell"; title = "Docksymbol animieren"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Docksymbol animieren";
 
-/* Class = "NSMenuItem"; title = "alle 3 Stunden"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "alle 3 Stunden";
 
-/* Class = "NSTextFieldCell"; title = "Bewege Artikel in den Papierkorb:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Bewege Artikel in den Papierkorb:";
 
-/* Class = "NSTextFieldCell"; title = "Standard RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Standard RSS Reader:";
 
-/* Class = "NSButtonCell"; title = "Markiere aktualisierte Artikel als Neu"; ObjectID = "meo-78-YOl"; */
+/* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Markiere aktualisierte Artikel als Neu";
 
-/* Class = "NSMenuItem"; title = "alle 5 Minuten"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "alle 5 Minuten";
 
-/* Class = "NSButtonCell"; title = "Neue Artikel beim Programmstart abrufen"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Neue Artikel beim Programmstart abrufen";
 
-/* Class = "NSButtonCell"; title = "Öffne Links im Hintergrund"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Öffne Links im Hintergrund";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
 "qeb-at-hYb.title" = "Updates:";
 
-/* Class = "NSButtonCell"; title = "Anonymisierten Systembericht senden"; ObjectID = "qno-Cg-EkC"; */
+/* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Anonymisierten Systembericht senden";
 
-/* Class = "NSTextFieldCell"; title = "Markiere aktuellen Artikel als gelesen:"; ObjectID = "sCl-hz-PFF"; */
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
 "sCl-hz-PFF.title" = "Markiere aktuellen Artikel als gelesen:";
 
-/* Class = "NSMenuItem"; title = "jede Stunde"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "jede Stunde";

--- a/Interfaces/de.lproj/GroupFolder.strings
+++ b/Interfaces/de.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Neuer Gruppenordner"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Neuer Gruppenordner";
 
-/* Class = "NSButtonCell"; title = "Erstellen"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Erstellen";
 
-/* Class = "NSButtonCell"; title = "Abbrechen"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Abbrechen";
 
-/* Class = "NSTextFieldCell"; title = "Geben Sie den Namen des Gruppenordners ein:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Geben Sie den Namen des Gruppenordners ein:";

--- a/Interfaces/de.lproj/InfoWindow.strings
+++ b/Interfaces/de.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Fenster"; ObjectID = "5"; */
-"5.title" = "Fenster";
-
-/* Class = "NSTextFieldCell"; title = "(Folder name)"; ObjectID = "104"; */
-"104.title" = "(Folder name)";
-
-/* Class = "NSTextFieldCell"; title = "Letzte Aktualisierung:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Letzte Aktualisierung:";
 
-/* Class = "NSTextFieldCell"; title = "(Last refresh date)"; ObjectID = "106"; */
-"106.title" = "(Last refresh date)";
-
-/* Class = "NSButtonCell"; title = "Überprüfen"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Überprüfen";
 
-/* Class = "NSButtonCell"; title = "Abonnementadresse:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "Abonnementadresse";
-
-/* Class = "NSTextFieldCell"; title = "Benutzername:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Benutzername:";
 
-/* Class = "NSTextFieldCell"; title = "Passwort:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Passwort:";
 
-/* Class = "NSButtonCell"; title = "Authentifizierung aktualisieren"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Authentifizierung aktualisieren";
 
-/* Class = "NSButtonCell"; title = "Authentifizierung:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Authentifizierung";
-
-/* Class = "NSTextFieldCell"; title = "Artikelanzahl:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Artikelanzahl:";
 
-/* Class = "NSTextFieldCell"; title = "Ungelesen:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Ungelesen:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Abonniert"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Abonniert";
 
-/* Class = "NSButtonCell"; title = "Allgemein:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Allgemein";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Ganze Webseite sofort anzeigen";
 
-/* Class = "NSButtonCell"; title = "Beschreibung:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Beschreibung";
 
-/* Class = "NSButtonCell"; title = "Ganze Webseite sofort anzeigen"; ObjectID = "126"; */
-"126.title" = "Ganze Webseite sofort anzeigen";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Authentifizierung";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Allgemein";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "Abonnementadresse";

--- a/Interfaces/de.lproj/MainMenu.strings
+++ b/Interfaces/de.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Alle nach vorne bringen";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Wiederholen";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Rechtschreibung";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Rechtschreibung";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Rechtschreibung……";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Rechtschreibprüfung";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Während der Texteingabe prüfen";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoomen";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Ausgewähltes Abonnement aktualisieren";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Danksagungen";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Neues Abonnement…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportiere ausgewählte Abonnements";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna Webseite";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Papierkorb leeren";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Vorheriger Tab";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Layout";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Horizontal";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Vertikal";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,17 +319,11 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Anhang herunterladen";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Symbolleiste anpassen…";
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Statusleiste ausblenden";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -383,23 +349,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name (alphabetisch)";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Gruppen in der exportierten Datei beibehalten";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -431,8 +385,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Indiziere Datenbank";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Rechtschreibung";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Als gelesen markieren";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/de.lproj/MainMenu.strings
+++ b/Interfaces/de.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Fenster";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "Hauptmenü";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -324,12 +321,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Statusleiste ausblenden";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Filter-Leiste anzeigen";

--- a/Interfaces/de.lproj/RSSFeed.strings
+++ b/Interfaces/de.lproj/RSSFeed.strings
@@ -1,39 +1,29 @@
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "6"; */
-"6.title" = "RSS Feed";
-
-/* Class = "NSMenuItem"; title = "Adresse"; ObjectID = "45"; */
-"45.title" = "Adresse";
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "49"; */
-"49.title" = "RSS Feed";
-
-/* Class = "NSButtonCell"; title = "Abbrechen"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Abbrechen";
 
-/* Class = "NSButtonCell"; title = "Abonnieren"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Abonnieren";
 
-/* Class = "NSTextFieldCell"; title = "Quelle:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Quelle:";
 
-/* Class = "NSTextFieldCell"; title = "Ein neues Abonnement erstellen"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Ein neues Abonnement erstellen";
 
-/* Class = "NSTextFieldCell"; title = "Geben Sie den Link für das Abonnement ein oder wählen Sie eine Quelle aus der Liste."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Geben Sie den Link für das Abonnement ein oder wählen Sie eine Quelle aus der Liste.";
 
-/* Class = "NSTextFieldCell"; title = "Adresse:"; ObjectID = "110"; */
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "Adresse:";
 
-/* Class = "NSButtonCell"; title = "Speichern"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Speichern";
 
-/* Class = "NSButtonCell"; title = "Abbrechen"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Abbrechen";
 
-/* Class = "NSTextFieldCell"; title = "Abonnement bearbeiten"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Abonnement bearbeiten";
 
-/* Class = "NSButtonCell"; title = "Im Open Reader abonnieren"; ObjectID = "116"; */
+/* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */
 "116.title" = "Im Open Reader abonnieren";

--- a/Interfaces/de.lproj/SearchFolder.strings
+++ b/Interfaces/de.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Field names go here"; ObjectID = "33"; */
-"33.title" = "Field names go here";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "62"; */
-"62.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "keiner"; ObjectID = "82"; */
-"82.title" = "keiner";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Name des intelligenten Ordners:\n"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Name des intelligenten Ordners:";
 
-/* Class = "NSButtonCell"; title = "OK"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "OK";
 
-/* Class = "NSButtonCell"; title = "Abbrechen"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Abbrechen";
 
-/* Class = "NSTextFieldCell"; title = "Enthält Artikel mit"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Enthält Artikel mit";
 
-/* Class = "NSTextFieldCell"; title = "der folgenden Eigenschaften"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "der folgenden Eigenschaften";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/de.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/de.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
-/* Class = "NSButtonCell"; title = "Synchronisiere mit einem Open Reader Server"; ObjectID = "Lkv-md-rEW"; */
+/* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Synchronisiere mit einem Open Reader Server";
 
-/* Class = "NSTextFieldCell"; title = "Passwort:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Passwort:";
 
-/* Class = "NSTextFieldCell"; title = "Benutzername:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Benutzername:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/es.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/es.lproj/AdvancedPreferencesView.strings
@@ -1,42 +1,38 @@
-
-/* Class = "NSTextFieldCell"; title = "Cuanto mayor sea el número, las suscripciones se descargarán más rápidamente."; ObjectID = "2GQ-cu-fbh"; */
+/* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "Cuanto mayor sea el número, las suscripciones se descargarán más rápidamente.";
 
-/* Class = "NSTextFieldCell"; title = "Estos ajustes no se deberían modificar por un usuario normal de Vienna. Consulte el archivo de ayuda para obtener detalles de cada ajuste.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Estos ajustes no se deberían modificar por un usuario normal de Vienna. Consulte el archivo de ayuda para obtener detalles de cada ajuste.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Estos ajustes no se deberían modificar por un usuario normal de Vienna. Consulte el archivo de ayuda para obtener detalles de cada ajuste.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
-/* Class = "NSTextFieldCell"; title = "Descargas simultáneas:"; ObjectID = "Ngw-hP-yW4"; */
+/* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
 "Ngw-hP-yW4.title" = "Descargas simultáneas:";
 
-/* Class = "NSTextFieldCell"; title = "Sin embargo, cuanto mayor sea el número su equipo proporciona una menor respuesta al actualizar las fuentes."; ObjectID = "S3T-cW-hys"; */
+/* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "Sin embargo, cuanto mayor sea el número su equipo proporciona una menor respuesta al actualizar las fuentes.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
-/* Class = "NSButtonCell"; title = "Activar plugins en el navegador integrado"; ObjectID = "fIz-4t-Ogg"; */
+/* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Activar plugins en el navegador integrado";
 
-/* Class = "NSButtonCell"; title = "Activar JavaScript en el navegador integrado"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Activar JavaScript en el navegador integrado";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/es.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/es.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Al ver artículos o páginas web:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Al ver artículos o páginas web:";
 
-/* Class = "NSTextFieldCell"; title = "Lista de carpetas:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Lista de carpetas:";
 
-/* Class = "NSButtonCell"; title = "Seleccionar…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Seleccionar…";
 
-/* Class = "NSButtonCell"; title = "Mostrar iconos de las fuentes en la lista de carpetas"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Mostrar iconos de las fuentes en la lista de carpetas";
 
-/* Class = "NSTextFieldCell"; title = "Lista de artículos:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Lista de artículos:";
 
-/* Class = "NSTextFieldCell"; title = "(Ejemplo)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Ejemplo)";
-
-/* Class = "NSTextFieldCell"; title = "(Ejemplo)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Ejemplo)";
-
-/* Class = "NSButtonCell"; title = "Seleccionar…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Seleccionar…";
 
-/* Class = "NSButtonCell"; title = "No usar fuentes más pequeñas de:"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "No usar fuentes más pequeñas de:";

--- a/Interfaces/es.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/es.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Vaciar papelera"; ObjectID = "5"; */
-"5.title" = "Vaciar papelera";
-
-/* Class = "NSButtonCell"; title = "Vaciar papelera"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Vaciar papelera";
 
-/* Class = "NSButtonCell"; title = "No vaciar papelera"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "No vaciar papelera";
 
-/* Class = "NSTextFieldCell"; title = "Hay artículos eliminados en la papelera.\n¿Desea vaciar la papelera antes de salir?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Hay artículos eliminados en la papelera. ¿Desea vaciar la papelera antes de salir?";
 
-/* Class = "NSButtonCell"; title = "No volver a mostrar este mensaje"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "No volver a mostrar este mensaje";

--- a/Interfaces/es.lproj/FeedCredentials.strings
+++ b/Interfaces/es.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Nombre:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Nombre:";
 
-/* Class = "NSTextFieldCell"; title = "El acceso a %@ requiere que proporcione las credenciales de inicio de sesión."; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "El acceso a %@ requiere que proporcione las credenciales de inicio de sesión.";
 
-/* Class = "NSTextFieldCell"; title = "Contraseña:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Contraseña:";
 
-/* Class = "NSButtonCell"; title = "Iniciar sesión"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Iniciar sesión";
 
-/* Class = "NSTextFieldCell"; title = "El nombre de usuario y la contraseña serán recordados para la próxima vez que actualice esta suscripción."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "El nombre de usuario y la contraseña serán recordados para la próxima vez que actualice esta suscripción.";

--- a/Interfaces/es.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/es.lproj/GeneralPreferencesView.strings
@@ -1,108 +1,83 @@
-
-/* Class = "NSMenuItem"; title = "Cada 15 minutos"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Cada 15 minutos";
 
-/* Class = "NSButtonCell"; title = "Después del comando \"No leído siguiente\" "; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Después del comando \"No leído siguiente\" ";
 
-/* Class = "NSMenuItem"; title = "(Path)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Path)";
-
-/* Class = "NSMenuItem"; title = "Cada 30 minutos"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Cada 30 minutos";
 
-/* Class = "NSMenuItem"; title = "Cada 2 horas"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Cada 2 horas";
 
-/* Class = "NSButtonCell"; title = "Mostrar número de no leídos en el icono de la aplicación"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Mostrar número de no leídos en el icono de la aplicación";
 
-/* Class = "NSTextFieldCell"; title = "Cuando se recuperan nuevos artículos no leídos:"; ObjectID = "BbI-0A-zEG"; */
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
 "BbI-0A-zEG.title" = "Cuando se recuperan nuevos artículos no leídos:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Otra..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Otra...";
 
-/* Class = "NSMenuItem"; title = "Ninguno"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Ninguno";
-
-/* Class = "NSButtonCell"; title = "Buscar nuevas versiones de Vienna al inicio"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Buscar nuevas versiones de Vienna al inicio";
 
-/* Class = "NSMenuItem"; title = "Manualmente"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manualmente";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Cada 6 horas"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Cada 6 horas";
 
-/* Class = "NSButtonCell"; title = "Después de un breve instante"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Después de un breve instante";
 
-/* Class = "NSButtonCell"; title = "Mostrar en la barra de menús"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Mostrar en la barra de menús";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
-
-/* Class = "NSButtonCell"; title = "Buscar últimas versiones beta"; ObjectID = "OID-qF-Pp0"; */
+/* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Buscar últimas versiones beta";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Abrir enlaces en un navegador externo"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Abrir enlaces en un navegador externo";
 
-/* Class = "NSTextFieldCell"; title = "Buscar nuevos artículos:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Buscar nuevos artículos:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Guardar archivos descargados en:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Guardar archivos descargados en:";
 
-/* Class = "NSButtonCell"; title = "Animar icono de la aplicación"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Animar icono de la aplicación";
 
-/* Class = "NSMenuItem"; title = "Cada 3 horas"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Cada 3 horas";
 
-/* Class = "NSTextFieldCell"; title = "Mover artículos a la papelera:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Mover artículos a la papelera:";
 
-/* Class = "NSTextFieldCell"; title = "Lector RSS predeterminado:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Lector RSS predeterminado:";
 
-/* Class = "NSButtonCell"; title = "Marcar artículos actualizados como nuevos"; ObjectID = "meo-78-YOl"; */
+/* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Marcar artículos actualizados como nuevos";
 
-/* Class = "NSMenuItem"; title = "Cada 5 minutos"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Cada 5 minutos";
 
-/* Class = "NSButtonCell"; title = "Buscar nuevos artículos al inicio"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Buscar nuevos artículos al inicio";
 
-/* Class = "NSButtonCell"; title = "Abrir nuevos enlaces en segundo plano"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Abrir nuevos enlaces en segundo plano";
 
-/* Class = "NSTextFieldCell"; title = "Actualizaciones:"; ObjectID = "qeb-at-hYb"; */
+/* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
 "qeb-at-hYb.title" = "Actualizaciones:";
 
-/* Class = "NSButtonCell"; title = "Incluir perfil anónimo del sistema"; ObjectID = "qno-Cg-EkC"; */
+/* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Incluir perfil anónimo del sistema";
 
-/* Class = "NSTextFieldCell"; title = "Marcar artículo actual como leído:"; ObjectID = "sCl-hz-PFF"; */
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
 "sCl-hz-PFF.title" = "Marcar artículo actual como leído:";
 
-/* Class = "NSMenuItem"; title = "Cada hora"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Cada hora";

--- a/Interfaces/es.lproj/GroupFolder.strings
+++ b/Interfaces/es.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Nueva carpeta de grupo"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nueva carpeta de grupo";
 
-/* Class = "NSButtonCell"; title = "Guardar"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Guardar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Introduzca el nombre de la carpeta de grupo:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Introduzca el nombre de la carpeta de grupo:";

--- a/Interfaces/es.lproj/InfoWindow.strings
+++ b/Interfaces/es.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Ventana"; ObjectID = "5"; */
-"5.title" = "Ventana";
-
-/* Class = "NSTextFieldCell"; title = "(Nombre de la carpeta)"; ObjectID = "104"; */
-"104.title" = "(Nombre de la carpeta)";
-
-/* Class = "NSTextFieldCell"; title = "Última actualización:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Última actualización:";
 
-/* Class = "NSTextFieldCell"; title = "(Fecha de última actualización)"; ObjectID = "106"; */
-"106.title" = "(Fecha de última actualización)";
-
-/* Class = "NSButtonCell"; title = "Validar"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Validar";
 
-/* Class = "NSButtonCell"; title = "URL de la fuente:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL de la fuente";
-
-/* Class = "NSTextFieldCell"; title = "Nombre de usuario:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Nombre de usuario:";
 
-/* Class = "NSTextFieldCell"; title = "Contraseña:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Contraseña:";
 
-/* Class = "NSButtonCell"; title = "Actualizar autenticación"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Actualizar autenticación";
 
-/* Class = "NSButtonCell"; title = "Autenticación:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autenticación";
-
-/* Class = "NSTextFieldCell"; title = "Tamaño:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Tamaño:";
 
-/* Class = "NSTextFieldCell"; title = "No leídos:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "No leídos:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Suscrito"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Suscrito";
 
-/* Class = "NSButtonCell"; title = "General:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "General";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Cargar artículos HTML completamente";
 
-/* Class = "NSButtonCell"; title = "Descripción:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Descripción";
 
-/* Class = "NSButtonCell"; title = "Cargar artículos HTML completamente"; ObjectID = "126"; */
-"126.title" = "Cargar artículos HTML completamente";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autenticación";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "General";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL de la fuente";

--- a/Interfaces/es.lproj/MainMenu.strings
+++ b/Interfaces/es.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Traer todo al frente";
 
@@ -15,7 +14,7 @@
 "24.title" = "Ventana";
 
 /* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";/*no*/
+"29.title" = "MainMenu";
 
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Rehacer";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Ortografía";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Ortografía";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Ortografía…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Comprobar ortografía";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Comprobar ortografía mientras se escribe";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoom";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Actualizar suscripciones seleccionadas";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Agradecimientos";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nueva suscripción…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportar suscripciones seleccionadas";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Página web de Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Vaciar papelera";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Pestaña anterior";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Formato";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Horizontal";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Vertical";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Descargar archivo adjunto";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Personalizar barra de herramientas…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar barra de estado";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Nombre";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Mantener carpetas de grupo en el archivo exportado";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Volver a indexar base de datos";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Ortografía";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Marcar como leído";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/es.lproj/MainMenu.strings
+++ b/Interfaces/es.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Ventana";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar barra de estado";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Mostrar barra de filtro";

--- a/Interfaces/es.lproj/RSSFeed.strings
+++ b/Interfaces/es.lproj/RSSFeed.strings
@@ -1,39 +1,29 @@
-
-/* Class = "NSWindow"; title = "Fuente RSS"; ObjectID = "6"; */
-"6.title" = "Fuente RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "Fuente RSS"; ObjectID = "49"; */
-"49.title" = "Fuente RSS";
-
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Cancelar";
 
-/* Class = "NSButtonCell"; title = "Suscribirse"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Suscribirse";
 
-/* Class = "NSTextFieldCell"; title = "Fuente:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Fuente:";
 
-/* Class = "NSTextFieldCell"; title = "Crear nueva suscripción "; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Crear nueva suscripción ";
 
-/* Class = "NSTextFieldCell"; title = "Introduzca el enlace de la fuente de noticias a continuación, o elija de la lista de fuentes para introducir el acceso directo proporcionado por la fuente de noticias."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Introduzca el enlace de la fuente de noticias a continuación, o elija de la lista de fuentes para introducir el acceso directo proporcionado por la fuente de noticias.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Guardar"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Guardar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Editar suscripción:"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Editar suscripción:";
 
-/* Class = "NSButtonCell"; title = "Suscribirse a Open Reader"; ObjectID = "116"; */
+/* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */
 "116.title" = "Suscribirse a Open Reader";

--- a/Interfaces/es.lproj/SearchFolder.strings
+++ b/Interfaces/es.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Field names go here"; ObjectID = "33"; */
-"33.title" = "Field names go here";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "62"; */
-"62.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "82"; */
-"82.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Nombre de la carpeta inteligente:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Nombre de la carpeta inteligente:";
 
-/* Class = "NSButtonCell"; title = "Guardar"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Guardar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Mostrar todos los artículos que cumplan"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Mostrar todos los artículos que cumplan";
 
-/* Class = "NSTextFieldCell"; title = "de las siguientes condiciones:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "de las siguientes condiciones:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/es.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/es.lproj/SyncingPreferencesView.strings
@@ -1,44 +1,31 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
-/* Class = "NSButton"; ibShadowedToolTip = "Visitar página web"; ObjectID = "Ar5-Qc-YTe"; */
+/* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visitar página web";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
-/* Class = "NSButtonCell"; title = "Sincronizar con servidor Open Reader"; ObjectID = "Lkv-md-rEW"; */
+/* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sincronizar con servidor Open Reader";
 
-/* Class = "NSTextFieldCell"; title = "Contraseña:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Contraseña:";
 
-/* Class = "NSTextFieldCell"; title = "Usuario:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Usuario:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Seleccione un servidor compatible con la API Open Reader"; ObjectID = "kM0-7a-obO"; */
+/* Class = "NSTextField"; ibShadowedToolTip = "Select a server supporting the Open Reader API"; ObjectID = "kM0-7a-obO"; */
 "kM0-7a-obO.ibShadowedToolTip" = "Seleccione un servidor compatible con la API Open Reader";
 
 /* Class = "NSTextFieldCell"; title = "URL: https://"; ObjectID = "tec-2d-Xej"; */
 "tec-2d-Xej.title" = "URL: https://";
 
-/* Class = "NSTextFieldCell"; title = "Servidor:"; ObjectID = "uTl-XE-0ym"; */
+/* Class = "NSTextFieldCell"; title = "Server:"; ObjectID = "uTl-XE-0ym"; */
 "uTl-XE-0ym.title" = "Servidor:";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Dirección del servidor compatible con la API Open Reader"; ObjectID = "vZE-Pl-S9H"; */
+/* Class = "NSTextField"; ibShadowedToolTip = "Address of a server supporting the Open Reader API"; ObjectID = "vZE-Pl-S9H"; */
 "vZE-Pl-S9H.ibShadowedToolTip" = "Dirección del servidor compatible con la API Open Reader";
 
 /* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Select a server supporting the Open Reader API"; ObjectID = "zAy-oc-zmb"; */

--- a/Interfaces/eu.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/eu.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Hurrengo aukerak ez dira zertan aldatu behar Vienna-k egoki ibiltzeko. Laguntzan begiratu bakoitzaren informazioa jakiteko.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Hurrengo aukerak ez dira zertan aldatu behar Vienna-k egoki ibiltzeko. Laguntzan begiratu bakoitzaren informazioa jakiteko.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Hurrengo aukerak ez dira zertan aldatu behar Vienna-k egoki ibiltzeko. Laguntzan begiratu bakoitzaren informazioa jakiteko.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Aktibatu JavaScript barne nabegatzailean"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Aktibatu JavaScript barne nabegatzailean";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/eu.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/eu.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Artikuluak edota web orriak ikustean:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Artikuluak edota web orriak ikustean:";
 
-/* Class = "NSTextFieldCell"; title = "Direktorioentzako letra lista:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Direktorioentzako letra lista:";
 
-/* Class = "NSButtonCell"; title = "Aukeratu…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Aukeratu…";
 
-/* Class = "NSButtonCell"; title = "Erakutsi direktorioen irudiak direktorioen listan"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Erakutsi direktorioen irudiak direktorioen listan";
 
-/* Class = "NSTextFieldCell"; title = "Artikuluentzako letra lista:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Artikuluentzako letra lista:";
 
-/* Class = "NSTextFieldCell"; title = "(Adibidea)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Adibidea)";
-
-/* Class = "NSTextFieldCell"; title = "(Adibidea)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Adibidea)";
-
-/* Class = "NSButtonCell"; title = "Aukeratu…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Aukeratu…";
 
-/* Class = "NSButtonCell"; title = "Ez erabili inoiz letra tamainarik txikiagoa baino"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Ez erabili inoiz letra tamainarik txikiagoa baino";

--- a/Interfaces/eu.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/eu.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Zakarrontzia Hustu"; ObjectID = "5"; */
-"5.title" = "Zakarrontzia Hustu";
-
-/* Class = "NSButtonCell"; title = "Zakarrontzia Hustu"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Zakarrontzia Hustu";
 
-/* Class = "NSButtonCell"; title = "Ez hustu zakarrontzia"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Ez hustu zakarrontzia";
 
-/* Class = "NSTextFieldCell"; title = "Ezabatutako artikuluak zakarrontzian daude.\nIrten aurretik zakarrontzia hustu nahi al duzu?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Ezabatutako artikuluak zakarrontzian daude. Irten aurretik zakarrontzia hustu nahi al duzu?";
 
-/* Class = "NSButtonCell"; title = "Ez erakutsi ohar hau berriro"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Ez erakutsi ohar hau berriro";

--- a/Interfaces/eu.lproj/FeedCredentials.strings
+++ b/Interfaces/eu.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Ezeztatu"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Ezeztatu";
 
-/* Class = "NSTextFieldCell"; title = "Izena:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Izena:";
 
-/* Class = "NSTextFieldCell"; title = "%@-ra sartzeko beharrezkoa da izena ematea"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "%@-ra sartzeko beharrezkoa da izena ematea";
 
-/* Class = "NSTextFieldCell"; title = "Pasahitza:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Pasahitza:";
 
-/* Class = "NSButtonCell"; title = "Izena Eman"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Izena Eman";
 
-/* Class = "NSTextFieldCell"; title = "Emandako erabiltzaile izena eta pasahitza gorde egingo dira harpidetza eguneratzean erabiltzeko."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Emandako erabiltzaile izena eta pasahitza gorde egingo dira harpidetza eguneratzean erabiltzeko.";

--- a/Interfaces/eu.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/eu.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "15 minuturo"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "15 minuturo";
 
-/* Class = "NSButtonCell"; title = "\"Hurrengo Irakurri Gabea\" komandoaren ondoren"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "\"Hurrengo Irakurri Gabea\" komandoaren ondoren";
 
-/* Class = "NSMenuItem"; title = "(Helbidea)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Helbidea)";
-
-/* Class = "NSMenuItem"; title = "30 minuturo"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "30 minuturo";
 
-/* Class = "NSMenuItem"; title = "2 orduro"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "2 orduro";
 
-/* Class = "NSButtonCell"; title = "Erakutsi programaren ikonoan irakurri gabeko artikuluen kontadorea"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Erakutsi programaren ikonoan irakurri gabeko artikuluen kontadorea";
 
-/* Class = "NSTextFieldCell"; title = "Artikulu berri irakurri gabeak jasotzerakoan"; ObjectID = "BbI-0A-zEG"; */
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
 "BbI-0A-zEG.title" = "Artikulu berri irakurri gabeak jasotzerakoan";
 
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "Besteak..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Besteak...";
-
-/* Class = "NSMenuItem"; title = "Ezer"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Ezer";
 
 /* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Check for newer versions of Vienna on start up";
 
-/* Class = "NSMenuItem"; title = "Eskuz"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Eskuz";
 
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "6 orduro"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "6 orduro";
 
-/* Class = "NSButtonCell"; title = "Atzerapen txiki baten ondoren"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Atzerapen txiki baten ondoren";
 
-/* Class = "NSButtonCell"; title = "Erakutsi menuan"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Erakutsi menuan";
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "Bestelakoak";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "Bestelakoak";
-
-/* Class = "NSButtonCell"; title = "Ireki estekak kanpo nabegatzailean"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Ireki estekak kanpo nabegatzailean";
 
-/* Class = "NSTextFieldCell"; title = "Begiratu artikulu berririk daude:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Begiratu artikulu berririk daude:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Gorde deskargatutako fitxategiak hemen"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Gorde deskargatutako fitxategiak hemen";
 
-/* Class = "NSButtonCell"; title = "Aplikazioaren ikonoa saltoka jarri"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Aplikazioaren ikonoa saltoka jarri";
 
-/* Class = "NSMenuItem"; title = "3 orduro"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "3 orduro";
 
 /* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Move articles to Trash:";
 
-/* Class = "NSTextFieldCell"; title = "Ireki estekak kanpo nabegatzailean"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Ireki estekak kanpo nabegatzailean";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "5 minuturo Begiratu artikulu berririk daude:"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "5 minuturo Begiratu artikulu berririk daude:";
 
-/* Class = "NSButtonCell"; title = "Default RSS Reader:"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Default RSS Reader:";
 
-/* Class = "NSButtonCell"; title = "Ireki esteka berriak atzekaldean"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Ireki esteka berriak atzekaldean";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Mark current article read:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Mark current article read:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Mark current article read:";
 
-/* Class = "NSMenuItem"; title = "Orduro"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Orduro";

--- a/Interfaces/eu.lproj/GroupFolder.strings
+++ b/Interfaces/eu.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panela"; ObjectID = "5"; */
-"5.title" = "Panela";
-
-/* Class = "NSTextFieldCell"; title = "Talde Berrirako Direktorioa"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Talde Berrirako Direktorioa";
 
-/* Class = "NSButtonCell"; title = "Gorde"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Gorde";
 
-/* Class = "NSButtonCell"; title = "Ezeztatu"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Ezeztatu";
 
-/* Class = "NSTextFieldCell"; title = "Sartu taldearen direktorioaren izena:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Sartu taldearen direktorioaren izena:";

--- a/Interfaces/eu.lproj/InfoWindow.strings
+++ b/Interfaces/eu.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Lehioa"; ObjectID = "5"; */
-"5.title" = "Lehioa";
-
-/* Class = "NSTextFieldCell"; title = "(Direktorio izena)"; ObjectID = "104"; */
-"104.title" = "(Direktorio izena)";
-
-/* Class = "NSTextFieldCell"; title = "Azken Eguneratuak:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Azken Eguneratuak:";
 
-/* Class = "NSTextFieldCell"; title = "(Azken eguneratze data)"; ObjectID = "106"; */
-"106.title" = "(Azken eguneratze data)";
-
-/* Class = "NSButtonCell"; title = "Frogatu"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Frogatu";
 
-/* Class = "NSButtonCell"; title = "URL jarioa:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL jarioa";
-
-/* Class = "NSTextFieldCell"; title = "Erabiltzaile izena:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Erabiltzaile izena:";
 
-/* Class = "NSTextFieldCell"; title = "Pasahitza:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Pasahitza:";
 
-/* Class = "NSButtonCell"; title = "Berritu Autentifikazioa"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Berritu Autentifikazioa";
 
-/* Class = "NSButtonCell"; title = "Autentifikazioa:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autentifikazioa";
-
-/* Class = "NSTextFieldCell"; title = "Tamaina:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Tamaina:";
 
-/* Class = "NSTextFieldCell"; title = "Irakurri gabeak:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Irakurri gabeak:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Harpidetuta"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Harpidetuta";
-
-/* Class = "NSButtonCell"; title = "Orokorra:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Orokorra";
-
-/* Class = "NSButtonCell"; title = "Deskripzioa:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "Deskripzioa";
 
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Load Full HTML Articles";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "Deskripzioa";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autentifikazioa";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Orokorra";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL jarioa";

--- a/Interfaces/eu.lproj/MainMenu.strings
+++ b/Interfaces/eu.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Dena aurrera eraman";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Berregin";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Idazkera";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Idazkera";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Idazkera…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Akats Ortografikoak Aztertu";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Akats Ortografikoak Aztertu Idazten Den Heinean";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoom";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Eguneratu Aukeratutako Harpidetzak";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Kontutan Hartu Beharrekoak";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Harpidetza Berria…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Aukeratutako harpidetzak esportatu";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna-ren Web orria";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Zakarrontzia Hustu";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Aurreko Fitxa";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Eskema";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Txostena";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Trinkotuta";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Download Enclosure";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Customize Toolbar…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Hide Status Bar";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Mantendu talde direktorioak esportatutako fitxategietan";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Idazkera";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Irakurrita Moduan Jarri";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/eu.lproj/MainMenu.strings
+++ b/Interfaces/eu.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Lehioa";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "Menu Nagusia";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Hide Status Bar";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Show Filter Bar";

--- a/Interfaces/eu.lproj/RSSFeed.strings
+++ b/Interfaces/eu.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS Jarioa"; ObjectID = "6"; */
-"6.title" = "RSS Jarioa";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS Jarioa"; ObjectID = "49"; */
-"49.title" = "RSS Jarioa";
-
-/* Class = "NSButtonCell"; title = "Ezeztatu"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Ezeztatu";
 
-/* Class = "NSButtonCell"; title = "Harpidetu"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Harpidetu";
 
-/* Class = "NSTextFieldCell"; title = "Iturria:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Iturria:";
 
-/* Class = "NSTextFieldCell"; title = "Harpidetza berri bat sortu"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Harpidetza berri bat sortu";
 
-/* Class = "NSTextFieldCell"; title = "Sartu jarioaren URL helbidea behean, edota aukeratu bat iturrien listatik."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Sartu jarioaren URL helbidea behean, edota aukeratu bat iturrien listatik.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Gorde"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Gorde";
 
-/* Class = "NSButtonCell"; title = "Ezeztatu"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Ezeztatu";
 
-/* Class = "NSTextFieldCell"; title = "Harpidetza editatu"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Harpidetza editatu";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/eu.lproj/SearchFolder.strings
+++ b/Interfaces/eu.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "32"; */
-"32.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "Fitxategi izenak hemen doaz"; ObjectID = "33"; */
-"33.title" = "Fitxategi izenak hemen doaz";
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "34"; */
-"34.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "Operazioak hemen doaz"; ObjectID = "56"; */
-"56.title" = "Operazioak hemen doaz";
-
-/* Class = "NSMenuItem"; title = "Ezer"; ObjectID = "62"; */
-"62.title" = "Ezer";
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "64"; */
-"64.title" = "Bestelakoak";
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "74"; */
-"74.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "80"; */
-"80.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "Ezer"; ObjectID = "82"; */
-"82.title" = "Ezer";
-
-/* Class = "NSMenu"; title = "Bestelakoak"; ObjectID = "87"; */
-"87.title" = "Bestelakoak";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Direktorio adimenduaren izena:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Direktorio adimenduaren izena:";
 
-/* Class = "NSButtonCell"; title = "Gorde"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Gorde";
 
-/* Class = "NSButtonCell"; title = "Ezeztatu"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Ezeztatu";
 
-/* Class = "NSTextFieldCell"; title = "Erakutsi zerikusia duten artikulu guztiak"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Erakutsi zerikusia duten artikulu guztiak";
 
-/* Class = "NSTextFieldCell"; title = "honako baldintzekin:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "honako baldintzekin:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/eu.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/eu.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Pasahitza:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Pasahitza:";
 
-/* Class = "NSTextFieldCell"; title = "Izena:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Izena:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/fr.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/fr.lproj/AdvancedPreferencesView.strings
@@ -1,42 +1,38 @@
-
-/* Class = "NSTextFieldCell"; title = "Plus le nombre est élevé, plus vos abonnements seront rapidement mis à jour."; ObjectID = "2GQ-cu-fbh"; */
+/* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "Plus le nombre est élevé, plus vos abonnements seront rapidement mis à jour.";
 
-/* Class = "NSTextFieldCell"; title = "Ces réglages ne nécessitent pas d'être changés pour une utilisation basique de Vienna. Se référer au fichier d'aide pour plus de détails.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Ces réglages ne nécessitent pas d'être changés pour une utilisation basique de Vienna. Se référer au fichier d'aide pour plus de détails.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Ces réglages ne nécessitent pas d'être changés pour une utilisation basique de Vienna. Se référer au fichier d'aide pour plus de détails.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
-/* Class = "NSTextFieldCell"; title = "Téléchargements simultanés :"; ObjectID = "Ngw-hP-yW4"; */
+/* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
 "Ngw-hP-yW4.title" = "Téléchargements simultanés :";
 
-/* Class = "NSTextFieldCell"; title = "Néanmoins, un nombre élevé peut rendre votre ordinateur moins réactif au moment du rafraîchissement des abonnements."; ObjectID = "S3T-cW-hys"; */
+/* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "Néanmoins, un nombre élevé peut rendre votre ordinateur moins réactif au moment du rafraîchissement des abonnements.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
-/* Class = "NSButtonCell"; title = "Activer les plugins dans le navigateur interne"; ObjectID = "fIz-4t-Ogg"; */
+/* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Activer les plugins dans le navigateur interne";
 
-/* Class = "NSButtonCell"; title = "Activer JavaScript dans le navigateur interne"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Activer JavaScript dans le navigateur interne";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/fr.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/fr.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
+"71S-pg-AjX.title" = "Lors de l'affichage d'articles ou de pages Web:";
 
-/* Class = "NSTextFieldCell"; title = "Lors de l'affichage d'articles ou de pages Web :"; ObjectID = "71S-pg-AjX"; */
-"71S-pg-AjX.title" = "Lors de l'affichage d'articles ou de pages Web :";
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
+"B5v-p5-vrf.title" = "Liste des dossiers:";
 
-/* Class = "NSTextFieldCell"; title = "Liste des dossiers :"; ObjectID = "B5v-p5-vrf"; */
-"B5v-p5-vrf.title" = "Liste des dossiers :";
-
-/* Class = "NSButtonCell"; title = "Sélectionner…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Sélectionner…";
 
-/* Class = "NSButtonCell"; title = "Afficher les icônes de flux dans la liste des dossiers"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Afficher les icônes de flux dans la liste des dossiers";
 
-/* Class = "NSTextFieldCell"; title = "Liste des articles :"; ObjectID = "auD-UC-Pij"; */
-"auD-UC-Pij.title" = "Liste des articles :";
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
+"auD-UC-Pij.title" = "Liste des articles:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Sélectionner…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Sélectionner…";
 
-/* Class = "NSButtonCell"; title = "Ne jamais utiliser de police de taille inférieure à"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Ne jamais utiliser de police de taille inférieure à";

--- a/Interfaces/fr.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/fr.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Vider la corbeille"; ObjectID = "5"; */
-"5.title" = "Vider la corbeille";
-
-/* Class = "NSButtonCell"; title = "Vider la corbeille"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Vider la corbeille";
 
-/* Class = "NSButtonCell"; title = "Ne pas vider la corbeille"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Ne pas vider la corbeille";
 
-/* Class = "NSTextFieldCell"; title = "La corbeille contient des articles supprimés.\nSouhaitez-vous la vider avant de quitter ?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "La corbeille contient des articles supprimés. Souhaitez-vous la vider avant de quitter ?";
 
-/* Class = "NSButtonCell"; title = "Ne plus afficher cette alerte"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Ne plus afficher cette alerte";

--- a/Interfaces/fr.lproj/FeedCredentials.strings
+++ b/Interfaces/fr.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Annuler"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Annuler";
 
-/* Class = "NSTextFieldCell"; title = "Nom :"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Nom :";
 
-/* Class = "NSTextFieldCell"; title = "L'accès à %@ nécessite de vous identifier"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "L'accès à %@ nécessite de vous identifier";
 
-/* Class = "NSTextFieldCell"; title = "Mot de passe :"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Mot de passe :";
 
-/* Class = "NSButtonCell"; title = "S'identifier"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "S'identifier";
 
-/* Class = "NSTextFieldCell"; title = "Le nom d'utilisateur et le mot de passe fournis seront conservés pour le prochain accès à ce flux."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Le nom d'utilisateur et le mot de passe fournis seront conservés pour le prochain accès à ce flux.";

--- a/Interfaces/fr.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/fr.lproj/GeneralPreferencesView.strings
@@ -1,108 +1,83 @@
-
-/* Class = "NSMenuItem"; title = "Toutes les 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Toutes les 15 minutes";
 
-/* Class = "NSButtonCell"; title = "Après la commande \"Suivant non lu\""; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Après la commande \"Suivant non lu\"";
 
-/* Class = "NSMenuItem"; title = "(Path)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Path)";
-
-/* Class = "NSMenuItem"; title = "Toutes les 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Toutes les 30 minutes";
 
-/* Class = "NSMenuItem"; title = "Toutes les 2 heures"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Toutes les 2 heures";
 
-/* Class = "NSButtonCell"; title = "Afficher le nombre d'articles non lus sur l'icône de l'application"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Afficher le nombre d'articles non lus sur l'icône de l'application";
 
-/* Class = "NSTextFieldCell"; title = "Lorsque de nouveaux articles sont récupérés :\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Lorsque de nouveaux articles sont récupérés :\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Lorsque de nouveaux articles sont récupérés :";
 
-/* Class = "NSMenu"; title = "AutresVues"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "AutresVues";
-
-/* Class = "NSMenuItem"; title = "Autre…"; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Autre…";
 
-/* Class = "NSMenuItem"; title = "Aucun"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Aucun";
-
-/* Class = "NSButtonCell"; title = "Rechercher une mise à jour de Vienna au lancement"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Rechercher une mise à jour de Vienna au lancement";
 
-/* Class = "NSMenuItem"; title = "Manuellement"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manuellement";
 
-/* Class = "NSMenu"; title = "AutresVues"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "AutresVues";
-
-/* Class = "NSMenuItem"; title = "Toutes les 6 heures"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Toutes les 6 heures";
 
-/* Class = "NSButtonCell"; title = "Après un court délai"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Après un court délai";
 
-/* Class = "NSButtonCell"; title = "Afficher dans la barre de menu"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Afficher dans la barre de menu";
 
-/* Class = "NSMenu"; title = "AutresVues"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "AutresVues";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
-
-/* Class = "NSButtonCell"; title = "Rechercher les dernières versions Beta"; ObjectID = "OID-qF-Pp0"; */
+/* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Rechercher les dernières versions Beta";
 
-/* Class = "NSMenu"; title = "AutresVues"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "AutresVues";
-
-/* Class = "NSButtonCell"; title = "Ouvrir les liens dans un autre navigateur"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Ouvrir les liens dans un autre navigateur";
 
-/* Class = "NSTextFieldCell"; title = "Relever les nouveaux articles :"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Relever les nouveaux articles :";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Enregistrer les fichiers téléchargés dans :"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Enregistrer les fichiers téléchargés dans :";
 
-/* Class = "NSButtonCell"; title = "Faire rebondir l'icône de l'application"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Faire rebondir l'icône de l'application";
 
-/* Class = "NSMenuItem"; title = "Toutes les 3 heures"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Toutes les 3 heures";
 
-/* Class = "NSTextFieldCell"; title = "Déplacer les articles dans la corbeille :"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Déplacer les articles dans la corbeille :";
 
-/* Class = "NSTextFieldCell"; title = "Lecteur RSS par défaut :"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Lecteur RSS par défaut :";
 
-/* Class = "NSButtonCell"; title = "Indiquer comme non-lus les articles mis à jour"; ObjectID = "meo-78-YOl"; */
+/* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Indiquer comme non-lus les articles mis à jour";
 
-/* Class = "NSMenuItem"; title = "Toutes les 5 minutes"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Toutes les 5 minutes";
 
-/* Class = "NSButtonCell"; title = "Relever les nouveaux articles au lancement"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Relever les nouveaux articles au lancement";
 
-/* Class = "NSButtonCell"; title = "Ouvrir les liens à l'arrière plan"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Ouvrir les liens à l'arrière plan";
 
-/* Class = "NSTextFieldCell"; title = "Mises à jour logicielles :"; ObjectID = "qeb-at-hYb"; */
+/* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
 "qeb-at-hYb.title" = "Mises à jour logicielles :";
 
-/* Class = "NSButtonCell"; title = "Inclure un profil anonyme du système"; ObjectID = "qno-Cg-EkC"; */
+/* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Inclure un profil anonyme du système";
 
-/* Class = "NSTextFieldCell"; title = "Marquer l'article courant comme lu :\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Marquer l'article courant comme lu :\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Marquer l'article courant comme lu :";
 
-/* Class = "NSMenuItem"; title = "Toutes les heures"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Toutes les heures";

--- a/Interfaces/fr.lproj/GroupFolder.strings
+++ b/Interfaces/fr.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panneau"; ObjectID = "5"; */
-"5.title" = "Panneau";
-
-/* Class = "NSTextFieldCell"; title = "Nouveau groupe"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nouveau groupe";
 
-/* Class = "NSButtonCell"; title = "Créer"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Créer";
 
-/* Class = "NSButtonCell"; title = "Annuler"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Annuler";
 
-/* Class = "NSTextFieldCell"; title = "Entrer le nom du nouveau groupe :\n"; ObjectID = "36"; */
-"36.title" = "Entrer le nom du nouveau groupe :";
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
+"36.title" = "Entrer le nom du nouveau groupe:";

--- a/Interfaces/fr.lproj/InfoWindow.strings
+++ b/Interfaces/fr.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Fenêtre"; ObjectID = "5"; */
-"5.title" = "Fenêtre";
-
-/* Class = "NSTextFieldCell"; title = "(Folder name)"; ObjectID = "104"; */
-"104.title" = "(Folder name)";
-
-/* Class = "NSTextFieldCell"; title = "Dernier rafraîchissement :"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Dernier rafraîchissement :";
 
-/* Class = "NSTextFieldCell"; title = "(Last refresh date)"; ObjectID = "106"; */
-"106.title" = "(Last refresh date)";
-
-/* Class = "NSButtonCell"; title = "Vérifier"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Vérifier";
 
-/* Class = "NSButtonCell"; title = "URL du flux :"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL du flux";
-
-/* Class = "NSTextFieldCell"; title = "Nom d'utilisateur :"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Nom d'utilisateur :";
 
-/* Class = "NSTextFieldCell"; title = "Mot de passe :\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Mot de passe :";
 
-/* Class = "NSButtonCell"; title = "Mise à jour de l'identification"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Mise à jour de l'identification";
 
-/* Class = "NSButtonCell"; title = "Identification :"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Identification";
-
-/* Class = "NSTextFieldCell"; title = "Taille :"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Taille :";
 
-/* Class = "NSTextFieldCell"; title = "Non lus :\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Non lus :";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Abonné"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Abonné";
 
-/* Class = "NSButtonCell"; title = "Général :"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Général";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Afficher la page complète immédiatement";
 
-/* Class = "NSButtonCell"; title = "Description :"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Description";
 
-/* Class = "NSButtonCell"; title = "Afficher la page complète immédiatement"; ObjectID = "126"; */
-"126.title" = "Afficher la page complète immédiatement";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Identification";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Général";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL du flux";

--- a/Interfaces/fr.lproj/MainMenu.strings
+++ b/Interfaces/fr.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Fenêtre";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Masquer la barre de status";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Afficher la barre de filtre";

--- a/Interfaces/fr.lproj/MainMenu.strings
+++ b/Interfaces/fr.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Tout ramener au premier plan";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Refaire";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Orthographe";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Orthographe";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Orthographe…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Vérifier l'orthographe";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Vérifier l'orthographe lors de la frappe";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Réduire/Agrandir";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Rafraîchir les abonnements sélectionnés";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Crédits";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nouvel abonnement…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exporter les abonnements sélectionnés";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Site internet";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Vider la corbeille";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Onglet précédent";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Agencement";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Horizontal";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Vertical";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Télécharger le fichier incorporé";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Personnaliser la barre d'outils…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Masquer la barre de status";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Titre";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Conserver le groupement par dossier dans le fichier exporté";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,10 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Réindexer la base de données";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Orthographe";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Marquer comme lu";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";
-
-

--- a/Interfaces/fr.lproj/RSSFeed.strings
+++ b/Interfaces/fr.lproj/RSSFeed.strings
@@ -1,39 +1,29 @@
-
-/* Class = "NSWindow"; title = "Flux RSS"; ObjectID = "6"; */
-"6.title" = "Flux RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "Flux RSS"; ObjectID = "49"; */
-"49.title" = "Flux RSS";
-
-/* Class = "NSButtonCell"; title = "Annuler"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Annuler";
 
-/* Class = "NSButtonCell"; title = "S'abonner"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "S'abonner";
 
-/* Class = "NSTextFieldCell"; title = "Source :"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Source :";
 
-/* Class = "NSTextFieldCell"; title = "Créer un nouvel abonnement"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Créer un nouvel abonnement";
 
-/* Class = "NSTextFieldCell"; title = "Entrer le lien pour le flux RSS, ou choisir un type de source à partir de la liste et entrer un nom pour obtenir le flux RSS associé."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Entrer le lien pour le flux RSS, ou choisir un type de source à partir de la liste et entrer un nom pour obtenir le flux RSS associé.";
 
-/* Class = "NSTextFieldCell"; title = "URL :"; ObjectID = "110"; */
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL :";
 
-/* Class = "NSButtonCell"; title = "Modifier"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Modifier";
 
-/* Class = "NSButtonCell"; title = "Annuler"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Annuler";
 
-/* Class = "NSTextFieldCell"; title = "Éditer le lien de l'abonnement"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Éditer le lien de l'abonnement";
 
-/* Class = "NSButtonCell"; title = "S'abonner à travers le serveur Open Reader"; ObjectID = "116"; */
+/* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */
 "116.title" = "S'abonner à travers le serveur Open Reader";

--- a/Interfaces/fr.lproj/SearchFolder.strings
+++ b/Interfaces/fr.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
+"94.title" = "Nom du dossier intelligent:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Field names go here"; ObjectID = "33"; */
-"33.title" = "Field names go here";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "chacune"; ObjectID = "62"; */
-"62.title" = "chacune";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "chacune"; ObjectID = "82"; */
-"82.title" = "chacune";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Nom du dossier intelligent :"; ObjectID = "94"; */
-"94.title" = "Nom du dossier intelligent :";
-
-/* Class = "NSButtonCell"; title = "Valider"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Valider";
 
-/* Class = "NSButtonCell"; title = "Annuler"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Annuler";
 
-/* Class = "NSTextFieldCell"; title = "Montrer les articles qui satisfont"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Montrer les articles qui satisfont";
 
-/* Class = "NSTextFieldCell"; title = "des conditions suivantes :"; ObjectID = "100"; */
-"100.title" = "des conditions suivantes :";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
+"100.title" = "des conditions suivantes:";

--- a/Interfaces/fr.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/fr.lproj/SyncingPreferencesView.strings
@@ -1,45 +1,32 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
-/* Class = "NSButton"; ibExternalAccessibilityDescription = "Visiter le site web"; ObjectID = "Ar5-Qc-YTe"; */
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visiter le site web";
 
-/* Class = "NSButton"; ibShadowedToolTip = "Visiter le site web"; ObjectID = "Ar5-Qc-YTe"; */
+/* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visiter le site web";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
-/* Class = "NSButtonCell"; title = "Synchroniser avec un serveur Open Reader"; ObjectID = "Lkv-md-rEW"; */
+/* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Synchroniser avec un serveur Open Reader";
 
-/* Class = "NSTextFieldCell"; title = "Mot de passe :"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Mot de passe :";
 
-/* Class = "NSTextFieldCell"; title = "Nom utilisateur :"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Nom utilisateur :";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Sélection d'un serveur supportant l'API Open Reader"; ObjectID = "kM0-7a-obO"; */
+/* Class = "NSTextField"; ibShadowedToolTip = "Select a server supporting the Open Reader API"; ObjectID = "kM0-7a-obO"; */
 "kM0-7a-obO.ibShadowedToolTip" = "Sélection d'un serveur supportant l'API Open Reader";
 
 /* Class = "NSTextFieldCell"; title = "URL: https://"; ObjectID = "tec-2d-Xej"; */
 "tec-2d-Xej.title" = "URL: https://";
 
-/* Class = "NSTextFieldCell"; title = "Serveur :"; ObjectID = "uTl-XE-0ym"; */
+/* Class = "NSTextFieldCell"; title = "Server:"; ObjectID = "uTl-XE-0ym"; */
 "uTl-XE-0ym.title" = "Serveur :";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Adresse d'un serveur supportant l'API Open Reader"; ObjectID = "vZE-Pl-S9H"; */
+/* Class = "NSTextField"; ibShadowedToolTip = "Address of a server supporting the Open Reader API"; ObjectID = "vZE-Pl-S9H"; */
 "vZE-Pl-S9H.ibShadowedToolTip" = "Adresse d'un serveur supportant l'API Open Reader";
 
-/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Sélection d'un serveur supportant l'API Open Reader"; ObjectID = "zAy-oc-zmb"; */
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Select a server supporting the Open Reader API"; ObjectID = "zAy-oc-zmb"; */
 "zAy-oc-zmb.ibExternalAccessibilityDescription" = "Sélection d'un serveur supportant l'API Open Reader";

--- a/Interfaces/gl.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/gl.lproj/EmptyTrashWarning.strings
@@ -1,7 +1,3 @@
-
-/* Class = "NSWindow"; title = "Empty Trash"; ObjectID = "5"; */
-"5.title" = "Tirar o lixo";
-
 /* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Tirar o lixo";
 

--- a/Interfaces/gl.lproj/FeedCredentials.strings
+++ b/Interfaces/gl.lproj/FeedCredentials.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Cancelar";
 

--- a/Interfaces/gl.lproj/GroupFolder.strings
+++ b/Interfaces/gl.lproj/GroupFolder.strings
@@ -1,7 +1,3 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
 /* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Novo cartafol de grupo";
 

--- a/Interfaces/gl.lproj/InfoWindow.strings
+++ b/Interfaces/gl.lproj/InfoWindow.strings
@@ -1,21 +1,8 @@
-
-/* Class = "NSWindow"; title = "Window"; ObjectID = "5"; */
-"5.title" = "Fiestra";
-
-/* Class = "NSTextFieldCell"; title = "(Folder name)"; ObjectID = "104"; */
-"104.title" = "(Nome do cartafol)";
-
 /* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Última actualización:";
 
-/* Class = "NSTextFieldCell"; title = "(Last refresh date)"; ObjectID = "106"; */
-"106.title" = "(Data da última actualización)";
-
 /* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Validar";
-
-/* Class = "NSButtonCell"; title = "Feed URL:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL da fonte";
 
 /* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Nome de usuario:";
@@ -26,9 +13,6 @@
 /* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Actualizar autenticación";
 
-/* Class = "NSButtonCell"; title = "Authentication:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autenticación";
-
 /* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Tamaño:";
 
@@ -38,11 +22,17 @@
 /* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Subscrito";
 
-/* Class = "NSButtonCell"; title = "General:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Xeral";
-
-/* Class = "NSButtonCell"; title = "Description:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "Descrición";
-
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Cargar artigos HTML completamente";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "Descrición";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autenticación";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Xeral";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL da fonte";

--- a/Interfaces/gl.lproj/MainMenu.strings
+++ b/Interfaces/gl.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Traer todo ao fronte";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Refacer";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Ortografía";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Ortografía";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Ortografía…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Comprobar ortografía";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Comprobar ortografía namentres escribe";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoom";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Actualizar subscricións seleccionadas";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Agradecemento";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nova subscricións…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportar subscricións seleccionadas";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Páxina web de Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Baleirar o lixo";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Lapela anterior";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Formato";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Horizontal";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Vertical";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Descargar arquivo adxunto";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Personalizar barra de ferramentas…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar barra de estado";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Nome";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Manter os cartafoles de grupo no arquivo exportado";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Volver a indexar a base de datos";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Ortografía";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Marcar como lido";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/gl.lproj/MainMenu.strings
+++ b/Interfaces/gl.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Xanela";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "Menú principal";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar barra de estado";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Amosar barra de filtros";

--- a/Interfaces/it.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/it.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Le impostazioni qui non dovrebbero essere modificate per il normale uso di Vienna. Fai riferimento all'Aiuto per dettagli su ciascuna impostazione.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Le impostazioni qui non dovrebbero essere modificate per il normale uso di Vienna. Fai riferimento all'Aiuto per dettagli su ciascuna impostazione.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Le impostazioni qui non dovrebbero essere modificate per il normale uso di Vienna. Fai riferimento all'Aiuto per dettagli su ciascuna impostazione.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Attiva JavaScript nel browser interno"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Attiva JavaScript nel browser interno";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/it.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/it.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Quando visualizzi articoli o pagine web:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Quando visualizzi articoli o pagine web:";
 
-/* Class = "NSTextFieldCell"; title = "Font elenco cartelle:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Font elenco cartelle:";
 
-/* Class = "NSButtonCell"; title = "Seleziona…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Seleziona…";
 
-/* Class = "NSButtonCell"; title = "Mostra immagini cartelle nell'elenco cartelle"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Mostra immagini cartelle nell'elenco cartelle";
 
-/* Class = "NSTextFieldCell"; title = "Font elenco articoli:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Font elenco articoli:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Seleziona…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Seleziona…";
 
-/* Class = "NSButtonCell"; title = "Non utilizzare mai dimensioni font inferiori a"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Non utilizzare mai dimensioni font inferiori a";

--- a/Interfaces/it.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/it.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Svuota Cestino"; ObjectID = "5"; */
-"5.title" = "Svuota Cestino";
-
-/* Class = "NSButtonCell"; title = "Svuota Cestino"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Svuota Cestino";
 
-/* Class = "NSButtonCell"; title = "Non Svuotare il Cestino"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Non Svuotare il Cestino";
 
-/* Class = "NSTextFieldCell"; title = "Ci sono degli articoli eliminati nel cestino.\nDesideri svuotare il cestino prima di uscire?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Ci sono degli articoli eliminati nel cestino. Desideri svuotare il cestino prima di uscire?";
 
-/* Class = "NSButtonCell"; title = "Non mostrare di nuovo questo avviso"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Non mostrare di nuovo questo avviso";

--- a/Interfaces/it.lproj/FeedCredentials.strings
+++ b/Interfaces/it.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Annulla"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Annulla";
 
-/* Class = "NSTextFieldCell"; title = "Nome:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Nome:";
 
-/* Class = "NSTextFieldCell"; title = "L'accesso a %@ richiede l'inserimento delle tue credenziali di login"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "L'accesso a %@ richiede l'inserimento delle tue credenziali di login";
 
 /* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Password:";
 
-/* Class = "NSButtonCell"; title = "Login"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Login";
 
-/* Class = "NSTextFieldCell"; title = "Nome utente e password da te forniti saranno ricordati la prossima volta che aggiornerai questa iscrizione."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Nome utente e password da te forniti saranno ricordati la prossima volta che aggiornerai questa iscrizione.";

--- a/Interfaces/it.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/it.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "Ogni 15 minuti"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Ogni 15 minuti";
 
-/* Class = "NSButtonCell"; title = "Dopo il comando \"Prossimo Non Letto\""; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Dopo il comando \"Prossimo Non Letto\"";
 
-/* Class = "NSMenuItem"; title = "(Percorso)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Percorso)";
-
-/* Class = "NSMenuItem"; title = "Ogni 30 minuti"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Ogni 30 minuti";
 
-/* Class = "NSMenuItem"; title = "Ogni 2 ore"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Ogni 2 ore";
 
-/* Class = "NSButtonCell"; title = "Mostra il contatore articoli non letti sull'icona dell'applicazione"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Mostra il contatore articoli non letti sull'icona dell'applicazione";
 
-/* Class = "NSTextFieldCell"; title = "Quando vengono recuperati nuovi articoli non letti:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Quando vengono recuperati nuovi articoli non letti:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Quando vengono recuperati nuovi articoli non letti:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Altro..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Altro...";
 
-/* Class = "NSMenuItem"; title = "Nessuno"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Nessuno";
-
-/* Class = "NSButtonCell"; title = "Controlla nuove versioni di Vienna all'avvio"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Controlla nuove versioni di Vienna all'avvio";
 
-/* Class = "NSMenuItem"; title = "Manualmente"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manualmente";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Ogni 6 ore"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Ogni 6 ore";
 
-/* Class = "NSButtonCell"; title = "Dopo un breve ritardo"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Dopo un breve ritardo";
 
-/* Class = "NSButtonCell"; title = "Mostra nella barra menu"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Mostra nella barra menu";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Apri collegamenti in un browser esterno"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Apri collegamenti in un browser esterno";
 
-/* Class = "NSTextFieldCell"; title = "Controlla nuovi articoli:\n"; ObjectID = "ewU-JH-fMC"; */
-"ewU-JH-fMC.title" = "Controlla nuovi articoli:\n";
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
+"ewU-JH-fMC.title" = "Controlla nuovi articoli:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Registra file scaricati in:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Registra file scaricati in:";
 
-/* Class = "NSButtonCell"; title = "Fai rimbalzare l'icona dell'applicazione"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Fai rimbalzare l'icona dell'applicazione";
 
-/* Class = "NSMenuItem"; title = "Ogni 3 ore"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Ogni 3 ore";
 
-/* Class = "NSTextFieldCell"; title = "Sposta articoli nel Cestino:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Sposta articoli nel Cestino:";
 
-/* Class = "NSTextFieldCell"; title = "Lettore RSS di default:\n"; ObjectID = "kGA-Sa-RLG"; */
-"kGA-Sa-RLG.title" = "Lettore RSS di default:\n";
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
+"kGA-Sa-RLG.title" = "Lettore RSS di default:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "Ogni 30 minuti"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Ogni 30 minuti";
 
-/* Class = "NSButtonCell"; title = "Controlla nuovi articoli all'avvio"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Controlla nuovi articoli all'avvio";
 
-/* Class = "NSButtonCell"; title = "Apri nuovi collegamenti sullo sfondo"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Apri nuovi collegamenti sullo sfondo";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Segnala l'articolo corrente come letto:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Segnala l'articolo corrente come letto:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Segnala l'articolo corrente come letto:";
 
-/* Class = "NSMenuItem"; title = "Ogni ora"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Ogni ora";

--- a/Interfaces/it.lproj/GroupFolder.strings
+++ b/Interfaces/it.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Pannello"; ObjectID = "5"; */
-"5.title" = "Pannello";
-
-/* Class = "NSTextFieldCell"; title = "Nuova Cartella Gruppo"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nuova Cartella Gruppo";
 
-/* Class = "NSButtonCell"; title = "Registra"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Registra";
 
-/* Class = "NSButtonCell"; title = "Annulla"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Annulla";
 
-/* Class = "NSTextFieldCell"; title = "Inserisci il nome della cartella gruppo:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Inserisci il nome della cartella gruppo:";

--- a/Interfaces/it.lproj/InfoWindow.strings
+++ b/Interfaces/it.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Finestra"; ObjectID = "5"; */
-"5.title" = "Finestra";
-
-/* Class = "NSTextFieldCell"; title = "(nome Cartella)"; ObjectID = "104"; */
-"104.title" = "(nome Cartella)";
-
-/* Class = "NSTextFieldCell"; title = "Ultimo Aggiornamento:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Ultimo Aggiornamento:";
 
-/* Class = "NSTextFieldCell"; title = "(Data ultimo aggiornameto)"; ObjectID = "106"; */
-"106.title" = "(Data ultimo aggiornameto)";
-
-/* Class = "NSButtonCell"; title = "Convalida"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Convalida";
 
-/* Class = "NSButtonCell"; title = "URL Feed:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL Feed";
-
-/* Class = "NSTextFieldCell"; title = "Nome utente:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Nome utente:";
 
-/* Class = "NSTextFieldCell"; title = "Password:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Password:";
 
-/* Class = "NSButtonCell"; title = "Aggiorna Autenticazione"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Aggiorna Autenticazione";
 
-/* Class = "NSButtonCell"; title = "Autenticazione:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autenticazione";
-
-/* Class = "NSTextFieldCell"; title = "Dim.:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Dim.:";
 
-/* Class = "NSTextFieldCell"; title = "Non letti:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Non letti:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Iscritto"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Iscritto";
 
-/* Class = "NSButtonCell"; title = "Generale:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Generale";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Use Web Page for Articles";
 
-/* Class = "NSButtonCell"; title = "Descrizione:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Descrizione";
 
-/* Class = "NSButtonCell"; title = "Use Web Page for Articles"; ObjectID = "126"; */
-"126.title" = "Use Web Page for Articles";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autenticazione";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Generale";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL Feed";

--- a/Interfaces/it.lproj/MainMenu.strings
+++ b/Interfaces/it.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Finestra";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Nascondi Barra di Stato";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Mostra Barra Filtro";

--- a/Interfaces/it.lproj/MainMenu.strings
+++ b/Interfaces/it.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Porta tutto in primo piano";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Ripristina";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Ortografia";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Ortografia";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Ortografia…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Controlla ortografia";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Controlla ortografia mentre scrivo";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Ridimensiona";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Aggiorna Iscrizioni Selezionate";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Riconoscimenti";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nuova Iscrizione…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Esporta le iscrizioni selezionate";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Sito Web Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Vuota Cestino";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Pannello Precedente";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Layout";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Rapporto";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Condensato";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Scarica Enclosure";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Personalizza Barra Strumenti…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Nascondi Barra di Stato";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Mantieni i gruppi di cartelle nel file esportato";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Ortografia";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Segnala Come Letto";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/it.lproj/RSSFeed.strings
+++ b/Interfaces/it.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "Feed RSS"; ObjectID = "6"; */
-"6.title" = "Feed RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "Feed RSS"; ObjectID = "49"; */
-"49.title" = "Feed RSS";
-
-/* Class = "NSButtonCell"; title = "Annulla"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Annulla";
 
-/* Class = "NSButtonCell"; title = "Iscriviti"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Iscriviti";
 
-/* Class = "NSTextFieldCell"; title = "Sorgente:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Sorgente:";
 
-/* Class = "NSTextFieldCell"; title = "Crea una nuova iscrizione RSS"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Crea una nuova iscrizione RSS";
 
-/* Class = "NSTextFieldCell"; title = "Inserisci il collegamento al feed RSS in basso. Oppure scegli dalla lista Sorgente ed inserisci il nome breve per il feed RSS fornito da tale sorgente."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Inserisci il collegamento al feed RSS in basso. Oppure scegli dalla lista Sorgente ed inserisci il nome breve per il feed RSS fornito da tale sorgente.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Registra"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Registra";
 
-/* Class = "NSButtonCell"; title = "Annulla"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Annulla";
 
-/* Class = "NSTextFieldCell"; title = "Modifica iscrizione"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Modifica iscrizione";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/it.lproj/SearchFolder.strings
+++ b/Interfaces/it.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "I nomi dei campi vanno qui"; ObjectID = "33"; */
-"33.title" = "I nomi dei campi vanno qui";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Gli operator vanno qui"; ObjectID = "56"; */
-"56.title" = "Gli operator vanno qui";
-
-/* Class = "NSMenuItem"; title = "Nessuna"; ObjectID = "62"; */
-"62.title" = "Nessuna";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nessuna"; ObjectID = "82"; */
-"82.title" = "Nessuna";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Nome cartella smart:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Nome cartella smart:";
 
-/* Class = "NSButtonCell"; title = "Registra"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Registra";
 
-/* Class = "NSButtonCell"; title = "Annulla"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Annulla";
 
-/* Class = "NSTextFieldCell"; title = "Contiene articoli che rispondono a"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Contiene articoli che rispondono a";
 
-/* Class = "NSTextFieldCell"; title = "seguenti:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "seguenti:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/it.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/it.lproj/SyncingPreferencesView.strings
@@ -1,18 +1,8 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
-
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
 
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
@@ -20,11 +10,8 @@
 /* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Password:";
 
-/* Class = "NSTextFieldCell"; title = "Nome:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Nome:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/ja.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/ja.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,11 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "通常 Vienna を使用するに当たってこの項目を設定する必要 はありません。各項目の詳細はヘルプを参照してください。\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "通常 Vienna を使用するに当たってこの項目を設定する必要 はありません。各項目の詳細はヘルプを参照してください。\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "通常 Vienna を使用するに当たってこの項目を設定する必要 はありません。各項目の詳細はヘルプを参照してください。
+";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +14,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "内蔵ブラウザの JavaScript を有効にする"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "内蔵ブラウザの JavaScript を有効にする";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/ja.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/ja.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "記事やウェブページを閲覧中："; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "記事やウェブページを閲覧中：";
 
-/* Class = "NSTextFieldCell"; title = "フォルダリストフォント："; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "フォルダリストフォント：";
 
-/* Class = "NSButtonCell"; title = "選択…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "選択…";
 
-/* Class = "NSButtonCell"; title = "フォルダリストでフォルダイメージを使用する"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "フォルダリストでフォルダイメージを使用する";
 
-/* Class = "NSTextFieldCell"; title = "記事リストフォント："; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "記事リストフォント：";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "選択…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "選択…";
 
-/* Class = "NSButtonCell"; title = "これより小さいフォントサイズを使わない："; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "これより小さいフォントサイズを使わない：";

--- a/Interfaces/ja.lproj/FeedCredentials.strings
+++ b/Interfaces/ja.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "キャンセル"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "キャンセル";
 
-/* Class = "NSTextFieldCell"; title = "名前："; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "名前：";
 
-/* Class = "NSTextFieldCell"; title = "%@ へのアクセスにはログイン証明が必要です"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "%@ へのアクセスにはログイン証明が必要です";
 
-/* Class = "NSTextFieldCell"; title = "パスワード："; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "パスワード：";
 
-/* Class = "NSButtonCell"; title = "ログイン"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "ログイン";
 
-/* Class = "NSTextFieldCell"; title = "この購読を更新するためにユーザ名とパスワードを記憶します。"; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "この購読を更新するためにユーザ名とパスワードを記憶します。";

--- a/Interfaces/ja.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/ja.lproj/GeneralPreferencesView.strings
@@ -1,80 +1,55 @@
-
-/* Class = "NSMenuItem"; title = "15分ごと"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "15分ごと";
 
-/* Class = "NSButtonCell"; title = "\"次の未読\" コマンドの後"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "\"次の未読\" コマンドの後";
 
-/* Class = "NSMenuItem"; title = "（パス）"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "（パス）";
-
-/* Class = "NSMenuItem"; title = "３０分ごと"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "３０分ごと";
 
-/* Class = "NSMenuItem"; title = "２時間ごと"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "２時間ごと";
 
-/* Class = "NSButtonCell"; title = "未読記事数をアプリケーションアイコンに表示"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "未読記事数をアプリケーションアイコンに表示";
 
-/* Class = "NSTextFieldCell"; title = "新規未読記事を取得したとき：\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "新規未読記事を取得したとき：\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "新規未読記事を取得したとき：";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "その他..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "その他...";
-
-/* Class = "NSMenuItem"; title = "なし"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "なし";
 
 /* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Check for newer versions of Vienna on start up";
 
-/* Class = "NSMenuItem"; title = "手動"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "手動";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "６時間ごと"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "６時間ごと";
 
-/* Class = "NSButtonCell"; title = "少したった後"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "少したった後";
 
 /* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Show in menu bar";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
-
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "リンクをデフォルトブラウザで開く"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "リンクをデフォルトブラウザで開く";
 
-/* Class = "NSTextFieldCell"; title = "新しい記事をチェック："; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "新しい記事をチェック：";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "ダウンロードしたファイルの保存先："; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "ダウンロードしたファイルの保存先：";
 
-/* Class = "NSButtonCell"; title = "アプリケーションアイコンを跳ねさせる"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "アプリケーションアイコンを跳ねさせる";
 
-/* Class = "NSMenuItem"; title = "3時間ごと"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "3時間ごと";
 
 /* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
@@ -86,13 +61,13 @@
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "5分ごと"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "5分ごと";
 
 /* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Check for new articles on start up";
 
-/* Class = "NSButtonCell"; title = "新しいリンクを背面で開く"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "新しいリンクを背面で開く";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Mark current article read:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Mark current article read:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Mark current article read:";
 
-/* Class = "NSMenuItem"; title = "１時間ごと"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "１時間ごと";

--- a/Interfaces/ja.lproj/GroupFolder.strings
+++ b/Interfaces/ja.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "パネル"; ObjectID = "5"; */
-"5.title" = "パネル";
-
-/* Class = "NSTextFieldCell"; title = "新規グループフォルダ"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "新規グループフォルダ";
 
-/* Class = "NSButtonCell"; title = "保存"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "保存";
 
-/* Class = "NSButtonCell"; title = "キャンセル"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "キャンセル";
 
-/* Class = "NSTextFieldCell"; title = "グループフォルダ名を入力：\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "グループフォルダ名を入力：";

--- a/Interfaces/ja.lproj/InfoWindow.strings
+++ b/Interfaces/ja.lproj/InfoWindow.strings
@@ -1,51 +1,35 @@
-
-/* Class = "NSWindow"; title = "ウインドウ"; ObjectID = "5"; */
-"5.title" = "ウインドウ";
-
-/* Class = "NSTextFieldCell"; title = "(Folder name)"; ObjectID = "104"; */
-"104.title" = "(Folder name)";
-
-/* Class = "NSTextFieldCell"; title = "最後の更新："; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "最後の更新：";
 
-/* Class = "NSTextFieldCell"; title = "(Last refresh date)"; ObjectID = "106"; */
-"106.title" = "(Last refresh date)";
-
-/* Class = "NSButtonCell"; title = "確認"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "確認";
 
-/* Class = "NSButtonCell"; title = "フィード URL："; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "フィード URL";
-
-/* Class = "NSTextFieldCell"; title = "ユーザ名："; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "ユーザ名：";
 
-/* Class = "NSTextFieldCell"; title = "パスワード：\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "パスワード：";
 
-/* Class = "NSButtonCell"; title = "アップデート認証"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "アップデート認証";
 
-/* Class = "NSTextFieldCell"; title = "サイズ："; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "サイズ：";
 
-/* Class = "NSTextFieldCell"; title = "未読：\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "未読：";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "購読中"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "購読中";
 
-/* Class = "NSButtonCell"; title = "一般："; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "一般";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Use Web Page for Articles";
 
-/* Class = "NSButtonCell"; title = "説明："; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "説明";
 
-/* Class = "NSButtonCell"; title = "Use Web Page for Articles"; ObjectID = "126"; */
-"126.title" = "Use Web Page for Articles";
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "一般";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "フィード URL";

--- a/Interfaces/ja.lproj/MainMenu.strings
+++ b/Interfaces/ja.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "ウインドウ";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Hide Status Bar";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Show Filter Bar";

--- a/Interfaces/ja.lproj/MainMenu.strings
+++ b/Interfaces/ja.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "すべてを手前に移動";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "やり直し";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "スペル";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "スペル";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "スペル…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "スペルチェック";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "入力中に自動スペルチェック";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "拡大／縮小";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "選択された購読を更新";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "謝辞";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "新規購読…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "選択中の購読を書き出す";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna ホームページ";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "ゴミ箱を空にする";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "前のタブ";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "レイアウト";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "レポート";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "凝縮";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Download Enclosure";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Customize Toolbar…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Hide Status Bar";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,12 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "グループフォルダをファイルに書き出す";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:
+";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +389,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "スペル";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "既読にする";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/ja.lproj/RSSFeed.strings
+++ b/Interfaces/ja.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS フィード"; ObjectID = "6"; */
-"6.title" = "RSS フィード";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS フィード"; ObjectID = "49"; */
-"49.title" = "RSS フィード";
-
-/* Class = "NSButtonCell"; title = "キャンセル"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "キャンセル";
 
-/* Class = "NSButtonCell"; title = "購読"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "購読";
 
-/* Class = "NSTextFieldCell"; title = "ソース："; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "ソース：";
 
-/* Class = "NSTextFieldCell"; title = "新規購読を作成"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "新規購読を作成";
 
-/* Class = "NSTextFieldCell"; title = "ニュースフィードへのリンクを入力してください。またはソースリストからニュースフィードのショートカット名を入力してください。"; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "ニュースフィードへのリンクを入力してください。またはソースリストからニュースフィードのショートカット名を入力してください。";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "保存"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "保存";
 
-/* Class = "NSButtonCell"; title = "キャンセル"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "キャンセル";
 
-/* Class = "NSTextFieldCell"; title = "購読を編集"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "購読を編集";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/ja.lproj/SearchFolder.strings
+++ b/Interfaces/ja.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "フィールド名"; ObjectID = "33"; */
-"33.title" = "フィールド名";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "オペレータ"; ObjectID = "56"; */
-"56.title" = "オペレータ";
-
-/* Class = "NSMenuItem"; title = "なし"; ObjectID = "62"; */
-"62.title" = "なし";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "なし"; ObjectID = "82"; */
-"82.title" = "なし";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "スマートフォルダ名："; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "スマートフォルダ名：";
 
-/* Class = "NSButtonCell"; title = "保存"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "保存";
 
-/* Class = "NSButtonCell"; title = "キャンセル"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "キャンセル";
 
-/* Class = "NSTextFieldCell"; title = "以下の条件の"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "以下の条件の";
 
-/* Class = "NSTextFieldCell"; title = "に一致したすべての記事を表示："; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "に一致したすべての記事を表示：";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/ja.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/ja.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "パスワード："; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "パスワード：";
 
-/* Class = "NSTextFieldCell"; title = "名前："; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "名前：";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/ko.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/ko.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,11 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Vienna 를 일반적인 사용시에는 이 설정들을 변경할 필요가 없습니다. 각 설정에 대한 상세정보는 도움말을 참고하십시오.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Vienna 를 일반적인 사용시에는 이 설정들을 변경할 필요가 없습니다. 각 설정에 대한 상세정보는 도움말을 참고하십시오.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Vienna 를 일반적인 사용시에는 이 설정들을 변경할 필요가 없습니다. 각 설정에 대한 상세정보는 도움말을 참고하십시오.
+";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +14,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "내부 브라우져에서 자바스크립트 사용"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "내부 브라우져에서 자바스크립트 사용";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/ko.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/ko.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "기사 및 웹페이지 보기:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "기사 및 웹페이지 보기:";
 
-/* Class = "NSTextFieldCell"; title = "폴더 및 구독 목록  서체:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "폴더 및 구독 목록  서체:";
 
-/* Class = "NSButtonCell"; title = "선택…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "선택…";
 
-/* Class = "NSButtonCell"; title = "구독 목록에 아이콘 이미지 사용"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "구독 목록에 아이콘 이미지 사용";
 
-/* Class = "NSTextFieldCell"; title = "기사 목록  서체:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "기사 목록  서체:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "선택…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "선택…";
 
-/* Class = "NSButtonCell"; title = "다음보다 작은 서체 크기 사용 안함:"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "다음보다 작은 서체 크기 사용 안함:";

--- a/Interfaces/ko.lproj/FeedCredentials.strings
+++ b/Interfaces/ko.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "취소"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "취소";
 
-/* Class = "NSTextFieldCell"; title = "이름:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "이름:";
 
-/* Class = "NSTextFieldCell"; title = "%@ 구독은 로그인을 요구합니다."; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "%@ 구독은 로그인을 요구합니다.";
 
-/* Class = "NSTextFieldCell"; title = "암호:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "암호:";
 
-/* Class = "NSButtonCell"; title = "로그인"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "로그인";
 
-/* Class = "NSTextFieldCell"; title = "입력한 사용자 이름과 암호는 다음에 이 구독을 갱신시 사용하기\n위해 기억됩니다."; ObjectID = "39"; */
-"39.title" = "입력한 사용자 이름과 암호는 다음에 이 구독을 갱신시 사용하기\n위해 기억됩니다.";
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
+"39.title" = "입력한 사용자 이름과 암호는 다음에 이 구독을 갱신시 사용하기 위해 기억됩니다.";

--- a/Interfaces/ko.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/ko.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "15분마다"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "15분마다";
 
-/* Class = "NSButtonCell"; title = "\"읽지 않은 다음 항목\" 명령을 실행한 후에"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "\"읽지 않은 다음 항목\" 명령을 실행한 후에";
 
-/* Class = "NSMenuItem"; title = "(Path)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Path)";
-
-/* Class = "NSMenuItem"; title = "30분마다"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "30분마다";
 
-/* Class = "NSMenuItem"; title = "2시간마다"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "2시간마다";
 
-/* Class = "NSButtonCell"; title = "응용 프로그램 아이콘에 읽지 않은 항목 수 표시"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "응용 프로그램 아이콘에 읽지 않은 항목 수 표시";
 
-/* Class = "NSTextFieldCell"; title = "읽지 않은 새 기사 추가시:"; ObjectID = "BbI-0A-zEG"; */
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
 "BbI-0A-zEG.title" = "읽지 않은 새 기사 추가시:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "선택..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "선택...";
 
-/* Class = "NSMenuItem"; title = "없음"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "없음";
-
-/* Class = "NSButtonCell"; title = "시작시 새 버전의 Vienna 확인   링크를 항상 백그라운드 상태로 열기"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "시작시 새 버전의 Vienna 확인   링크를 항상 백그라운드 상태로 열기";
 
-/* Class = "NSMenuItem"; title = "수동으로"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "수동으로";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "6시간마다"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "6시간마다";
 
-/* Class = "NSButtonCell"; title = "일정 시간 지연 후에"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "일정 시간 지연 후에";
 
 /* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Show in menu bar";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
-
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "링크를 외부(기본) 브라우저로 열기"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "링크를 외부(기본) 브라우저로 열기";
 
-/* Class = "NSTextFieldCell"; title = "새 기사 확인:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "새 기사 확인:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "링크를 항상 백그라운드 상태로 열기다운로드한 파일 저장:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "링크를 항상 백그라운드 상태로 열기다운로드한 파일 저장:";
 
-/* Class = "NSButtonCell"; title = "응용 프로그램 아이콘 움직이기"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "응용 프로그램 아이콘 움직이기";
 
-/* Class = "NSMenuItem"; title = "3시간마다"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "3시간마다";
 
 /* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Move articles to Trash:";
 
-/* Class = "NSTextFieldCell"; title = "링크를 외부(기본) 브라우져로 열기"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "링크를 외부(기본) 브라우져로 열기";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "5분마다 "; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "5분마다 ";
 
 /* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Check for new articles on start up";
 
-/* Class = "NSButtonCell"; title = "링크를 항상 백그라운드 상태로 열기"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "링크를 항상 백그라운드 상태로 열기";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Mark current article read:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Mark current article read:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Mark current article read:";
 
-/* Class = "NSMenuItem"; title = "1시간마다"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "1시간마다";

--- a/Interfaces/ko.lproj/GroupFolder.strings
+++ b/Interfaces/ko.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "새 그룹 폴더 추가"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "새 그룹 폴더 추가";
 
-/* Class = "NSButtonCell"; title = "추가"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "추가";
 
-/* Class = "NSButtonCell"; title = "취소"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "취소";
 
-/* Class = "NSTextFieldCell"; title = "새 그룹 폴더의 이름을 입력하십시오:"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "새 그룹 폴더의 이름을 입력하십시오:";

--- a/Interfaces/ko.lproj/InfoWindow.strings
+++ b/Interfaces/ko.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Window"; ObjectID = "5"; */
-"5.title" = "Window";
-
-/* Class = "NSTextFieldCell"; title = "(Folder name)"; ObjectID = "104"; */
-"104.title" = "(Folder name)";
-
-/* Class = "NSTextFieldCell"; title = "최종 갱신일:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "최종 갱신일:";
 
-/* Class = "NSTextFieldCell"; title = "(Last refresh date)"; ObjectID = "106"; */
-"106.title" = "(Last refresh date)";
-
-/* Class = "NSButtonCell"; title = "피드 확인"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "피드 확인";
 
-/* Class = "NSButtonCell"; title = "피드 URL:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "피드 URL";
-
-/* Class = "NSTextFieldCell"; title = "이름:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "이름:";
 
-/* Class = "NSTextFieldCell"; title = "암호:"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "암호:";
 
-/* Class = "NSButtonCell"; title = "인증 갱신"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "인증 갱신";
 
-/* Class = "NSButtonCell"; title = "인증:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "인증";
-
-/* Class = "NSTextFieldCell"; title = "전체:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "전체:";
 
-/* Class = "NSTextFieldCell"; title = "현재:"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "현재:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "구독하기"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "구독하기";
 
-/* Class = "NSButtonCell"; title = "일반:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "일반";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Use Web Page for Articles";
 
-/* Class = "NSButtonCell"; title = "설명:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "설명";
 
-/* Class = "NSButtonCell"; title = "Use Web Page for Articles"; ObjectID = "126"; */
-"126.title" = "Use Web Page for Articles";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "인증";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "일반";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "피드 URL";

--- a/Interfaces/ko.lproj/MainMenu.strings
+++ b/Interfaces/ko.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "윈도우";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "메인메뉴";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Hide Status Bar";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Show Filter Bar";

--- a/Interfaces/ko.lproj/MainMenu.strings
+++ b/Interfaces/ko.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "모두 앞으로 가져오기";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "복귀";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "철자 검사";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "철자 검사";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "철자 검사…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "철자 검사";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "입력시 철자 검사";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "확대 및 축소";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "선택된 구독 갱신";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "감사의 말";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "새 구독…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "선택된 항목만";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna 웹사이트";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "휴지통 비우기";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "이전 탭";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "레이아웃";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "일반";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "수직 배열";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Download Enclosure";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Customize Toolbar…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Hide Status Bar";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "그룹 폴더의 구조 유지";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "철자 검사";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "읽음으로 표시";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/ko.lproj/RSSFeed.strings
+++ b/Interfaces/ko.lproj/RSSFeed.strings
@@ -1,35 +1,25 @@
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "6"; */
-"6.title" = "RSS Feed";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "49"; */
-"49.title" = "RSS Feed";
-
-/* Class = "NSButtonCell"; title = "취소"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "취소";
 
-/* Class = "NSButtonCell"; title = "구독하기"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "구독하기";
 
-/* Class = "NSTextFieldCell"; title = "추가"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "추가";
 
 /* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Create a new subscription";
 
-/* Class = "NSTextFieldCell"; title = "새 구독 추가"; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "새 구독 추가";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "URL:"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "저장"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "저장";
 
 /* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */

--- a/Interfaces/ko.lproj/SearchFolder.strings
+++ b/Interfaces/ko.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Field names go here"; ObjectID = "33"; */
-"33.title" = "Field names go here";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "62"; */
-"62.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "82"; */
-"82.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "스마트 폴더 이름:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "스마트 폴더 이름:";
 
-/* Class = "NSButtonCell"; title = "저장"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "저장";
 
-/* Class = "NSButtonCell"; title = "취소"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "취소";
 
-/* Class = "NSTextFieldCell"; title = "다음의"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "다음의";
 
-/* Class = "NSTextFieldCell"; title = "조건에 일치하는 모든 기사 항목:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "조건에 일치하는 모든 기사 항목:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/ko.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/ko.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "암호:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "암호:";
 
-/* Class = "NSTextFieldCell"; title = "이름:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "이름:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/nl.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/nl.lproj/AdvancedPreferencesView.strings
@@ -1,42 +1,38 @@
-
-/* Class = "NSTextFieldCell"; title = "Hoe hoger de waarde, des te sneller worden uw abonnementen gedownload."; ObjectID = "2GQ-cu-fbh"; */
+/* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "Hoe hoger de waarde, des te sneller worden uw abonnementen gedownload.";
 
-/* Class = "NSTextFieldCell"; title = "Deze instellingen hoeven niet veranderd te worden voor normaal gebruik van Vienna. Kijk in de Help voor informatie over de instellingen."; ObjectID = "GaX-8c-QaN"; */
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
 "GaX-8c-QaN.title" = "Deze instellingen hoeven niet veranderd te worden voor normaal gebruik van Vienna. Kijk in de Help voor informatie over de instellingen.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
-/* Class = "NSTextFieldCell"; title = "Gelijktijdige downloads:"; ObjectID = "Ngw-hP-yW4"; */
+/* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
 "Ngw-hP-yW4.title" = "Gelijktijdige downloads:";
 
-/* Class = "NSTextFieldCell"; title = "Echter, hogere waarden kunnen er ook voor zorgen dat uw computer trager reageert tijdens het downloaden van abonnementen."; ObjectID = "S3T-cW-hys"; */
+/* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "Echter, hogere waarden kunnen er ook voor zorgen dat uw computer trager reageert tijdens het downloaden van abonnementen.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Activeer JavaScript in interne browser"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Activeer JavaScript in interne browser";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/nl.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/nl.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Weergave van artikelen en webpagina's:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Weergave van artikelen en webpagina's:";
 
-/* Class = "NSTextFieldCell"; title = "Lettertype voor lijsten:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Lettertype voor lijsten:";
 
-/* Class = "NSButtonCell"; title = "Kies…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Kies…";
 
-/* Class = "NSButtonCell"; title = "Toon symbolen in mappenlijst"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Toon symbolen in mappenlijst";
 
-/* Class = "NSTextFieldCell"; title = "Lettertype voor artikelen:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Lettertype voor artikelen:";
 
-/* Class = "NSTextFieldCell"; title = "(Voorbeeld)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Voorbeeld)";
-
-/* Class = "NSTextFieldCell"; title = "(Voorbeeld)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Voorbeeld)";
-
-/* Class = "NSButtonCell"; title = "Kies…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Kies…";
 
-/* Class = "NSButtonCell"; title = "Gebruik nooit lettergrootte kleiner dan:"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Gebruik nooit lettergrootte kleiner dan:";

--- a/Interfaces/nl.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/nl.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Empty Trash"; ObjectID = "5"; */
-"5.title" = "Empty Trash";
-
-/* Class = "NSButtonCell"; title = "Leeg prullenmand"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Leeg prullenmand";
 
-/* Class = "NSButtonCell"; title = "Annuleer"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Annuleer";
 
-/* Class = "NSTextFieldCell"; title = "Er zijn gewiste artikelen in de prullenmand.\nWil u de prullenmand nu leeg maken?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Er zijn gewiste artikelen in de prullenmand. Wilt u de prullenmand nu leeg maken?";
 
-/* Class = "NSButtonCell"; title = "Toon deze waarschuwing niet opnieuw"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Toon deze waarschuwing niet opnieuw";

--- a/Interfaces/nl.lproj/FeedCredentials.strings
+++ b/Interfaces/nl.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Annuleer"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Annuleer";
 
-/* Class = "NSTextFieldCell"; title = "Gebruikersnaam:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Gebruikersnaam:";
 
-/* Class = "NSTextFieldCell"; title = "U dient een gebruikersnaam en wachtwoord op te geven om toegang te krijgen tot %@."; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "U dient een gebruikersnaam en wachtwoord op te geven om toegang te krijgen tot %@.";
 
-/* Class = "NSTextFieldCell"; title = "Wachtwoord:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Wachtwoord:";
 
-/* Class = "NSButtonCell"; title = "Log in"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Log in";
 
-/* Class = "NSTextFieldCell"; title = "De opgegeven gebruikersnaam en wachtwoord zullen worden opgeslagen, zodat u deze niet nog eens hoeft op te geven."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "De opgegeven gebruikersnaam en wachtwoord zullen worden opgeslagen, zodat u deze niet nog eens hoeft op te geven.";

--- a/Interfaces/nl.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/nl.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "Elke 15 minuten"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Elke 15 minuten";
 
-/* Class = "NSButtonCell"; title = "Na \"Volgende ongelezen\"-commando"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Na \"Volgende ongelezen\"-commando";
 
-/* Class = "NSMenuItem"; title = "(Pad)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Pad)";
-
-/* Class = "NSMenuItem"; title = "Elke 30 minuten"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Elke 30 minuten";
 
-/* Class = "NSMenuItem"; title = "Elke 2 uur"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Elke 2 uur";
 
-/* Class = "NSButtonCell"; title = "Toon het aantal ongelezen artikelen in de Dock"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Toon het aantal ongelezen artikelen in de Dock";
 
-/* Class = "NSTextFieldCell"; title = "Wanneer nieuwe ongelezen artikelen zijn opgehaald:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Wanneer nieuwe ongelezen artikelen zijn opgehaald:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Wanneer nieuwe ongelezen artikelen zijn opgehaald:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Andere..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Andere...";
 
-/* Class = "NSMenuItem"; title = "Niets"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Niets";
-
-/* Class = "NSButtonCell"; title = "Zoek naar nieuwere versie bij het starten"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Zoek naar nieuwere versie bij het starten";
 
-/* Class = "NSMenuItem"; title = "Handmatig"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Handmatig";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Elke 6 uur"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Elke 6 uur";
 
-/* Class = "NSButtonCell"; title = "Na een korte vertraging"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Na een korte vertraging";
 
-/* Class = "NSButtonCell"; title = "Toon in menubalk"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Toon in menubalk";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Open koppeling in externe browser"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Open koppeling in externe browser";
 
-/* Class = "NSTextFieldCell"; title = "Zoek naar nieuwe artikelen:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Zoek naar nieuwe artikelen:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Bewaar downloads in:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Bewaar downloads in:";
 
-/* Class = "NSButtonCell"; title = "Springend toepassingssymbool"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Springend toepassingssymbool";
 
-/* Class = "NSMenuItem"; title = "Elke 3 uur"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Elke 3 uur";
 
-/* Class = "NSTextFieldCell"; title = "Verplaats artikelen naar prullenmand:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Verplaats artikelen naar prullenmand:";
 
-/* Class = "NSTextFieldCell"; title = "Standaard RSS-lezer:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Standaard RSS-lezer:";
 
-/* Class = "NSButtonCell"; title = "Markeer bijgewerkte artikelen als nieuw"; ObjectID = "meo-78-YOl"; */
+/* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Markeer bijgewerkte artikelen als nieuw";
 
-/* Class = "NSMenuItem"; title = "Elke 5 minuten"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Elke 5 minuten";
 
-/* Class = "NSButtonCell"; title = "Zoek naar nieuwe artikelen bij het starten"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Zoek naar nieuwe artikelen bij het starten";
 
-/* Class = "NSButtonCell"; title = "Open koppeling op de achtergrond"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Open koppeling op de achtergrond";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Markeer huidige artikel als gelezen:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Markeer huidige artikel als gelezen:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Markeer huidige artikel als gelezen:";
 
-/* Class = "NSMenuItem"; title = "Elk uur"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Elk uur";

--- a/Interfaces/nl.lproj/GroupFolder.strings
+++ b/Interfaces/nl.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Paneel"; ObjectID = "5"; */
-"5.title" = "Paneel";
-
-/* Class = "NSTextFieldCell"; title = "Nieuwe groep-map"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nieuwe groep-map";
 
-/* Class = "NSButtonCell"; title = "Bewaar"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Bewaar";
 
-/* Class = "NSButtonCell"; title = "Annuleer"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Annuleer";
 
-/* Class = "NSTextFieldCell"; title = "Geef de naam van de groep-map:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Geef de naam van de groep-map:";

--- a/Interfaces/nl.lproj/InfoWindow.strings
+++ b/Interfaces/nl.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Venster"; ObjectID = "5"; */
-"5.title" = "Venster";
-
-/* Class = "NSTextFieldCell"; title = "(Mapnaam)"; ObjectID = "104"; */
-"104.title" = "(Mapnaam)";
-
-/* Class = "NSTextFieldCell"; title = "Laatste keer vernieuwd:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Laatste keer vernieuwd:";
 
-/* Class = "NSTextFieldCell"; title = "(Datum laatste vernieuwing)"; ObjectID = "106"; */
-"106.title" = "(Datum laatste vernieuwing)";
-
-/* Class = "NSButtonCell"; title = "Valideer"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Valideer";
 
-/* Class = "NSButtonCell"; title = "URL van feed:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL van feed";
-
-/* Class = "NSTextFieldCell"; title = "Gebruikersnaam:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Gebruikersnaam:";
 
-/* Class = "NSTextFieldCell"; title = "Wachtwoord:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Wachtwoord:";
 
-/* Class = "NSButtonCell"; title = "Werk authenticatie bij"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Werk authenticatie bij";
 
-/* Class = "NSButtonCell"; title = "Authenticatie:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Authenticatie";
-
-/* Class = "NSTextFieldCell"; title = "Grootte:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Grootte:";
 
-/* Class = "NSTextFieldCell"; title = "Ongelezen:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Ongelezen:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Geabonneerd"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Geabonneerd";
 
-/* Class = "NSButtonCell"; title = "Algemeen:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Algemeen";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Gebruik webpagina voor artikelen";
 
-/* Class = "NSButtonCell"; title = "Omschrijving:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Omschrijving";
 
-/* Class = "NSButtonCell"; title = "Gebruik webpagina voor artikelen"; ObjectID = "126"; */
-"126.title" = "Gebruik webpagina voor artikelen";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Authenticatie";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Algemeen";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL van feed";

--- a/Interfaces/nl.lproj/MainMenu.strings
+++ b/Interfaces/nl.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Venster";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Verberg statusbalk";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Toon filterbalk";

--- a/Interfaces/nl.lproj/MainMenu.strings
+++ b/Interfaces/nl.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Alles op voorgrond";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Opnieuw";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Spelling";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Spelling";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Spelling…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Controleer spelling";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Controleer spelling tijdens typen";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Vergroot/verklein";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Werk geselecteerde abonnementen bij";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Dankwoord";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nieuw abonnement…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exporteer geselecteerde abonnementen";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna-website";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Leeg prullenmand";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Vorige tab";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Lay-out";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Rapport";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Verkort";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Download bijlage";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Pas knoppenbalk aan…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Verberg statusbalk";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Op naam";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Behoud groeperingen in exportbestand";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Spelling";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Markeer als gelezen";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/nl.lproj/RSSFeed.strings
+++ b/Interfaces/nl.lproj/RSSFeed.strings
@@ -1,39 +1,29 @@
-
-/* Class = "NSWindow"; title = "RSS-feed"; ObjectID = "6"; */
-"6.title" = "RSS-feed";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS-feed"; ObjectID = "49"; */
-"49.title" = "RSS-feed";
-
-/* Class = "NSButtonCell"; title = "Annuleer"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Annuleer";
 
-/* Class = "NSButtonCell"; title = "Abonneer"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Abonneer";
 
-/* Class = "NSTextFieldCell"; title = "Bron:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Bron:";
 
-/* Class = "NSTextFieldCell"; title = "Neem een nieuw abonnement"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Neem een nieuw abonnement";
 
-/* Class = "NSTextFieldCell"; title = "Geef hieronder de koppeling voor het abonnement op, of kies een door de uitgever aangegeven koppeling op uit het menu hieronder."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Geef hieronder de koppeling voor het abonnement op, of kies een door de uitgever aangegeven koppeling op uit het menu hieronder.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Bewaar"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Bewaar";
 
-/* Class = "NSButtonCell"; title = "Annuleer"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Annuleer";
 
-/* Class = "NSTextFieldCell"; title = "Bewerk abonnement"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Bewerk abonnement";
 
-/* Class = "NSButtonCell"; title = "Abonneer in Open Reader"; ObjectID = "116"; */
+/* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */
 "116.title" = "Abonneer in Open Reader";

--- a/Interfaces/nl.lproj/SearchFolder.strings
+++ b/Interfaces/nl.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Veldnamen komen hier"; ObjectID = "33"; */
-"33.title" = "Veldnamen komen hier";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "Niets"; ObjectID = "62"; */
-"62.title" = "Niets";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Niets"; ObjectID = "82"; */
-"82.title" = "Niets";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Naam voor slimme map:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Naam voor slimme map:";
 
-/* Class = "NSButtonCell"; title = "Bewaar"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Bewaar";
 
-/* Class = "NSButtonCell"; title = "Annuleer"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Annuleer";
 
-/* Class = "NSTextFieldCell"; title = "Toon de artikelen die voldoen aan:"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Toon de artikelen die voldoen aan:";
 
-/* Class = "NSTextFieldCell"; title = "van de volgende voorwaarden:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "van de volgende voorwaarden:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/nl.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/nl.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
-/* Class = "NSButtonCell"; title = "Synchroniseer met een Open Reader server"; ObjectID = "Lkv-md-rEW"; */
+/* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Synchroniseer met een Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Wachtwoord:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Wachtwoord:";
 
-/* Class = "NSTextFieldCell"; title = "Gebruikersnaam:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Gebruikersnaam:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/pt-BR.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/pt-BR.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Estes ajustes não devem ser alterados para o uso normal do Vienna. Veja o arquivo de Ajuda para detalhes de cada ajuste.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Estes ajustes não devem ser alterados para o uso normal do Vienna. Veja o arquivo de Ajuda para detalhes de cada ajuste.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Estes ajustes não devem ser alterados para o uso normal do Vienna. Veja o arquivo de Ajuda para detalhes de cada ajuste.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Habilitar JavaScript no browser interno"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Habilitar JavaScript no browser interno";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/pt-BR.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/pt-BR.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Ao visualizar artigos ou páginas da web:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Ao visualizar artigos ou páginas da web:";
 
-/* Class = "NSTextFieldCell"; title = "Fonte da lista de pastas:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Fonte da lista de pastas:";
 
-/* Class = "NSButtonCell"; title = "Selecionar…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Selecionar…";
 
-/* Class = "NSButtonCell"; title = "Mostrar imagens de pastas na lista de pastas"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Mostrar imagens de pastas na lista de pastas";
 
-/* Class = "NSTextFieldCell"; title = "Fonte da lista de artigos:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Fonte da lista de artigos:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Selecionar…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Selecionar…";
 
-/* Class = "NSButtonCell"; title = "Nunca usar fontes menores que"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Nunca usar fontes menores que";

--- a/Interfaces/pt-BR.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/pt-BR.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Esvaziar Lixeira"; ObjectID = "5"; */
-"5.title" = "Esvaziar Lixeira";
-
-/* Class = "NSButtonCell"; title = "Esvaziar Lixeira"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Esvaziar Lixeira";
 
-/* Class = "NSButtonCell"; title = "Não Esvaziar Lixeira"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Não Esvaziar Lixeira";
 
-/* Class = "NSTextFieldCell"; title = "Existem artigos apagados na lixeira.\nVocê deseja esvaziar a lixeira antes de encerrar?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Existem artigos apagados na lixeira. Você deseja esvaziar a lixeira antes de encerrar?";
 
-/* Class = "NSButtonCell"; title = "Não mostrar este aviso novamente"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Não mostrar este aviso novamente";

--- a/Interfaces/pt-BR.lproj/FeedCredentials.strings
+++ b/Interfaces/pt-BR.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Nome:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Nome:";
 
-/* Class = "NSTextFieldCell"; title = "Acessar %@ requer que você entre suas credenciais"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Acessar %@ requer que você entre suas credenciais";
 
-/* Class = "NSTextFieldCell"; title = "Senha:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Senha:";
 
-/* Class = "NSButtonCell"; title = "Entrar"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Entrar";
 
-/* Class = "NSTextFieldCell"; title = "O nome de usuário e senha fornecidos serão lembrados da próxima vez que você atualizar esta assinatura."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "O nome de usuário e senha fornecidos serão lembrados da próxima vez que você atualizar esta assinatura.";

--- a/Interfaces/pt-BR.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/pt-BR.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "A cada 15 minutos"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "A cada 15 minutos";
 
-/* Class = "NSButtonCell"; title = "Após o comando \"Próxima não lida\" "; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Após o comando \"Próxima não lida\" ";
 
-/* Class = "NSMenuItem"; title = "(Caminho)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Caminho)";
-
-/* Class = "NSMenuItem"; title = "A cada 30 minutos"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "A cada 30 minutos";
 
-/* Class = "NSMenuItem"; title = "A cada 2 horas"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "A cada 2 horas";
 
-/* Class = "NSButtonCell"; title = "Mostrar número de não lidos no ícone do programa"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Mostrar número de não lidos no ícone do programa";
 
-/* Class = "NSTextFieldCell"; title = "Quando novos artigos são recebidos:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Quando novos artigos são recebidos:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Quando novos artigos são recebidos:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Outro..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Outro...";
 
-/* Class = "NSMenuItem"; title = "Nada"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Nada";
-
-/* Class = "NSButtonCell"; title = "Verificar novas versões do Vienna ao iniciar"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Verificar novas versões do Vienna ao iniciar";
 
-/* Class = "NSMenuItem"; title = "Manualmente"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manualmente";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "A cada 6 horas"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "A cada 6 horas";
 
-/* Class = "NSButtonCell"; title = "Após pequeno atraso"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Após pequeno atraso";
 
-/* Class = "NSButtonCell"; title = "Mostrar na barra de menu"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Mostrar na barra de menu";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Abrir links em um navegador externo"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Abrir links em um navegador externo";
 
-/* Class = "NSTextFieldCell"; title = "Verificar novos artigos:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Verificar novos artigos:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Salvar arquivos descarregados em:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Salvar arquivos descarregados em:";
 
-/* Class = "NSButtonCell"; title = "Animar o ícone do programa"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Animar o ícone do programa";
 
-/* Class = "NSMenuItem"; title = "A cada 3 horas"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "A cada 3 horas";
 
-/* Class = "NSTextFieldCell"; title = "Mover artigos para o Lixo:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Mover artigos para o Lixo:";
 
-/* Class = "NSTextFieldCell"; title = "Leitor RSS padrão:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Leitor RSS padrão:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "A cada 5 minutos"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "A cada 5 minutos";
 
-/* Class = "NSButtonCell"; title = "Verificar novos artigos ao iniciar"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Verificar novos artigos ao iniciar";
 
-/* Class = "NSButtonCell"; title = "Abrir novos links no fundo"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Abrir novos links no fundo";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Marcar artigo atual como lido:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Marcar artigo atual como lido:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Marcar artigo atual como lido:";
 
-/* Class = "NSMenuItem"; title = "A cada hora"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "A cada hora";

--- a/Interfaces/pt-BR.lproj/GroupFolder.strings
+++ b/Interfaces/pt-BR.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Painel"; ObjectID = "5"; */
-"5.title" = "Painel";
-
-/* Class = "NSTextFieldCell"; title = "Nova pasta de grupo"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nova pasta de grupo";
 
-/* Class = "NSButtonCell"; title = "Salvar"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Salvar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Entre o nome da pasta de grupo:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Entre o nome da pasta de grupo:";

--- a/Interfaces/pt-BR.lproj/InfoWindow.strings
+++ b/Interfaces/pt-BR.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Janela"; ObjectID = "5"; */
-"5.title" = "Janela";
-
-/* Class = "NSTextFieldCell"; title = "(Nome da pasta)"; ObjectID = "104"; */
-"104.title" = "(Nome da pasta)";
-
-/* Class = "NSTextFieldCell"; title = "Última atualização:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Última atualização:";
 
-/* Class = "NSTextFieldCell"; title = "(Última data de atualização)"; ObjectID = "106"; */
-"106.title" = "(Última data de atualização)";
-
-/* Class = "NSButtonCell"; title = "Validar"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Validar";
 
-/* Class = "NSButtonCell"; title = "URL das notícias:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL das notícias";
-
-/* Class = "NSTextFieldCell"; title = "Usuário:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Usuário:";
 
-/* Class = "NSTextFieldCell"; title = "Senha:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Senha:";
 
-/* Class = "NSButtonCell"; title = "Atualizar Autenticação"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Atualizar Autenticação";
 
-/* Class = "NSButtonCell"; title = "Autenticação:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autenticação";
-
-/* Class = "NSTextFieldCell"; title = "Tamanho:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Tamanho:";
 
-/* Class = "NSTextFieldCell"; title = "Não lido:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Não lido:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Assinado"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Assinado";
 
-/* Class = "NSButtonCell"; title = "Geral:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Geral";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Use Web Page for Articles";
 
-/* Class = "NSButtonCell"; title = "Descrição:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Descrição";
 
-/* Class = "NSButtonCell"; title = "Use Web Page for Articles"; ObjectID = "126"; */
-"126.title" = "Use Web Page for Articles";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autenticação";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Geral";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL das notícias";

--- a/Interfaces/pt-BR.lproj/MainMenu.strings
+++ b/Interfaces/pt-BR.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Trazer Todas para Frente";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Refazer";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Ortografia";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Ortografia";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Ortografia…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Verificar Ortografia";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Verificar Ortografia ao Digitar";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoom";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Atualizar Assinaturas Selecionadas";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Agradecimentos";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nova Assinatura…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportar assinaturas selecionadas";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Web Site do Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Limpar Lixeira";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Aba Anterior";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Layout";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Relatório";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Condensado";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Descarregar Anexo";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Personalizar Barra de Ferramentas…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar Barra de Status";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Nome";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Preservar pastas de grupo no arquivo exportado";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindexando banco de dados";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Ortografia";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Marcar Como Lido";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/pt-BR.lproj/MainMenu.strings
+++ b/Interfaces/pt-BR.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Janela";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar Barra de Status";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Mostrar Barra de Filtragem";

--- a/Interfaces/pt-BR.lproj/RSSFeed.strings
+++ b/Interfaces/pt-BR.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS"; ObjectID = "6"; */
-"6.title" = "RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS"; ObjectID = "49"; */
-"49.title" = "RSS";
-
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Cancelar";
 
-/* Class = "NSButtonCell"; title = "Assinar"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Assinar";
 
-/* Class = "NSTextFieldCell"; title = "Origem:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Origem:";
 
-/* Class = "NSTextFieldCell"; title = "Criar nova assinatura"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Criar nova assinatura";
 
-/* Class = "NSTextFieldCell"; title = "Entre o link das notícias abaixo. Ou escolha da lista de de Origens para entrar com um atalho para as notícias fornecidas pela origem."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Entre o link das notícias abaixo. Ou escolha da lista de de Origens para entrar com um atalho para as notícias fornecidas pela origem.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Salvar"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Salvar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Editar assinatura"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Editar assinatura";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/pt-BR.lproj/SearchFolder.strings
+++ b/Interfaces/pt-BR.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nomes de campos entram aqui"; ObjectID = "33"; */
-"33.title" = "Nomes de campos entram aqui";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operadores entram aqui"; ObjectID = "56"; */
-"56.title" = "Operadores entram aqui";
-
-/* Class = "NSMenuItem"; title = "Nada"; ObjectID = "62"; */
-"62.title" = "Nada";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nada"; ObjectID = "82"; */
-"82.title" = "Nada";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Nome da pasta inteligente:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Nome da pasta inteligente:";
 
-/* Class = "NSButtonCell"; title = "Salvar"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Salvar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Mostrar todos os artigos que combinam"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Mostrar todos os artigos que combinam";
 
-/* Class = "NSTextFieldCell"; title = "das seguintes condições:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "das seguintes condições:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/pt-BR.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/pt-BR.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Senha:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Senha:";
 
-/* Class = "NSTextFieldCell"; title = "Nome:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Nome:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/pt.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/pt.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Estas opções não devem ser alteradas para o uso normal do Vienna. Consulte o ficheiro de Ajuda para detalhes de cada opção.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Estas opções não devem ser alteradas para o uso normal do Vienna. Consulte o ficheiro de Ajuda para detalhes de cada opção.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Estas opções não devem ser alteradas para o uso normal do Vienna. Consulte o ficheiro de Ajuda para detalhes de cada opção.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Activar JavaScript no browser interno"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Activar JavaScript no browser interno";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/pt.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/pt.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Quando visualizar artigos ou páginas web:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Quando visualizar artigos ou páginas web:";
 
-/* Class = "NSTextFieldCell"; title = "Tipo de letra da lista de pastas:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Tipo de letra da lista de pastas:";
 
-/* Class = "NSButtonCell"; title = "Seleccionar…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Seleccionar…";
 
-/* Class = "NSButtonCell"; title = "Mostrar imagens da pastas na lista de pastas"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Mostrar imagens da pastas na lista de pastas";
 
-/* Class = "NSTextFieldCell"; title = "Tipo de letra da lista de artigos:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Tipo de letra da lista de artigos:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Seleccionar…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Seleccionar…";
 
-/* Class = "NSButtonCell"; title = "Nunca usar tipos de letra mais pequenas do que"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Nunca usar tipos de letra mais pequenas do que";

--- a/Interfaces/pt.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/pt.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Esvaziar Lixo"; ObjectID = "5"; */
-"5.title" = "Esvaziar Lixo";
-
-/* Class = "NSButtonCell"; title = "Esvaziar Lixo"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Esvaziar Lixo";
 
-/* Class = "NSButtonCell"; title = "Não Esvaziar Lixo"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Não Esvaziar Lixo";
 
-/* Class = "NSTextFieldCell"; title = "Existem artigos apagados no lixo.\nDeseja esvaziar o lixo antes de encerrar?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Existem artigos apagados no lixo. Deseja esvaziar o lixo antes de encerrar?";
 
-/* Class = "NSButtonCell"; title = "Não voltar a mostrar este aviso"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Não voltar a mostrar este aviso";

--- a/Interfaces/pt.lproj/FeedCredentials.strings
+++ b/Interfaces/pt.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Nome:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Nome:";
 
-/* Class = "NSTextFieldCell"; title = "O acesso a %@ necessita que disponibilize as suas credenciais"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "O acesso a %@ necessita que disponibilize as suas credenciais";
 
-/* Class = "NSTextFieldCell"; title = "Palavra-Passe:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Palavra-Passe:";
 
 /* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Log In";
 
-/* Class = "NSTextFieldCell"; title = "O nome de utilizador e palvra-passe que forneceu serão guardados para a próxima vez que actualizar esta subscrição."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "O nome de utilizador e palvra-passe que forneceu serão guardados para a próxima vez que actualizar esta subscrição.";

--- a/Interfaces/pt.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/pt.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "A cada 15 minutos"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "A cada 15 minutos";
 
-/* Class = "NSButtonCell"; title = "Após comando \"Próximo não lido\""; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Após comando \"Próximo não lido\"";
 
-/* Class = "NSMenuItem"; title = "(Localização)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Localização)";
-
-/* Class = "NSMenuItem"; title = "A cada 30 minutos"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "A cada 30 minutos";
 
-/* Class = "NSMenuItem"; title = "A cada 2 horas"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "A cada 2 horas";
 
-/* Class = "NSButtonCell"; title = "Mostrar número de artigos não lidos no ícone da aplicação"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Mostrar número de artigos não lidos no ícone da aplicação";
 
-/* Class = "NSTextFieldCell"; title = "Quando forem recebidos novos artigos:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Quando forem recebidos novos artigos:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Quando forem recebidos novos artigos:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Outro..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Outro...";
 
-/* Class = "NSMenuItem"; title = "Nenhum"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Nenhum";
-
-/* Class = "NSButtonCell"; title = "Verificar novas versões do Vienna ao iniciar"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Verificar novas versões do Vienna ao iniciar";
 
-/* Class = "NSMenuItem"; title = "Manualmente"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manualmente";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "A cada 6 horas"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "A cada 6 horas";
 
-/* Class = "NSButtonCell"; title = "Após uma pequena espera"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Após uma pequena espera";
 
-/* Class = "NSButtonCell"; title = "Mostrar na barra de menu"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Mostrar na barra de menu";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Abrir links num browser externo"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Abrir links num browser externo";
 
-/* Class = "NSTextFieldCell"; title = "Verificar novos artigos:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Verificar novos artigos:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Salvar ficheiros descarregados em:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Salvar ficheiros descarregados em:";
 
-/* Class = "NSButtonCell"; title = "Animar o ícone do programa"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Animar o ícone do programa";
 
-/* Class = "NSMenuItem"; title = "A cada 3 horas"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "A cada 3 horas";
 
-/* Class = "NSTextFieldCell"; title = "Mover artigos para o Lixo:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Mover artigos para o Lixo:";
 
-/* Class = "NSTextFieldCell"; title = "Leitor RSS padrão:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Leitor RSS padrão:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "A cada 5 minutos"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "A cada 5 minutos";
 
-/* Class = "NSButtonCell"; title = "Verificar novos artigos ao iniciar"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Verificar novos artigos ao iniciar";
 
-/* Class = "NSButtonCell"; title = "Abrir novos links em backgroung"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Abrir novos links em backgroung";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Marcar artigo actual como lido:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Marcar artigo actual como lido:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Marcar artigo actual como lido:";
 
-/* Class = "NSMenuItem"; title = "A cada hora"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "A cada hora";

--- a/Interfaces/pt.lproj/GroupFolder.strings
+++ b/Interfaces/pt.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Painel"; ObjectID = "5"; */
-"5.title" = "Painel";
-
-/* Class = "NSTextFieldCell"; title = "Nova pasta de grupo"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Nova pasta de grupo";
 
-/* Class = "NSButtonCell"; title = "Guardar"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Guardar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Introduza o nome da nova pasta de grupo:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Introduza o nome da nova pasta de grupo:";

--- a/Interfaces/pt.lproj/InfoWindow.strings
+++ b/Interfaces/pt.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Window"; ObjectID = "5"; */
-"5.title" = "Window";
-
-/* Class = "NSTextFieldCell"; title = "(Nome da pasta)"; ObjectID = "104"; */
-"104.title" = "(Nome da pasta)";
-
-/* Class = "NSTextFieldCell"; title = "Última Actualização:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Última Actualização:";
 
-/* Class = "NSTextFieldCell"; title = "(Data da última actualização)"; ObjectID = "106"; */
-"106.title" = "(Data da última actualização)";
-
-/* Class = "NSButtonCell"; title = "Validar"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Validar";
 
-/* Class = "NSButtonCell"; title = "URL da fonte:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL da fonte";
-
-/* Class = "NSTextFieldCell"; title = "Nome de utilizador:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Nome de utilizador:";
 
-/* Class = "NSTextFieldCell"; title = "Palavra-Passe:"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Palavra-Passe:";
 
-/* Class = "NSButtonCell"; title = "Actualizar autenticação"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Actualizar autenticação";
 
-/* Class = "NSButtonCell"; title = "Autenticação:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Autenticação";
-
-/* Class = "NSTextFieldCell"; title = "Tamanho:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Tamanho:";
 
-/* Class = "NSTextFieldCell"; title = "Não lidos:"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Não lidos:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Subscrito"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Subscrito";
-
-/* Class = "NSButtonCell"; title = "Geral:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Geral";
-
-/* Class = "NSButtonCell"; title = "Descrição:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "Descrição";
 
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Load Full HTML Articles";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "Descrição";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Autenticação";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Geral";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL da fonte";

--- a/Interfaces/pt.lproj/MainMenu.strings
+++ b/Interfaces/pt.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Trazer Todas para a Frente";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Refazer";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Ortografia";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Ortografia";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Ortografia…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Verificar Ortografia";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Verificar Ortografia ao Escrever";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zoom";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Actualizar Subscrições Seleccionadas";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Agradecimentos";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Nova Subscrição…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportar subscrições seleccionadas";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Página Web do Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Esvaziar Lixo";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Separador Anterior";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Layout";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Relatório";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Condensado";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Descarregar Anexo";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Personalizar Barra de Ferramentas…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar Barra de Estado";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Manter pasta de grupos no ficheiro exportado";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Ortografia";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Marcar Como Lido";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/pt.lproj/MainMenu.strings
+++ b/Interfaces/pt.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Janela";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Ocultar Barra de Estado";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Mostrar Barra de Filtragem";

--- a/Interfaces/pt.lproj/RSSFeed.strings
+++ b/Interfaces/pt.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "Fonte RSS"; ObjectID = "6"; */
-"6.title" = "Fonte RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "Fonte RSS"; ObjectID = "49"; */
-"49.title" = "Fonte RSS";
-
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Cancelar";
 
-/* Class = "NSButtonCell"; title = "Subscrever"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Subscrever";
 
-/* Class = "NSTextFieldCell"; title = "Origem:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Origem:";
 
-/* Class = "NSTextFieldCell"; title = "Criar uma nova subscrição"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Criar uma nova subscrição";
 
-/* Class = "NSTextFieldCell"; title = "Introduza o link para a nova fonte em baixo. Ou escolha na lista de Origens e intriduza um atalho para a fontes disponibilizadas pela origem."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Introduza o link para a nova fonte em baixo. Ou escolha na lista de Origens e intriduza um atalho para a fontes disponibilizadas pela origem.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Guardar"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Guardar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Editar subscrição"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Editar subscrição";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/pt.lproj/SearchFolder.strings
+++ b/Interfaces/pt.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nome do campo aqui"; ObjectID = "33"; */
-"33.title" = "Nome do campo aqui";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operadores aqui"; ObjectID = "56"; */
-"56.title" = "Operadores aqui";
-
-/* Class = "NSMenuItem"; title = "Nenhuma"; ObjectID = "62"; */
-"62.title" = "Nenhuma";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nenhuma"; ObjectID = "82"; */
-"82.title" = "Nenhuma";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Nome da pasta inteligente:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Nome da pasta inteligente:";
 
-/* Class = "NSButtonCell"; title = "Guardar"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Guardar";
 
-/* Class = "NSButtonCell"; title = "Cancelar"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Cancelar";
 
-/* Class = "NSTextFieldCell"; title = "Mostrar todos os artigos que combinam com"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Mostrar todos os artigos que combinam com";
 
-/* Class = "NSTextFieldCell"; title = "das seguintes condições:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "das seguintes condições:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/pt.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/pt.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Palavra-Passe:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Palavra-Passe:";
 
-/* Class = "NSTextFieldCell"; title = "Nome:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Nome:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/ru.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/ru.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Эти настройки не должны изменяться при повседневном использовании программы. Обратитесь к Справке для детальной информации о каждом параметре."; ObjectID = "GaX-8c-QaN"; */
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
 "GaX-8c-QaN.title" = "Эти настройки не должны изменяться при повседневном использовании программы. Обратитесь к Справке для детальной информации о каждом параметре.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Разрешить JavaScript во внешнем браузере"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Разрешить JavaScript во внешнем браузере";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/ru.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/ru.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "При просмотре статей или страниц:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "При просмотре статей или страниц:";
 
-/* Class = "NSTextFieldCell"; title = "Шрифт списка папок:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Шрифт списка папок:";
 
-/* Class = "NSButtonCell"; title = "Выбрать…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Выбрать…";
 
-/* Class = "NSButtonCell"; title = "Показывать изображения папок в списке папок"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Показывать изображения папок в списке папок";
 
-/* Class = "NSTextFieldCell"; title = "Шрифт списка статей:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Шрифт списка статей:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Выбрать…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Выбрать…";
 
-/* Class = "NSButtonCell"; title = "Никогда не использовать размер шрифта меньше"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Никогда не использовать размер шрифта меньше";

--- a/Interfaces/ru.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/ru.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Очистка Корзины"; ObjectID = "5"; */
-"5.title" = "Очистка Корзины";
-
-/* Class = "NSButtonCell"; title = "Очистить Корзину"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Очистить Корзину";
 
-/* Class = "NSButtonCell"; title = "Не очищать"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Не очищать";
 
-/* Class = "NSTextFieldCell"; title = "В Корзине есть удаленные статьи.\nОчистить Корзину перед завершением работы?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "В Корзине есть удаленные статьи. Очистить Корзину перед завершением работы?";
 
-/* Class = "NSButtonCell"; title = "Больше не показывать это сообщение"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Больше не показывать это сообщение";

--- a/Interfaces/ru.lproj/FeedCredentials.strings
+++ b/Interfaces/ru.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Отмена"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Отмена";
 
-/* Class = "NSTextFieldCell"; title = "Имя:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Имя:";
 
-/* Class = "NSTextFieldCell"; title = "Для доступа к %@ требуется указать имя пользователя и пароль"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Для доступа к %@ требуется указать имя пользователя и пароль";
 
-/* Class = "NSTextFieldCell"; title = "Пароль:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Пароль:";
 
-/* Class = "NSButtonCell"; title = "Войти"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Войти";
 
-/* Class = "NSTextFieldCell"; title = "Имя пользователя и пароль будут сохранены, так что вам не придется вводить их повторно"; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Имя пользователя и пароль будут сохранены, так что вам не придется вводить их повторно";

--- a/Interfaces/ru.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/ru.lproj/GeneralPreferencesView.strings
@@ -1,80 +1,55 @@
-
-/* Class = "NSMenuItem"; title = "Каждые 15 минут"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Каждые 15 минут";
 
-/* Class = "NSButtonCell"; title = "По вызову команды \"Следующая Непрочитанная\""; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "По вызову команды \"Следующая Непрочитанная\"";
 
-/* Class = "NSMenuItem"; title = "(Path)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Path)";
-
-/* Class = "NSMenuItem"; title = "Каждые 30 минут"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Каждые 30 минут";
 
-/* Class = "NSMenuItem"; title = "Каждые 2 часа"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Каждые 2 часа";
 
-/* Class = "NSButtonCell"; title = "Отобразить их число в иконке приложения"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Отобразить их число в иконке приложения";
 
-/* Class = "NSTextFieldCell"; title = "При получении новых статей:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "При получении новых статей:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "При получении новых статей:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Иное..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Иное...";
 
-/* Class = "NSMenuItem"; title = "Нет"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Нет";
-
-/* Class = "NSButtonCell"; title = "Проверять наличие новых версий Vienna при запуске"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Проверять наличие новых версий Vienna при запуске";
 
-/* Class = "NSMenuItem"; title = "Вручную"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Вручную";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Каждые 6 часов"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Каждые 6 часов";
 
-/* Class = "NSButtonCell"; title = "После небольшой задержки"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "После небольшой задержки";
 
-/* Class = "NSButtonCell"; title = "Отображать меню"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Отображать меню";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Открывать ссылки во внешнем браузере"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Открывать ссылки во внешнем браузере";
 
-/* Class = "NSTextFieldCell"; title = "Проверять наличие статей:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Проверять наличие статей:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Загружать файлы в:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Загружать файлы в:";
 
-/* Class = "NSButtonCell"; title = "Трясти иконку в Док"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Трясти иконку в Док";
 
-/* Class = "NSMenuItem"; title = "Каждые 3 часов"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Каждые 3 часов";
 
 /* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
@@ -86,13 +61,13 @@
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "Каждые 5 минут"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Каждые 5 минут";
 
 /* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Check for new articles on start up";
 
-/* Class = "NSButtonCell"; title = "Открывать ссылки в фоне"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Открывать ссылки в фоне";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Mark current article read:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Mark current article read:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Mark current article read:";
 
-/* Class = "NSMenuItem"; title = "Ежечасно"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Ежечасно";

--- a/Interfaces/ru.lproj/GroupFolder.strings
+++ b/Interfaces/ru.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Панель"; ObjectID = "5"; */
-"5.title" = "Панель";
-
-/* Class = "NSTextFieldCell"; title = "Новая Группа"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Новая Группа";
 
-/* Class = "NSButtonCell"; title = "Сохранить"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Сохранить";
 
-/* Class = "NSButtonCell"; title = "Отмена"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Отмена";
 
-/* Class = "NSTextFieldCell"; title = "Введите название группы:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Введите название группы:";

--- a/Interfaces/ru.lproj/MainMenu.strings
+++ b/Interfaces/ru.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Окно";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "Главное меню";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Спрятать строку статуса";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Показать панель фильтра";

--- a/Interfaces/ru.lproj/MainMenu.strings
+++ b/Interfaces/ru.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Все окна – на передний план";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Повторить";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Правописание";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Правописание";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Правописание…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Проверить правописание";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Проверять правописание при наборе текста";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Изменить масштаб";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Обновить выбранные подписки";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Благодарности";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Новая подписка…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Экспортировать выбранные подписки";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Сайт программы Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Очистить Корзину";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Предыдущая вкладка";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Раскладка";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Отчет";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Сжатая";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Загрузить вложение";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Настроить панель инструментов";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Спрятать строку статуса";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "По названию";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Сохранить группы в экспортируемом файле";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Проиндексировать базу данных";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Правописание";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Отметить как прочитанное";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/ru.lproj/RSSFeed.strings
+++ b/Interfaces/ru.lproj/RSSFeed.strings
@@ -1,39 +1,29 @@
-
-/* Class = "NSWindow"; title = "Канал RSS"; ObjectID = "6"; */
-"6.title" = "Канал RSS";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "Канал RSS"; ObjectID = "49"; */
-"49.title" = "Канал RSS";
-
-/* Class = "NSButtonCell"; title = "Отмена"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Отмена";
 
-/* Class = "NSButtonCell"; title = "Подписаться"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Подписаться";
 
-/* Class = "NSTextFieldCell"; title = "Источник:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Источник:";
 
-/* Class = "NSTextFieldCell"; title = "Создание новой подписки"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Создание новой подписки";
 
-/* Class = "NSTextFieldCell"; title = "Введите ссылку на канал новостей или выберите канал из списка Источник для добавления ссылки с заданного источника."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Введите ссылку на канал новостей или выберите канал из списка Источник для добавления ссылки с заданного источника.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Сохранить"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Сохранить";
 
-/* Class = "NSButtonCell"; title = "Отмена"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Отмена";
 
-/* Class = "NSTextFieldCell"; title = "Изменение подписки"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Изменение подписки";
 
-/* Class = "NSButtonCell"; title = "Использовать Open Reader"; ObjectID = "116"; */
+/* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */
 "116.title" = "Использовать Open Reader";

--- a/Interfaces/ru.lproj/SearchFolder.strings
+++ b/Interfaces/ru.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Названия полей"; ObjectID = "33"; */
-"33.title" = "Названия полей";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Операторы"; ObjectID = "56"; */
-"56.title" = "Операторы";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "62"; */
-"62.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Ни одному"; ObjectID = "82"; */
-"82.title" = "Ни одному";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Имя новой смарт-папки:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Имя новой смарт-папки:";
 
-/* Class = "NSButtonCell"; title = "Сохранить"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Сохранить";
 
-/* Class = "NSButtonCell"; title = "Отмена"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Отмена";
 
-/* Class = "NSTextFieldCell"; title = "Показывать статьи, соответствующие"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Показывать статьи, соответствующие";
 
-/* Class = "NSTextFieldCell"; title = "из следующих условий:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "из следующих условий:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/sv.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/sv.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Dessa inställningar borde inte behöva ändras för normal användning av Vienna. Se Hjälp för detaljer kring varje inställning.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Dessa inställningar borde inte behöva ändras för normal användning av Vienna. Se Hjälp för detaljer kring varje inställning.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Dessa inställningar borde inte behöva ändras för normal användning av Vienna. Se Hjälp för detaljer kring varje inställning.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Aktivera JavaScript i inbyggda webbläsaren"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Aktivera JavaScript i inbyggda webbläsaren";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/sv.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/sv.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Vid visning av artiklar eller webbsidor:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Vid visning av artiklar eller webbsidor:";
 
-/* Class = "NSTextFieldCell"; title = "Mapplista:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Mapplista:";
 
-/* Class = "NSButtonCell"; title = "Välj…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Välj…";
 
-/* Class = "NSButtonCell"; title = "Visa ikoner i mapplistan"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Visa ikoner i mapplistan";
 
-/* Class = "NSTextFieldCell"; title = "Artikellista:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Artikellista:";
 
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Sample)";
-
-/* Class = "NSTextFieldCell"; title = "(Sample)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Sample)";
-
-/* Class = "NSButtonCell"; title = "Välj…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Välj…";
 
-/* Class = "NSButtonCell"; title = "Använd aldrig typsnitt mindre än"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Använd aldrig typsnitt mindre än";

--- a/Interfaces/sv.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/sv.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Töm papperskorgen"; ObjectID = "5"; */
-"5.title" = "Töm papperskorgen";
-
-/* Class = "NSButtonCell"; title = "Töm papperskorgen"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Töm papperskorgen";
 
-/* Class = "NSButtonCell"; title = "Töm inte papperskorgen"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Töm inte papperskorgen";
 
-/* Class = "NSTextFieldCell"; title = "Det finns raderade artiklar i papperskorgen.\nVill du tömma papperskorgen innan du avslutar Vienna?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Det finns raderade artiklar i papperskorgen. Vill du tömma papperskorgen innan du avslutar Vienna?";
 
-/* Class = "NSButtonCell"; title = "Visa inte denna varning igen"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Visa inte denna varning igen";

--- a/Interfaces/sv.lproj/FeedCredentials.strings
+++ b/Interfaces/sv.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Avbryt"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Avbryt";
 
-/* Class = "NSTextFieldCell"; title = "Namn:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Namn:";
 
-/* Class = "NSTextFieldCell"; title = "Anslutning till %@ kräver att du anger inloggningsuppgifter"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Anslutning till %@ kräver att du anger inloggningsuppgifter";
 
-/* Class = "NSTextFieldCell"; title = "Lösenord:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Lösenord:";
 
-/* Class = "NSButtonCell"; title = "Logga in"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Logga in";
 
-/* Class = "NSTextFieldCell"; title = "Användarnamnet och lösenordet du anger kommer att kommas ihåg till nästa gång du uppdaterar den här prenumerationen."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Användarnamnet och lösenordet du anger kommer att kommas ihåg till nästa gång du uppdaterar den här prenumerationen.";

--- a/Interfaces/sv.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/sv.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "Var 15:e minut"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Var 15:e minut";
 
-/* Class = "NSButtonCell"; title = "Efter att ha valt \"Nästa olästa\""; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Efter att ha valt \"Nästa olästa\"";
 
-/* Class = "NSMenuItem"; title = "(Sökväg)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Sökväg)";
-
-/* Class = "NSMenuItem"; title = "Var 30:e minut"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Var 30:e minut";
 
-/* Class = "NSMenuItem"; title = "Varannan timme"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Varannan timme";
 
-/* Class = "NSButtonCell"; title = "Visa antalet olästa artiklar på programikonen"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Visa antalet olästa artiklar på programikonen";
 
-/* Class = "NSTextFieldCell"; title = "När nya olästa artiklar är mottagna:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "När nya olästa artiklar är mottagna:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "När nya olästa artiklar är mottagna:";
 
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Annan..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Annan...";
 
-/* Class = "NSMenuItem"; title = "Ingenting"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Ingenting";
-
-/* Class = "NSButtonCell"; title = "Leta efter uppdateringar av Vienna vid uppstart"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Leta efter uppdateringar av Vienna vid uppstart";
 
-/* Class = "NSMenuItem"; title = "Manuellt"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Manuellt";
 
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Var 6:e timme"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Var 6:e timme";
 
-/* Class = "NSButtonCell"; title = "Efter en kort stund"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Efter en kort stund";
 
-/* Class = "NSButtonCell"; title = "Visa i menyraden"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Visa i menyraden";
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "Andra vyer";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "Andra vyer";
-
-/* Class = "NSButtonCell"; title = "Öppna länkar i extern webbläsare"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Öppna länkar i extern webbläsare";
 
-/* Class = "NSTextFieldCell"; title = "Uppdatera artiklar:\n"; ObjectID = "ewU-JH-fMC"; */
-"ewU-JH-fMC.title" = "Uppdatera artiklar:\n";
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
+"ewU-JH-fMC.title" = "Uppdatera artiklar:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Spara nedladdade filer i:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Spara nedladdade filer i:";
 
-/* Class = "NSButtonCell"; title = "Stutsa programikonen"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Stutsa programikonen";
 
-/* Class = "NSMenuItem"; title = "Var 3:e timme"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Var 3:e timme";
 
-/* Class = "NSTextFieldCell"; title = "Flytta artiklar till Papperskorgen:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Flytta artiklar till Papperskorgen:";
 
-/* Class = "NSTextFieldCell"; title = "Förvald RSS-läsare:\n"; ObjectID = "kGA-Sa-RLG"; */
-"kGA-Sa-RLG.title" = "Förvald RSS-läsare:\n";
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
+"kGA-Sa-RLG.title" = "Förvald RSS-läsare:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "Var 5:e minut"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Var 5:e minut";
 
-/* Class = "NSButtonCell"; title = "Uppdatera artiklar vid uppstart"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Uppdatera artiklar vid uppstart";
 
-/* Class = "NSButtonCell"; title = "Öppna nya länkar i bakgrunden"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Öppna nya länkar i bakgrunden";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Markera nuvarande artikel som läst:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Markera nuvarande artikel som läst:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Markera nuvarande artikel som läst:";
 
-/* Class = "NSMenuItem"; title = "Varje timme"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Varje timme";

--- a/Interfaces/sv.lproj/GroupFolder.strings
+++ b/Interfaces/sv.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Ny gruppmapp"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Ny gruppmapp";
 
-/* Class = "NSButtonCell"; title = "Spara"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Spara";
 
-/* Class = "NSButtonCell"; title = "Avbryt"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Avbryt";
 
-/* Class = "NSTextFieldCell"; title = "Ange namn på gruppmappen:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Ange namn på gruppmappen:";

--- a/Interfaces/sv.lproj/InfoWindow.strings
+++ b/Interfaces/sv.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Fönster"; ObjectID = "5"; */
-"5.title" = "Fönster";
-
-/* Class = "NSTextFieldCell"; title = "(Mappnamn)"; ObjectID = "104"; */
-"104.title" = "(Mappnamn)";
-
-/* Class = "NSTextFieldCell"; title = "Senaste uppdaterad:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Senaste uppdaterad:";
 
-/* Class = "NSTextFieldCell"; title = "(Senaste uppdateringsdatum)"; ObjectID = "106"; */
-"106.title" = "(Senaste uppdateringsdatum)";
-
-/* Class = "NSButtonCell"; title = "Validera"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Validera";
 
-/* Class = "NSButtonCell"; title = "Feed URL:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "Feed URL";
-
-/* Class = "NSTextFieldCell"; title = "Användarnamn:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Användarnamn:";
 
-/* Class = "NSTextFieldCell"; title = "Lösenord:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Lösenord:";
 
-/* Class = "NSButtonCell"; title = "Uppdatera authentisering"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Uppdatera authentisering";
 
-/* Class = "NSButtonCell"; title = "Authentisering:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Authentisering";
-
-/* Class = "NSTextFieldCell"; title = "Storlek:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Storlek:";
 
-/* Class = "NSTextFieldCell"; title = "Olästa:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Olästa:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Prenumererad"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Prenumererad";
 
-/* Class = "NSButtonCell"; title = "Generellt:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Generellt";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Use Web Page for Articles";
 
-/* Class = "NSButtonCell"; title = "Beskrivning:"; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "Beskrivning";
 
-/* Class = "NSButtonCell"; title = "Use Web Page for Articles"; ObjectID = "126"; */
-"126.title" = "Use Web Page for Articles";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Authentisering";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Generellt";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "Feed URL";

--- a/Interfaces/sv.lproj/MainMenu.strings
+++ b/Interfaces/sv.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Lägg alla överst";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Gör om";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Stavning";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Stavning";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Stavning…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Kontrollera stavning";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Kontrollera stavning medan jag skriver";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Zooma";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Uppdatera markerade prenumerationer";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Tillkännagivanden";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Ny prenumeration…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Exportera markerade prenumerationer";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna webbsida";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Töm papperskorgen";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Föregående flik";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Layout";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Rapport";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Kompakt";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Ladda ner bilaga";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Anpassa verktygsrad…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Göm statusfältet";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Bevara gruppmappar";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Stavning";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Markera som läst";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/sv.lproj/MainMenu.strings
+++ b/Interfaces/sv.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Fönster";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Göm statusfältet";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Visa filtrera-fältet";

--- a/Interfaces/sv.lproj/RSSFeed.strings
+++ b/Interfaces/sv.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "6"; */
-"6.title" = "RSS Feed";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "49"; */
-"49.title" = "RSS Feed";
-
-/* Class = "NSButtonCell"; title = "Avbryt"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Avbryt";
 
-/* Class = "NSButtonCell"; title = "Prenumerera"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Prenumerera";
 
-/* Class = "NSTextFieldCell"; title = "Källa:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Källa:";
 
-/* Class = "NSTextFieldCell"; title = "Skapa ny RSS-prenumeration"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Skapa ny RSS-prenumeration";
 
-/* Class = "NSTextFieldCell"; title = "Ange länk till RSS-ström nedan. Eller välj från listan och ange ett kortnamn på RSS-ström som tillhandahålls av specificerad källa."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Ange länk till RSS-ström nedan. Eller välj från listan och ange ett kortnamn på RSS-ström som tillhandahålls av specificerad källa.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Spara"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Spara";
 
-/* Class = "NSButtonCell"; title = "Avbryt"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Avbryt";
 
-/* Class = "NSTextFieldCell"; title = "Redigera prenumeration"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Redigera prenumeration";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/sv.lproj/SearchFolder.strings
+++ b/Interfaces/sv.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "32"; */
-"32.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Fältnamn här"; ObjectID = "33"; */
-"33.title" = "Fältnamn här";
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "34"; */
-"34.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Operatörer hör"; ObjectID = "56"; */
-"56.title" = "Operatörer hör";
-
-/* Class = "NSMenuItem"; title = "Ingenting"; ObjectID = "62"; */
-"62.title" = "Ingenting";
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "64"; */
-"64.title" = "Andra vyer";
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "74"; */
-"74.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Objekt3"; ObjectID = "75"; */
-"75.title" = "Objekt3";
-
-/* Class = "NSMenuItem"; title = "Objekt2"; ObjectID = "76"; */
-"76.title" = "Objekt2";
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "80"; */
-"80.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Ingenting"; ObjectID = "82"; */
-"82.title" = "Ingenting";
-
-/* Class = "NSMenu"; title = "Andra vyer"; ObjectID = "87"; */
-"87.title" = "Andra vyer";
-
-/* Class = "NSMenuItem"; title = "Objekt3"; ObjectID = "88"; */
-"88.title" = "Objekt3";
-
-/* Class = "NSMenuItem"; title = "Objekt3"; ObjectID = "89"; */
-"89.title" = "Objekt3";
-
-/* Class = "NSMenuItem"; title = "Objekt2"; ObjectID = "90"; */
-"90.title" = "Objekt2";
-
-/* Class = "NSTextFieldCell"; title = "Namn på smart mapp:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Namn på smart mapp:";
 
-/* Class = "NSButtonCell"; title = "Spara"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Spara";
 
-/* Class = "NSButtonCell"; title = "Avbryt"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Avbryt";
 
-/* Class = "NSTextFieldCell"; title = "Visa alla artiklar som matchar"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Visa alla artiklar som matchar";
 
-/* Class = "NSTextFieldCell"; title = "av följande villkor:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "av följande villkor:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/sv.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/sv.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Lösenord:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Lösenord:";
 
-/* Class = "NSTextFieldCell"; title = "Namn:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Namn:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/tr.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/tr.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Vienna'nın normal kullanımında bu ayarların değiştirilmesine gerek yoktur. Her bir ayar için Yardım dosyasına başvurun..\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Vienna'nın normal kullanımında bu ayarların değiştirilmesine gerek yoktur. Her bir ayar için Yardım dosyasına başvurun..\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Vienna'nın normal kullanımında bu ayarların değiştirilmesine gerek yoktur. Her bir ayar için Yardım dosyasına başvurun.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "İç tarayıcıda JavaScript'i Aktif Et"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "İç tarayıcıda JavaScript'i Aktif Et";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/tr.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/tr.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Web sayfalarını veya makaleleri görüntülerken:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Web sayfalarını veya makaleleri görüntülerken:";
 
-/* Class = "NSTextFieldCell"; title = "Klasör liste yazıtipi:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Klasör liste yazıtipi:";
 
-/* Class = "NSButtonCell"; title = "Seç…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Seç…";
 
-/* Class = "NSButtonCell"; title = "Klasör imajlarını klasör listesinde göster"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Klasör imajlarını klasör listesinde göster";
 
-/* Class = "NSTextFieldCell"; title = "Makale liste yazıtipi:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Makale liste yazıtipi:";
 
-/* Class = "NSTextFieldCell"; title = "(Örnek)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Örnek)";
-
-/* Class = "NSTextFieldCell"; title = "(Örnek)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Örnek)";
-
-/* Class = "NSButtonCell"; title = "Seç…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Seç…";
 
-/* Class = "NSButtonCell"; title = "Bundan daha küçük yazıtipi kullanma"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Bundan daha küçük yazıtipi kullanma";

--- a/Interfaces/tr.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/tr.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Çöp kutusunu boşalt"; ObjectID = "5"; */
-"5.title" = "Çöp kutusunu boşalt";
-
-/* Class = "NSButtonCell"; title = "Çöp kutusunu boşalt"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Çöp kutusunu boşalt";
 
-/* Class = "NSButtonCell"; title = "Çöp kutusunu boşaltma"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Çöp kutusunu boşaltma";
 
-/* Class = "NSTextFieldCell"; title = "Çöp kutusunda silinmiş makaleler bulunuyor.\nÇıkmadan önce onları silmek ister misiniz?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "Çöp kutusunda silinmiş makaleler bulunuyor. Çıkmadan önce onları silmek ister misiniz?";
 
-/* Class = "NSButtonCell"; title = "Bu uyarıyı bir daha gösterme"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Bu uyarıyı bir daha gösterme";

--- a/Interfaces/tr.lproj/FeedCredentials.strings
+++ b/Interfaces/tr.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "İptal"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "İptal";
 
-/* Class = "NSTextFieldCell"; title = "Ad:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Ad:";
 
-/* Class = "NSTextFieldCell"; title = "%@ erişimi giriş kanıtlarını belirtmenizi gerektiriyor"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "%@ erişimi giriş kanıtlarını belirtmenizi gerektiriyor";
 
-/* Class = "NSTextFieldCell"; title = "Şifre:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Şifre:";
 
-/* Class = "NSButtonCell"; title = "Giriş"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Giriş";
 
-/* Class = "NSTextFieldCell"; title = "Bu üyelik için girmiş olduğunuz kullanıcı adı ve şifre, aboneliği bir sonraki kez yenilediğinizde hatırlanacak."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Bu üyelik için girmiş olduğunuz kullanıcı adı ve şifre, aboneliği bir sonraki kez yenilediğinizde hatırlanacak.";

--- a/Interfaces/tr.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/tr.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "15 dakikada bir"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "15 dakikada bir";
 
-/* Class = "NSButtonCell"; title = "\"Next Unread\" komutundan sonra"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "\"Next Unread\" komutundan sonra";
 
-/* Class = "NSMenuItem"; title = "(Yol)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Yol)";
-
-/* Class = "NSMenuItem"; title = "30 dakikada bir"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "30 dakikada bir";
 
-/* Class = "NSMenuItem"; title = "2 saatte bir"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "2 saatte bir";
 
-/* Class = "NSButtonCell"; title = "Okunmamış makale sayısını uygulama ikonunda göster"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Okunmamış makale sayısını uygulama ikonunda göster";
 
-/* Class = "NSTextFieldCell"; title = "Yeni okunmamış makale alındığında:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Yeni okunmamış makale alındığında:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Yeni okunmamış makale alındığında:";
 
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "Diğer..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Diğer...";
 
-/* Class = "NSMenuItem"; title = "Hiçbir şey"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Hiçbir şey";
-
-/* Class = "NSButtonCell"; title = "Başlangıçta Vienna'nın yeni sürümünü kontrol et"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Başlangıçta Vienna'nın yeni sürümünü kontrol et";
 
-/* Class = "NSMenuItem"; title = "El ile"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "El ile";
 
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "6 saatte bir"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "6 saatte bir";
 
-/* Class = "NSButtonCell"; title = "Kısa bir aradan sonra"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Kısa bir aradan sonra";
 
-/* Class = "NSButtonCell"; title = "Menü barında göster"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Menü barında göster";
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "DiğerGörünümler";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "DiğerGörünümler";
-
-/* Class = "NSButtonCell"; title = "Bağlantıları harici tarayıcıda aç"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Bağlantıları harici tarayıcıda aç";
 
-/* Class = "NSTextFieldCell"; title = "Yeni makaleleri kontrol et:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Yeni makaleleri kontrol et:";
 
-/* Class = "NSMenuItem"; title = "(Yerelleştirme)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Yerelleştirme)";
-
-/* Class = "NSTextFieldCell"; title = "İndirilen dosyaları şuraya kaydet:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "İndirilen dosyaları şuraya kaydet:";
 
-/* Class = "NSButtonCell"; title = "Uygulama simgesini zıplat"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Uygulama simgesini zıplat";
 
-/* Class = "NSMenuItem"; title = "3 saatte bir"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "3 saatte bir";
 
-/* Class = "NSTextFieldCell"; title = "Seçili makaleleri çöp kutusuna taşı:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Seçili makaleleri çöp kutusuna taşı:";
 
-/* Class = "NSTextFieldCell"; title = "Varsayılan RSS Tarayıcısı:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "Varsayılan RSS Tarayıcısı:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "5 dakikada bir"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "5 dakikada bir";
 
-/* Class = "NSButtonCell"; title = "Başlangıçta yeni makaleleri kontrol et"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Başlangıçta yeni makaleleri kontrol et";
 
-/* Class = "NSButtonCell"; title = "Yeni bağlantıları arkaplanda aç"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Yeni bağlantıları arkaplanda aç";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Seçili makaleyi okundu olarak işaretle:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Seçili makaleyi okundu olarak işaretle:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Seçili makaleyi okundu olarak işaretle:";
 
-/* Class = "NSMenuItem"; title = "Her saat"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Her saat";

--- a/Interfaces/tr.lproj/GroupFolder.strings
+++ b/Interfaces/tr.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Yeni Grup Klasörü"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Yeni Grup Klasörü";
 
-/* Class = "NSButtonCell"; title = "Kaydet"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Kaydet";
 
-/* Class = "NSButtonCell"; title = "İptal"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "İptal";
 
-/* Class = "NSTextFieldCell"; title = "Grup Klasörü için bir ad girin:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Grup Klasörü için bir ad girin:";

--- a/Interfaces/tr.lproj/InfoWindow.strings
+++ b/Interfaces/tr.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Window"; ObjectID = "5"; */
-"5.title" = "Window";
-
-/* Class = "NSTextFieldCell"; title = "(Folder name)"; ObjectID = "104"; */
-"104.title" = "(Folder name)";
-
-/* Class = "NSTextFieldCell"; title = "En son yenilendi:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "En son yenilendi:";
 
-/* Class = "NSTextFieldCell"; title = "(Last refresh date)"; ObjectID = "106"; */
-"106.title" = "(Last refresh date)";
-
-/* Class = "NSButtonCell"; title = "Doğrula"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Doğrula";
 
-/* Class = "NSButtonCell"; title = "Besleme URLsi:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "Besleme URLsi";
-
-/* Class = "NSTextFieldCell"; title = "Kullanıcı adı:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Kullanıcı adı:";
 
-/* Class = "NSTextFieldCell"; title = "Şifre:"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Şifre:";
 
-/* Class = "NSButtonCell"; title = "Yetkilendirmeyi Güncelle"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Yetkilendirmeyi Güncelle";
 
-/* Class = "NSButtonCell"; title = "Yetki:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Yetki";
-
-/* Class = "NSTextFieldCell"; title = "Boyut:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Boyut:";
 
-/* Class = "NSTextFieldCell"; title = "Okunmadı:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Okunmadı:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Abone olundu"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Abone olundu";
-
-/* Class = "NSButtonCell"; title = "Genel:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Genel";
-
-/* Class = "NSButtonCell"; title = "Açıklama:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "Açıklama";
 
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Load Full HTML Articles";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "Açıklama";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Yetki";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Genel";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "Besleme URLsi";

--- a/Interfaces/tr.lproj/MainMenu.strings
+++ b/Interfaces/tr.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Pencere";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "AnaMenü";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Durum Çubuğunu Gizle";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Filtre Çubuğunu Göster";

--- a/Interfaces/tr.lproj/MainMenu.strings
+++ b/Interfaces/tr.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Hepsini Öne Getir";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "İleri Al";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Yazım";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Yazım";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Yazım…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Dilbilgisi Kontrolü";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Dilbilgisini Yazarken Kontrol Et";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Yakınlaştır";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Seçili Abonelikleri Yenile";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Teşekkürler";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Yeni Abonelik…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Seçili abonelikleri bir dosyaya aktar";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna Web Sitesi";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Çöpü Boşalt";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Önceki Sekme";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Arabirim";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Rapor Et";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Yoğunlaştırılmış";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Eki İndir";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Araç Çubuğunu Düzenle…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Durum Çubuğunu Gizle";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Aktarılan dosyada grup klasörlerini koru";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Yazım";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Okundu Olarak İşaretle";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/tr.lproj/RSSFeed.strings
+++ b/Interfaces/tr.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS Beslemesi"; ObjectID = "6"; */
-"6.title" = "RSS Beslemesi";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS Beslemesi"; ObjectID = "49"; */
-"49.title" = "RSS Beslemesi";
-
-/* Class = "NSButtonCell"; title = "İptal"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "İptal";
 
-/* Class = "NSButtonCell"; title = "Abone Ol"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Abone Ol";
 
-/* Class = "NSTextFieldCell"; title = "Kaynak:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Kaynak:";
 
-/* Class = "NSTextFieldCell"; title = "Yeni abonelik oluştur"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Yeni abonelik oluştur";
 
-/* Class = "NSTextFieldCell"; title = "Haber beslemesi için bağlantıyı aşağıya girin. Ya da Kaynak listesinden kaynak tarafından bildirilen kısayol adını girin."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Haber beslemesi için bağlantıyı aşağıya girin. Ya da Kaynak listesinden kaynak tarafından bildirilen kısayol adını girin.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Kaydet"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Kaydet";
 
-/* Class = "NSButtonCell"; title = "İptal"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "İptal";
 
-/* Class = "NSTextFieldCell"; title = "Aboneliği düzenle"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Aboneliği düzenle";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/tr.lproj/SearchFolder.strings
+++ b/Interfaces/tr.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "32"; */
-"32.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "Alan adları buraya yazılır"; ObjectID = "33"; */
-"33.title" = "Alan adları buraya yazılır";
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "34"; */
-"34.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "Operatörler buraya yazılır"; ObjectID = "56"; */
-"56.title" = "Operatörler buraya yazılır";
-
-/* Class = "NSMenuItem"; title = "Hiçbir şey"; ObjectID = "62"; */
-"62.title" = "Hiçbir şey";
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "64"; */
-"64.title" = "DiğerGörünümler";
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "74"; */
-"74.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "80"; */
-"80.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "Hiçbir şey"; ObjectID = "82"; */
-"82.title" = "Hiçbir şey";
-
-/* Class = "NSMenu"; title = "DiğerGörünümler"; ObjectID = "87"; */
-"87.title" = "DiğerGörünümler";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Akıllı klasör adı:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Akıllı klasör adı:";
 
-/* Class = "NSButtonCell"; title = "Kaydet"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Kaydet";
 
-/* Class = "NSButtonCell"; title = "İptal"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "İptal";
 
-/* Class = "NSTextFieldCell"; title = "Uyan tüm makaleleri göster"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Uyan tüm makaleleri göster";
 
-/* Class = "NSTextFieldCell"; title = "şu koşulları içeren:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "şu koşulları içeren:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/tr.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/tr.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Şifre:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Şifre:";
 
-/* Class = "NSTextFieldCell"; title = "Ad:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Ad:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/uk.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/uk.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "Параметри представлені тут не повинні змінюватися за умов звичайного використання Vienna. За інформацією про параметри звертайтеся у відповідний розділ Довідки.\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "Параметри представлені тут не повинні змінюватися за умов звичайного використання Vienna. За інформацією про параметри звертайтеся у відповідний розділ Довідки.\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "Параметри представлені тут не повинні змінюватися за умов звичайного використання Vienna. За інформацією про параметри звертайтеся у відповідний розділ Довідки.";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "Увімкнути JavaScript у внутрішньому браузері"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "Увімкнути JavaScript у внутрішньому браузері";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/uk.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/uk.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "Переглядати статті чи веб-сторінки:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "Переглядати статті чи веб-сторінки:";
 
-/* Class = "NSTextFieldCell"; title = "Шрифт списку папок:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "Шрифт списку папок:";
 
-/* Class = "NSButtonCell"; title = "Вибрати…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "Вибрати…";
 
-/* Class = "NSButtonCell"; title = "Показувати зображення папок у списку"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "Показувати зображення папок у списку";
 
-/* Class = "NSTextFieldCell"; title = "Шрифт списку статей:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "Шрифт списку статей:";
 
-/* Class = "NSTextFieldCell"; title = "(Зразок)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(Зразок)";
-
-/* Class = "NSTextFieldCell"; title = "(Зразок)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(Зразок)";
-
-/* Class = "NSButtonCell"; title = "Вибрати…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "Вибрати…";
 
-/* Class = "NSButtonCell"; title = "Ніколи не використовувати шрифт менший за"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "Ніколи не використовувати шрифт менший за";

--- a/Interfaces/uk.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/uk.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Спорожнити смітник"; ObjectID = "5"; */
-"5.title" = "Спорожнити смітник";
-
-/* Class = "NSButtonCell"; title = "Спорожнити смітник"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "Спорожнити смітник";
 
-/* Class = "NSButtonCell"; title = "Не спорожняти смітник"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "Не спорожняти смітник";
 
-/* Class = "NSTextFieldCell"; title = "У смітнику є видалені статті.\nЧи не хотіли б ви спорожнити смітник перед тим, як завершити програму?"; ObjectID = "19"; */
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
 "19.title" = "У смітнику є видалені статті. Чи не хотіли б ви спорожнити смітник перед тим, як завершити програму?";
 
-/* Class = "NSButtonCell"; title = "Більше не показувати це попередження"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "Більше не показувати це попередження";

--- a/Interfaces/uk.lproj/FeedCredentials.strings
+++ b/Interfaces/uk.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "Скасувати"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "Скасувати";
 
-/* Class = "NSTextFieldCell"; title = "Ім'я:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "Ім'я:";
 
-/* Class = "NSTextFieldCell"; title = "Правили доступу до %@ вимагають введення імені користувача та паролю"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "Правили доступу до %@ вимагають введення імені користувача та паролю";
 
-/* Class = "NSTextFieldCell"; title = "Пароль:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "Пароль:";
 
-/* Class = "NSButtonCell"; title = "Увійти"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "Увійти";
 
-/* Class = "NSTextFieldCell"; title = "Ім'я користувача та пароль будуть збережені, отож вам не доведеться вводити їх знову."; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Ім'я користувача та пароль будуть збережені, отож вам не доведеться вводити їх знову.";

--- a/Interfaces/uk.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/uk.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "Кожні 15 хвилин"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "Кожні 15 хвилин";
 
-/* Class = "NSButtonCell"; title = "Післи команди \"Наступне непрочитане\""; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "Післи команди \"Наступне непрочитане\"";
 
-/* Class = "NSMenuItem"; title = "(Шлях)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(Шлях)";
-
-/* Class = "NSMenuItem"; title = "Кожні 30 хвилин"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "Кожні 30 хвилин";
 
-/* Class = "NSMenuItem"; title = "Кожні 2 години"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "Кожні 2 години";
 
-/* Class = "NSButtonCell"; title = "Показувати кількість непрочитаних статей на іконці програми"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "Показувати кількість непрочитаних статей на іконці програми";
 
-/* Class = "NSTextFieldCell"; title = "Коли отримані нові статті:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "Коли отримані нові статті:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "Коли отримані нові статті:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Інше..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "Інше...";
 
-/* Class = "NSMenuItem"; title = "Нічого"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Нічого";
-
-/* Class = "NSButtonCell"; title = "Перевіряти наявність нових версій Vienna при запуску"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "Перевіряти наявність нових версій Vienna при запуску";
 
-/* Class = "NSMenuItem"; title = "Вручну"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "Вручну";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Кожні 6 годин"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "Кожні 6 годин";
 
-/* Class = "NSButtonCell"; title = "Після невеликої паузи"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "Після невеликої паузи";
 
-/* Class = "NSButtonCell"; title = "Показувати у меню"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "Показувати у меню";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Відкривати посилання у зовнішньому браузері"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "Відкривати посилання у зовнішньому браузері";
 
-/* Class = "NSTextFieldCell"; title = "Перевіряти наявність нових статей:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "Перевіряти наявність нових статей:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "Зберігати завантажені файли до:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "Зберігати завантажені файли до:";
 
-/* Class = "NSButtonCell"; title = "Заставити іконку програми стрибати"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "Заставити іконку програми стрибати";
 
-/* Class = "NSMenuItem"; title = "Кожні 3 години"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "Кожні 3 години";
 
-/* Class = "NSTextFieldCell"; title = "Перемістити статті до Смітника:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "Перемістити статті до Смітника:";
 
-/* Class = "NSTextFieldCell"; title = "RSS-переглядач за замовчуванням:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "RSS-переглядач за замовчуванням:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "Кожні 5 хвилин"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "Кожні 5 хвилин";
 
-/* Class = "NSButtonCell"; title = "Перевіряти наявність нових статей при запуску"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "Перевіряти наявність нових статей при запуску";
 
-/* Class = "NSButtonCell"; title = "Відкривати посилання на задньому плані"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "Відкривати посилання на задньому плані";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "Помітити поточну статтю як прочитану:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "Помітити поточну статтю як прочитану:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "Помітити поточну статтю як прочитану:";
 
-/* Class = "NSMenuItem"; title = "Кожної години"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "Кожної години";

--- a/Interfaces/uk.lproj/GroupFolder.strings
+++ b/Interfaces/uk.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "Panel"; ObjectID = "5"; */
-"5.title" = "Panel";
-
-/* Class = "NSTextFieldCell"; title = "Нова папка"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "Нова папка";
 
-/* Class = "NSButtonCell"; title = "Зберегти"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "Зберегти";
 
-/* Class = "NSButtonCell"; title = "Скасувати"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "Скасувати";
 
-/* Class = "NSTextFieldCell"; title = "Введіть ім'я папки:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "Введіть ім'я папки:";

--- a/Interfaces/uk.lproj/InfoWindow.strings
+++ b/Interfaces/uk.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "Вікно"; ObjectID = "5"; */
-"5.title" = "Вікно";
-
-/* Class = "NSTextFieldCell"; title = "(Назва папки)"; ObjectID = "104"; */
-"104.title" = "(Назва папки)";
-
-/* Class = "NSTextFieldCell"; title = "Останнє оновлення:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "Останнє оновлення:";
 
-/* Class = "NSTextFieldCell"; title = "(Дата останнього оновлення)"; ObjectID = "106"; */
-"106.title" = "(Дата останнього оновлення)";
-
-/* Class = "NSButtonCell"; title = "Валідувати"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "Валідувати";
 
-/* Class = "NSButtonCell"; title = "URL:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "URL";
-
-/* Class = "NSTextFieldCell"; title = "Ім'я користувача:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "Ім'я користувача:";
 
-/* Class = "NSTextFieldCell"; title = "Пароль:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "Пароль:";
 
-/* Class = "NSButtonCell"; title = "Оновити"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "Оновити";
 
-/* Class = "NSButtonCell"; title = "Аутентифікація:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "Аутентифікація";
-
-/* Class = "NSTextFieldCell"; title = "Розмір:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "Розмір:";
 
-/* Class = "NSTextFieldCell"; title = "Непрочитані:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "Непрочитані:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "Підписаний"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "Підписаний";
-
-/* Class = "NSButtonCell"; title = "Загальне:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "Загальне";
-
-/* Class = "NSButtonCell"; title = "Опис:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "Опис";
 
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Load Full HTML Articles";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "Опис";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "Аутентифікація";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "Загальне";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "URL";

--- a/Interfaces/uk.lproj/MainMenu.strings
+++ b/Interfaces/uk.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "Вікно";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Заховати стрічку статусу";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "Показати стрічку фільтру";

--- a/Interfaces/uk.lproj/MainMenu.strings
+++ b/Interfaces/uk.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "Витягнути все на передній план";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "Застосувати";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "Правопис";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "Правопис";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "Правопис…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "Перевірити правопис";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "Перевіряти правопис автоматично";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "Розгорнути";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "Оновити виділені підписки";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "Подяки";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "Нова підписка…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "Експортувати виділені підписки";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Веб-сайт Vienna";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "Спорожнити смітник";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "Попередня закладка";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "Розташування";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "Звіт";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "Стиснутий";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "Завантажити додаток";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "Customize Toolbar…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "Заховати стрічку статусу";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "Зберігати папки у експортованих файлах";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "Правопис";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "Помітити як прочитане";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/uk.lproj/RSSFeed.strings
+++ b/Interfaces/uk.lproj/RSSFeed.strings
@@ -1,38 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS-стрічка"; ObjectID = "6"; */
-"6.title" = "RSS-стрічка";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS-стрічка"; ObjectID = "49"; */
-"49.title" = "RSS-стрічка";
-
-/* Class = "NSButtonCell"; title = "Скасувати"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "Скасувати";
 
-/* Class = "NSButtonCell"; title = "Підписатися"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "Підписатися";
 
-/* Class = "NSTextFieldCell"; title = "Джерело:"; ObjectID = "104"; */
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
 "104.title" = "Джерело:";
 
-/* Class = "NSTextFieldCell"; title = "Створити нову підписку"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "Створити нову підписку";
 
-/* Class = "NSTextFieldCell"; title = "Введіть адресу стрічки новин, або виберіть стрічку зі списку Джерело для того, щоб додати стрічку з заданого джерела."; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "Введіть адресу стрічки новин, або виберіть стрічку зі списку Джерело для того, щоб додати стрічку з заданого джерела.";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "Зберегти"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "Зберегти";
 
-/* Class = "NSButtonCell"; title = "Скасувати"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "Скасувати";
 
-/* Class = "NSTextFieldCell"; title = "Редагування підписки"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "Редагування підписки";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/uk.lproj/SearchFolder.strings
+++ b/Interfaces/uk.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Назви полів"; ObjectID = "33"; */
-"33.title" = "Назви полів";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Оператори"; ObjectID = "56"; */
-"56.title" = "Оператори";
-
-/* Class = "NSMenuItem"; title = "Нічого"; ObjectID = "62"; */
-"62.title" = "Нічого";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Нічого"; ObjectID = "82"; */
-"82.title" = "Нічого";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "Назва вибірки:"; ObjectID = "94"; */
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
 "94.title" = "Назва вибірки:";
 
-/* Class = "NSButtonCell"; title = "Зберегти"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "Зберегти";
 
-/* Class = "NSButtonCell"; title = "Скасувати"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Скасувати";
 
-/* Class = "NSTextFieldCell"; title = "Показати всі статті, які відповідають"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "Показати всі статті, які відповідають";
 
-/* Class = "NSTextFieldCell"; title = "з наступних умов:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "з наступних умов:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/uk.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/uk.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "Пароль:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "Пароль:";
 
-/* Class = "NSTextFieldCell"; title = "Ім'я:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "Ім'я:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/zh-Hans.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/zh-Hans.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "这里的设置一般来讲不需要做调整。如果有需要，请您参考帮助文件来了解每个设置的细节。\n"; ObjectID = "GaX-8c-QaN"; */
-"GaX-8c-QaN.title" = "这里的设置一般来讲不需要做调整。如果有需要，请您参考帮助文件来了解每个设置的细节。\n";
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
+"GaX-8c-QaN.title" = "这里的设置一般来讲不需要做调整。如果有需要，请您参考帮助文件来了解每个设置的细节。";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "在内置浏览器中应用 Javascript"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "在内置浏览器中应用 Javascript";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/zh-Hans.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/zh-Hans.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "浏览文章或网页时:"; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "浏览文章或网页时:";
 
-/* Class = "NSTextFieldCell"; title = "文件夹列表字体:"; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "文件夹列表字体:";
 
-/* Class = "NSButtonCell"; title = "选择…"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "选择…";
 
-/* Class = "NSButtonCell"; title = "在文件夹列表中显示文件夹图片"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "在文件夹列表中显示文件夹图片";
 
-/* Class = "NSTextFieldCell"; title = "文章列表字体:"; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "文章列表字体:";
 
-/* Class = "NSTextFieldCell"; title = "(示范)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(示范)";
-
-/* Class = "NSTextFieldCell"; title = "(示范)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(示范)";
-
-/* Class = "NSButtonCell"; title = "选择…"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "选择…";
 
-/* Class = "NSButtonCell"; title = "字体永远大于"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "字体永远大于";

--- a/Interfaces/zh-Hans.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/zh-Hans.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "清空废纸篓"; ObjectID = "5"; */
-"5.title" = "清空废纸篓";
-
-/* Class = "NSButtonCell"; title = "清空废纸篓"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "清空废纸篓";
 
-/* Class = "NSButtonCell"; title = "不要清空废纸篓"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "不要清空废纸篓";
 
-/* Class = "NSTextFieldCell"; title = "废纸篓中有被删除的文章。\n您想在退出前清空废纸篓么？"; ObjectID = "19"; */
-"19.title" = "废纸篓中有被删除的文章。\n您想在退出前清空废纸篓么？";
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
+"19.title" = "废纸篓中有被删除的文章。您想在退出前清空废纸篓么？";
 
-/* Class = "NSButtonCell"; title = "不要再显示这个提示"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "不要再显示这个提示";

--- a/Interfaces/zh-Hans.lproj/FeedCredentials.strings
+++ b/Interfaces/zh-Hans.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "用户名:"; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "用户名:";
 
-/* Class = "NSTextFieldCell"; title = "您需要提供登陆信息才可以访问 %@ "; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "您需要提供登陆信息才可以访问 %@ ";
 
-/* Class = "NSTextFieldCell"; title = "密码:"; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "密码:";
 
-/* Class = "NSButtonCell"; title = "登陆"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "登陆";
 
-/* Class = "NSTextFieldCell"; title = "您所提供的用户名和密码将会被记录并且在下次更新频道时使用"; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "您所提供的用户名和密码将会被记录并且在下次更新频道时使用";

--- a/Interfaces/zh-Hans.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/zh-Hans.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "每15分钟"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "每15分钟";
 
-/* Class = "NSButtonCell"; title = "执行 \"下一篇未读文章\" 命令后"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "执行 \"下一篇未读文章\" 命令后";
 
-/* Class = "NSMenuItem"; title = "(路径)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(路径)";
-
-/* Class = "NSMenuItem"; title = "每三十分钟"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "每三十分钟";
 
-/* Class = "NSMenuItem"; title = "每两小时"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "每两小时";
 
-/* Class = "NSButtonCell"; title = "在程序图标中显示未读文章数目"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "在程序图标中显示未读文章数目";
 
-/* Class = "NSTextFieldCell"; title = "当接收到新文章后:\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "当接收到新文章后:\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "当接收到新文章后:";
 
-/* Class = "NSMenu"; title = "其他显示方式"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "其他显示方式";
-
-/* Class = "NSMenuItem"; title = "其他..."; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "其他...";
 
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "Nothing";
-
-/* Class = "NSButtonCell"; title = "程序启动后核查 Vienna 是否有新版本"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "程序启动后核查 Vienna 是否有新版本";
 
-/* Class = "NSMenuItem"; title = "手动"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "手动";
 
-/* Class = "NSMenu"; title = "其他显示方式"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "其他显示方式";
-
-/* Class = "NSMenuItem"; title = "每六小时"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "每六小时";
 
-/* Class = "NSButtonCell"; title = "略微延迟一下后"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "略微延迟一下后";
 
-/* Class = "NSButtonCell"; title = "在菜单栏中显示"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "在菜单栏中显示";
-
-/* Class = "NSMenu"; title = "其他显示方式"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "其他显示方式";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "其他显示方式"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "其他显示方式";
-
-/* Class = "NSButtonCell"; title = "在外部浏览器中打开连接"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "在外部浏览器中打开连接";
 
-/* Class = "NSTextFieldCell"; title = "检查新文章:"; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "检查新文章:";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "下载文件至:"; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "下载文件至:";
 
-/* Class = "NSButtonCell"; title = "弹跳程序图标"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "弹跳程序图标";
 
-/* Class = "NSMenuItem"; title = "每三小时"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "每三小时";
 
-/* Class = "NSTextFieldCell"; title = "移动文章到废纸篓于:"; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "移动文章到废纸篓于:";
 
-/* Class = "NSTextFieldCell"; title = "默认 RSS 阅读工具:"; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "默认 RSS 阅读工具:";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "每5分钟"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "每5分钟";
 
-/* Class = "NSButtonCell"; title = "程序启动后核查新文章"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "程序启动后核查新文章";
 
-/* Class = "NSButtonCell"; title = "在当前窗口后面打开连接"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "在当前窗口后面打开连接";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "标记当前文章为已读于:\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "标记当前文章为已读于:\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "标记当前文章为已读于:";
 
-/* Class = "NSMenuItem"; title = "每小时"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "每小时";

--- a/Interfaces/zh-Hans.lproj/GroupFolder.strings
+++ b/Interfaces/zh-Hans.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "视窗"; ObjectID = "5"; */
-"5.title" = "视窗";
-
-/* Class = "NSTextFieldCell"; title = "新建群组文件夹"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "新建群组文件夹";
 
-/* Class = "NSButtonCell"; title = "保存"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "保存";
 
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "请输入群组文件夹名称:\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "请输入群组文件夹名称:";

--- a/Interfaces/zh-Hans.lproj/InfoWindow.strings
+++ b/Interfaces/zh-Hans.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "窗口"; ObjectID = "5"; */
-"5.title" = "窗口";
-
-/* Class = "NSTextFieldCell"; title = "(文件夹名称)"; ObjectID = "104"; */
-"104.title" = "(文件夹名称)";
-
-/* Class = "NSTextFieldCell"; title = "上次更新:"; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "上次更新:";
 
-/* Class = "NSTextFieldCell"; title = "(上次更新时间)"; ObjectID = "106"; */
-"106.title" = "(上次更新时间)";
-
-/* Class = "NSButtonCell"; title = "认证"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "认证";
 
-/* Class = "NSButtonCell"; title = "频道 URL:"; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "频道 URL";
-
-/* Class = "NSTextFieldCell"; title = "用户名:"; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "用户名:";
 
-/* Class = "NSTextFieldCell"; title = "密码:\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "密码:";
 
-/* Class = "NSButtonCell"; title = "更新验证信息"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "更新验证信息";
 
-/* Class = "NSButtonCell"; title = "验证:"; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "验证";
-
-/* Class = "NSTextFieldCell"; title = "大小:"; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "大小:";
 
-/* Class = "NSTextFieldCell"; title = "未读:\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "未读:";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "订阅"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "订阅";
-
-/* Class = "NSButtonCell"; title = "通用:"; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "通用";
-
-/* Class = "NSButtonCell"; title = "介绍:"; ObjectID = "124"; */
-"E84-Uo-ybg.title" = "介绍";
 
 /* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
 "126.title" = "Load Full HTML Articles";
+
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
+"E84-Uo-ybg.title" = "介绍";
+
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "验证";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "通用";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "频道 URL";

--- a/Interfaces/zh-Hans.lproj/MainMenu.strings
+++ b/Interfaces/zh-Hans.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "窗口";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "主菜单";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "隐藏状态栏";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "显示过滤栏";

--- a/Interfaces/zh-Hans.lproj/MainMenu.strings
+++ b/Interfaces/zh-Hans.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "全部调到前面";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "重做";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "拼写";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "拼写";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "拼写…";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "检查拼写";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "键入时检查拼写";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "缩放";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "更新所选的频道";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "鸣谢";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "新的订阅…";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "输出所选的频道";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna 主页";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "清空废纸篓";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "上一个标签";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "布局";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "默认";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "三栏";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "下载附带文件";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "自定义工具栏…";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "隐藏状态栏";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "在输出的文件中保留群组文件夹";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "拼写";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "标记已读";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/zh-Hans.lproj/RSSFeed.strings
+++ b/Interfaces/zh-Hans.lproj/RSSFeed.strings
@@ -1,41 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS 频道"; ObjectID = "6"; */
-"6.title" = "RSS 频道";
-
-/* Class = "NSMenu"; title = "其他方式"; ObjectID = "44"; */
-"44.title" = "其他方式";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS 频道"; ObjectID = "49"; */
-"49.title" = "RSS 频道";
-
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "取消";
 
-/* Class = "NSButtonCell"; title = "订阅"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "订阅";
 
-/* Class = "NSTextFieldCell"; title = "来源:\n"; ObjectID = "104"; */
-"104.title" = "来源:\n";
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
+"104.title" = "来源:";
 
-/* Class = "NSTextFieldCell"; title = "订阅一个新的频道\n"; ObjectID = "106"; */
-"106.title" = "订阅一个新的频道\n";
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
+"106.title" = "订阅一个新的频道";
 
-/* Class = "NSTextFieldCell"; title = "请在下面输入频道的连接。或者从来源列表中选择然后按照提示输入对应信息"; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "请在下面输入频道的连接。或者从来源列表中选择然后按照提示输入对应信息";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL:";
 
-/* Class = "NSButtonCell"; title = "保存"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "保存";
 
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "编辑频道信息"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "编辑频道信息";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/zh-Hans.lproj/SearchFolder.strings
+++ b/Interfaces/zh-Hans.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
+"94.title" = "智能文件夹名称:";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Field names go here"; ObjectID = "33"; */
-"33.title" = "Field names go here";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "62"; */
-"62.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Nothing"; ObjectID = "82"; */
-"82.title" = "Nothing";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "智能文件夹名称:\n"; ObjectID = "94"; */
-"94.title" = "智能文件夹名称:\n";
-
-/* Class = "NSButtonCell"; title = "保存"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "保存";
 
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "显示所有符合"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "显示所有符合";
 
-/* Class = "NSTextFieldCell"; title = "以下条件的条目:"; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "以下条件的条目:";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/zh-Hans.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/zh-Hans.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "密码:"; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "密码:";
 
-/* Class = "NSTextFieldCell"; title = "用户名:"; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "用户名:";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";

--- a/Interfaces/zh-Hant.lproj/AdvancedPreferencesView.strings
+++ b/Interfaces/zh-Hant.lproj/AdvancedPreferencesView.strings
@@ -1,14 +1,10 @@
-
 /* Class = "NSTextFieldCell"; title = "The higher the number, the quicker your subscriptions will be downloaded."; ObjectID = "2GQ-cu-fbh"; */
 "2GQ-cu-fbh.title" = "The higher the number, the quicker your subscriptions will be downloaded.";
 
-/* Class = "NSTextFieldCell"; title = "一般使用 Vienna 時，此處的設定應無須加以更改。請參閱輔助說明檔案以取得各個設定的詳細資訊。"; ObjectID = "GaX-8c-QaN"; */
+/* Class = "NSTextFieldCell"; title = "The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting."; ObjectID = "GaX-8c-QaN"; */
 "GaX-8c-QaN.title" = "一般使用 Vienna 時，此處的設定應無須加以更改。請參閱輔助說明檔案以取得各個設定的詳細資訊。";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Gua-yV-73n"; */
-"Gua-yV-73n.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; */
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "Mlu-22-guR"; Note = "Do not localize"; */
 "Mlu-22-guR.title" = "30";
 
 /* Class = "NSTextFieldCell"; title = "Concurrent downloads:"; ObjectID = "Ngw-hP-yW4"; */
@@ -17,26 +13,26 @@
 /* Class = "NSTextFieldCell"; title = "However, high numbers also render your computer less responsive while refreshing feeds."; ObjectID = "S3T-cW-hys"; */
 "S3T-cW-hys.title" = "However, high numbers also render your computer less responsive while refreshing feeds.";
 
-/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; */
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "bKP-m5-YPx"; Note = "Do not localize"; */
 "bKP-m5-YPx.title" = "2";
 
-/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; */
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "dXW-1P-Mja"; Note = "Do not localize"; */
 "dXW-1P-Mja.title" = "15";
 
 /* Class = "NSButtonCell"; title = "Enable Plugins in the internal browser"; ObjectID = "fIz-4t-Ogg"; */
 "fIz-4t-Ogg.title" = "Enable Plugins in the internal browser";
 
-/* Class = "NSButtonCell"; title = "在內建瀏覽器中啟用 JavaScript"; ObjectID = "guK-dE-f6n"; */
+/* Class = "NSButtonCell"; title = "Enable JavaScript in the internal browser"; ObjectID = "guK-dE-f6n"; */
 "guK-dE-f6n.title" = "在內建瀏覽器中啟用 JavaScript";
 
-/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; */
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "koF-ku-VbZ"; Note = "Do not localize"; */
 "koF-ku-VbZ.title" = "1";
 
-/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; */
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "p15-eO-dBa"; Note = "Do not localize"; */
 "p15-eO-dBa.title" = "10";
 
-/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; */
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "q0t-6p-Xd6"; Note = "Do not localize"; */
 "q0t-6p-Xd6.title" = "50";
 
-/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; */
+/* Class = "NSMenuItem"; title = "5"; ObjectID = "yD7-hF-SbK"; Note = "Do not localize"; */
 "yD7-hF-SbK.title" = "5";

--- a/Interfaces/zh-Hant.lproj/AppearancePreferencesView.strings
+++ b/Interfaces/zh-Hant.lproj/AppearancePreferencesView.strings
@@ -1,27 +1,20 @@
-
-/* Class = "NSTextFieldCell"; title = "檢視文章或網頁時："; ObjectID = "71S-pg-AjX"; */
+/* Class = "NSTextFieldCell"; title = "When viewing articles or web pages:"; ObjectID = "71S-pg-AjX"; */
 "71S-pg-AjX.title" = "檢視文章或網頁時：";
 
-/* Class = "NSTextFieldCell"; title = "檔案夾列表字體："; ObjectID = "B5v-p5-vrf"; */
+/* Class = "NSTextFieldCell"; title = "Folder list font:"; ObjectID = "B5v-p5-vrf"; */
 "B5v-p5-vrf.title" = "檔案夾列表字體：";
 
-/* Class = "NSButtonCell"; title = "選取⋯"; ObjectID = "BDw-v3-mpF"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "BDw-v3-mpF"; */
 "BDw-v3-mpF.title" = "選取⋯";
 
-/* Class = "NSButtonCell"; title = "在檔案夾列表中顯示檔案夾影像"; ObjectID = "MEV-HA-bdL"; */
+/* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "MEV-HA-bdL"; */
 "MEV-HA-bdL.title" = "在檔案夾列表中顯示檔案夾影像";
 
-/* Class = "NSTextFieldCell"; title = "文章列表字體："; ObjectID = "auD-UC-Pij"; */
+/* Class = "NSTextFieldCell"; title = "Article list font:"; ObjectID = "auD-UC-Pij"; */
 "auD-UC-Pij.title" = "文章列表字體：";
 
-/* Class = "NSTextFieldCell"; title = "(範例)"; ObjectID = "azr-ft-M4J"; */
-"azr-ft-M4J.title" = "(範例)";
-
-/* Class = "NSTextFieldCell"; title = "(範例)"; ObjectID = "g63-xD-ICn"; */
-"g63-xD-ICn.title" = "(範例)";
-
-/* Class = "NSButtonCell"; title = "選取⋯"; ObjectID = "gGT-YP-aum"; */
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "gGT-YP-aum"; */
 "gGT-YP-aum.title" = "選取⋯";
 
-/* Class = "NSButtonCell"; title = "不要使用小於以下大小的字體"; ObjectID = "zfJ-Ge-Cxe"; */
+/* Class = "NSButtonCell"; title = "Never use font sizes smaller than"; ObjectID = "zfJ-Ge-Cxe"; */
 "zfJ-Ge-Cxe.title" = "不要使用小於以下大小的字體";

--- a/Interfaces/zh-Hant.lproj/EmptyTrashWarning.strings
+++ b/Interfaces/zh-Hant.lproj/EmptyTrashWarning.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "清空垃圾桶"; ObjectID = "5"; */
-"5.title" = "清空垃圾桶";
-
-/* Class = "NSButtonCell"; title = "清空垃圾桶"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
 "17.title" = "清空垃圾桶";
 
-/* Class = "NSButtonCell"; title = "不要清空垃圾桶"; ObjectID = "18"; */
+/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
 "18.title" = "不要清空垃圾桶";
 
-/* Class = "NSTextFieldCell"; title = "垃圾桶中有刪除的文章。\n您是否要在結束前清空垃圾桶？"; ObjectID = "19"; */
-"19.title" = "垃圾桶中有刪除的文章。\n您是否要在結束前清空垃圾桶？";
+/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
+"19.title" = "垃圾桶中有刪除的文章。您是否要在結束前清空垃圾桶？";
 
-/* Class = "NSButtonCell"; title = "不要再顯示此警告"; ObjectID = "20"; */
+/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
 "20.title" = "不要再顯示此警告";

--- a/Interfaces/zh-Hant.lproj/FeedCredentials.strings
+++ b/Interfaces/zh-Hant.lproj/FeedCredentials.strings
@@ -1,18 +1,17 @@
-
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "32"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "32"; */
 "32.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "帳號："; ObjectID = "33"; */
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "33"; */
 "33.title" = "帳號：";
 
-/* Class = "NSTextFieldCell"; title = "您必須要提供帳號、密碼等登入資訊，才能夠取得 %@ 的內容"; ObjectID = "34"; */
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
 "34.title" = "您必須要提供帳號、密碼等登入資訊，才能夠取得 %@ 的內容";
 
-/* Class = "NSTextFieldCell"; title = "密碼："; ObjectID = "37"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "37"; */
 "37.title" = "密碼：";
 
-/* Class = "NSButtonCell"; title = "登入"; ObjectID = "38"; */
+/* Class = "NSButtonCell"; title = "Log In"; ObjectID = "38"; */
 "38.title" = "登入";
 
-/* Class = "NSTextFieldCell"; title = "在下次您要更新這個訂閱頻道的時候，會自動使用您在這裡所提供的帳號與密碼資訊。"; ObjectID = "39"; */
+/* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "在下次您要更新這個訂閱頻道的時候，會自動使用您在這裡所提供的帳號與密碼資訊。";

--- a/Interfaces/zh-Hant.lproj/GeneralPreferencesView.strings
+++ b/Interfaces/zh-Hant.lproj/GeneralPreferencesView.strings
@@ -1,98 +1,73 @@
-
-/* Class = "NSMenuItem"; title = "每 15 分鐘"; ObjectID = "1Ll-uG-QWh"; */
+/* Class = "NSMenuItem"; title = "Every 15 minutes"; ObjectID = "1Ll-uG-QWh"; */
 "1Ll-uG-QWh.title" = "每 15 分鐘";
 
-/* Class = "NSButtonCell"; title = "在“下一個未閱讀項目”指令後"; ObjectID = "2oy-1i-QQP"; */
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "2oy-1i-QQP"; */
 "2oy-1i-QQP.title" = "在“下一個未閱讀項目”指令後";
 
-/* Class = "NSMenuItem"; title = "(路徑)"; ObjectID = "5Cq-8f-vbL"; */
-"5Cq-8f-vbL.title" = "(路徑)";
-
-/* Class = "NSMenuItem"; title = "每 30 分鐘"; ObjectID = "5VQ-jP-2rL"; */
+/* Class = "NSMenuItem"; title = "Every 30 minutes"; ObjectID = "5VQ-jP-2rL"; */
 "5VQ-jP-2rL.title" = "每 30 分鐘";
 
-/* Class = "NSMenuItem"; title = "每 2 小時"; ObjectID = "6wU-yO-cnV"; */
+/* Class = "NSMenuItem"; title = "Every 2 hours"; ObjectID = "6wU-yO-cnV"; */
 "6wU-yO-cnV.title" = "每 2 小時";
 
-/* Class = "NSButtonCell"; title = "在應用程式圖像上顯示未閱讀數目"; ObjectID = "7e3-Hu-RB5"; */
+/* Class = "NSButtonCell"; title = "Show the unread count on the application icon"; ObjectID = "7e3-Hu-RB5"; */
 "7e3-Hu-RB5.title" = "在應用程式圖像上顯示未閱讀數目";
 
-/* Class = "NSTextFieldCell"; title = "取得未閱讀的新文章時：\n"; ObjectID = "BbI-0A-zEG"; */
-"BbI-0A-zEG.title" = "取得未閱讀的新文章時：\n";
+/* Class = "NSTextFieldCell"; title = "When new unread articles are retrieved:"; ObjectID = "BbI-0A-zEG"; */
+"BbI-0A-zEG.title" = "取得未閱讀的新文章時：";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "DFg-c6-rCy"; */
-"DFg-c6-rCy.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "其他⋯"; ObjectID = "FiK-E7-RnG"; */
+/* Class = "NSMenuItem"; title = "Other…"; ObjectID = "FiK-E7-RnG"; */
 "FiK-E7-RnG.title" = "其他⋯";
 
-/* Class = "NSMenuItem"; title = "無"; ObjectID = "GAY-ra-eQY"; */
-"GAY-ra-eQY.title" = "無";
-
-/* Class = "NSButtonCell"; title = "啟動時檢查是否有新版的 Vienna"; ObjectID = "GnT-xT-rAZ"; */
+/* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "GnT-xT-rAZ"; */
 "GnT-xT-rAZ.title" = "啟動時檢查是否有新版的 Vienna";
 
-/* Class = "NSMenuItem"; title = "手動"; ObjectID = "H9Q-du-oax"; */
+/* Class = "NSMenuItem"; title = "Manually"; ObjectID = "H9Q-du-oax"; */
 "H9Q-du-oax.title" = "手動";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "HFO-4f-zYZ"; */
-"HFO-4f-zYZ.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "每 6 小時"; ObjectID = "IMa-1h-lIO"; */
+/* Class = "NSMenuItem"; title = "Every 6 hours"; ObjectID = "IMa-1h-lIO"; */
 "IMa-1h-lIO.title" = "每 6 小時";
 
-/* Class = "NSButtonCell"; title = "在短暫時間後"; ObjectID = "JDV-ek-xja"; */
+/* Class = "NSButtonCell"; title = "After a short delay"; ObjectID = "JDV-ek-xja"; */
 "JDV-ek-xja.title" = "在短暫時間後";
 
-/* Class = "NSButtonCell"; title = "顯示於選單列"; ObjectID = "JN6-lj-bQ1"; */
+/* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "JN6-lj-bQ1"; */
 "JN6-lj-bQ1.title" = "顯示於選單列";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "Klv-JA-PvP"; */
-"Klv-JA-PvP.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "Radio"; ObjectID = "NAE-EF-SsE"; */
-"NAE-EF-SsE.title" = "Radio";
 
 /* Class = "NSButtonCell"; title = "Search for latest Beta versions"; ObjectID = "OID-qF-Pp0"; */
 "OID-qF-Pp0.title" = "Search for latest Beta versions";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "XAi-oh-7Fq"; */
-"XAi-oh-7Fq.title" = "OtherViews";
-
-/* Class = "NSButtonCell"; title = "在外部瀏覽器中打開連結"; ObjectID = "YoM-Gv-hXn"; */
+/* Class = "NSButtonCell"; title = "Open links in external browser"; ObjectID = "YoM-Gv-hXn"; */
 "YoM-Gv-hXn.title" = "在外部瀏覽器中打開連結";
 
-/* Class = "NSTextFieldCell"; title = "檢查新文章："; ObjectID = "ewU-JH-fMC"; */
+/* Class = "NSTextFieldCell"; title = "Check for new articles:"; ObjectID = "ewU-JH-fMC"; */
 "ewU-JH-fMC.title" = "檢查新文章：";
 
-/* Class = "NSMenuItem"; title = "(Do not localise)"; ObjectID = "fYn-Rz-G69"; */
-"fYn-Rz-G69.title" = "(Do not localise)";
-
-/* Class = "NSTextFieldCell"; title = "將下載的文章儲存到："; ObjectID = "geD-Ws-mQm"; */
+/* Class = "NSTextFieldCell"; title = "Save downloaded files to:"; ObjectID = "geD-Ws-mQm"; */
 "geD-Ws-mQm.title" = "將下載的文章儲存到：";
 
-/* Class = "NSButtonCell"; title = "彈跳應用程式圖像"; ObjectID = "gi4-ao-0yS"; */
+/* Class = "NSButtonCell"; title = "Bounce the application icon"; ObjectID = "gi4-ao-0yS"; */
 "gi4-ao-0yS.title" = "彈跳應用程式圖像";
 
-/* Class = "NSMenuItem"; title = "每 3 小時"; ObjectID = "gnX-dW-XUD"; */
+/* Class = "NSMenuItem"; title = "Every 3 hours"; ObjectID = "gnX-dW-XUD"; */
 "gnX-dW-XUD.title" = "每 3 小時";
 
-/* Class = "NSTextFieldCell"; title = "將文章移至垃圾桶："; ObjectID = "k6Y-ib-PGb"; */
+/* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "k6Y-ib-PGb"; */
 "k6Y-ib-PGb.title" = "將文章移至垃圾桶：";
 
-/* Class = "NSTextFieldCell"; title = "預設的 RSS 閱讀程式："; ObjectID = "kGA-Sa-RLG"; */
+/* Class = "NSTextFieldCell"; title = "Default RSS Reader:"; ObjectID = "kGA-Sa-RLG"; */
 "kGA-Sa-RLG.title" = "預設的 RSS 閱讀程式：";
 
 /* Class = "NSButtonCell"; title = "Mark updated articles as new"; ObjectID = "meo-78-YOl"; */
 "meo-78-YOl.title" = "Mark updated articles as new";
 
-/* Class = "NSMenuItem"; title = "每 5 分鐘"; ObjectID = "oVW-ee-uJT"; */
+/* Class = "NSMenuItem"; title = "Every 5 minutes"; ObjectID = "oVW-ee-uJT"; */
 "oVW-ee-uJT.title" = "每 5 分鐘";
 
-/* Class = "NSButtonCell"; title = "啟動時檢查是否有新文章"; ObjectID = "pXX-MI-tJX"; */
+/* Class = "NSButtonCell"; title = "Check for new articles on start up"; ObjectID = "pXX-MI-tJX"; */
 "pXX-MI-tJX.title" = "啟動時檢查是否有新文章";
 
-/* Class = "NSButtonCell"; title = "在背景中打開新連結"; ObjectID = "pjg-Ze-H3l"; */
+/* Class = "NSButtonCell"; title = "Open new links in the background"; ObjectID = "pjg-Ze-H3l"; */
 "pjg-Ze-H3l.title" = "在背景中打開新連結";
 
 /* Class = "NSTextFieldCell"; title = "Updates:"; ObjectID = "qeb-at-hYb"; */
@@ -101,8 +76,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "qno-Cg-EkC"; */
 "qno-Cg-EkC.title" = "Include anonymous system profile";
 
-/* Class = "NSTextFieldCell"; title = "將目前的文章標記為已閱讀：\n"; ObjectID = "sCl-hz-PFF"; */
-"sCl-hz-PFF.title" = "將目前的文章標記為已閱讀：\n";
+/* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "sCl-hz-PFF"; */
+"sCl-hz-PFF.title" = "將目前的文章標記為已閱讀：";
 
-/* Class = "NSMenuItem"; title = "每小時"; ObjectID = "sSj-zI-6RY"; */
+/* Class = "NSMenuItem"; title = "Every hour"; ObjectID = "sSj-zI-6RY"; */
 "sSj-zI-6RY.title" = "每小時";

--- a/Interfaces/zh-Hant.lproj/GroupFolder.strings
+++ b/Interfaces/zh-Hant.lproj/GroupFolder.strings
@@ -1,15 +1,11 @@
-
-/* Class = "NSWindow"; title = "面板"; ObjectID = "5"; */
-"5.title" = "面板";
-
-/* Class = "NSTextFieldCell"; title = "新增群組檔案夾"; ObjectID = "32"; */
+/* Class = "NSTextFieldCell"; title = "New Group Folder"; ObjectID = "32"; */
 "32.title" = "新增群組檔案夾";
 
-/* Class = "NSButtonCell"; title = "儲存"; ObjectID = "34"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "34"; */
 "34.title" = "儲存";
 
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "35"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "35"; */
 "35.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "輸入群組檔案夾名稱：\n"; ObjectID = "36"; */
+/* Class = "NSTextFieldCell"; title = "Enter the group folder name:"; ObjectID = "36"; */
 "36.title" = "輸入群組檔案夾名稱：";

--- a/Interfaces/zh-Hant.lproj/InfoWindow.strings
+++ b/Interfaces/zh-Hant.lproj/InfoWindow.strings
@@ -1,54 +1,38 @@
-
-/* Class = "NSWindow"; title = "視窗"; ObjectID = "5"; */
-"5.title" = "視窗";
-
-/* Class = "NSTextFieldCell"; title = "(檔案夾名稱)"; ObjectID = "104"; */
-"104.title" = "(檔案夾名稱)";
-
-/* Class = "NSTextFieldCell"; title = "上次重新整理："; ObjectID = "105"; */
+/* Class = "NSTextFieldCell"; title = "Last Refreshed:"; ObjectID = "105"; */
 "105.title" = "上次重新整理：";
 
-/* Class = "NSTextFieldCell"; title = "(上次重新整理日期)"; ObjectID = "106"; */
-"106.title" = "(上次重新整理日期)";
-
-/* Class = "NSButtonCell"; title = "驗證"; ObjectID = "109"; */
+/* Class = "NSButtonCell"; title = "Validate"; ObjectID = "109"; */
 "109.title" = "驗證";
 
-/* Class = "NSButtonCell"; title = "訂閱頻道 URL："; ObjectID = "110"; */
-"xPF-M9-oZG.title" = "訂閱頻道 URL";
-
-/* Class = "NSTextFieldCell"; title = "使用者名稱："; ObjectID = "111"; */
+/* Class = "NSTextFieldCell"; title = "User name:"; ObjectID = "111"; */
 "111.title" = "使用者名稱：";
 
-/* Class = "NSTextFieldCell"; title = "密碼：\n"; ObjectID = "112"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "112"; */
 "112.title" = "密碼：";
 
-/* Class = "NSButtonCell"; title = "更新認證"; ObjectID = "115"; */
+/* Class = "NSButtonCell"; title = "Update Authentication"; ObjectID = "115"; */
 "115.title" = "更新認證";
 
-/* Class = "NSButtonCell"; title = "認證："; ObjectID = "116"; */
-"U0N-RF-bUt.title" = "認證";
-
-/* Class = "NSTextFieldCell"; title = "大小："; ObjectID = "117"; */
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "117"; */
 "117.title" = "大小：";
 
-/* Class = "NSTextFieldCell"; title = "未讀取：\n"; ObjectID = "118"; */
+/* Class = "NSTextFieldCell"; title = "Unread:"; ObjectID = "118"; */
 "118.title" = "未讀取：";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "119"; */
-"119.title" = "\n";
-
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "120"; */
-"120.title" = "\n";
-
-/* Class = "NSButtonCell"; title = "已訂閱"; ObjectID = "121"; */
+/* Class = "NSButtonCell"; title = "Subscribed"; ObjectID = "121"; */
 "121.title" = "已訂閱";
 
-/* Class = "NSButtonCell"; title = "一般："; ObjectID = "122"; */
-"i9j-KH-c3D.title" = "一般";
+/* Class = "NSButtonCell"; title = "Load Full HTML Articles"; ObjectID = "126"; */
+"126.title" = "Use Web Page for Articles";
 
-/* Class = "NSButtonCell"; title = "描述："; ObjectID = "124"; */
+/* Class = "NSTextFieldCell"; title = "Description"; ObjectID = "E84-Uo-ybg"; */
 "E84-Uo-ybg.title" = "描述";
 
-/* Class = "NSButtonCell"; title = "Use Web Page for Articles"; ObjectID = "126"; */
-"126.title" = "Use Web Page for Articles";
+/* Class = "NSTextFieldCell"; title = "Authentication"; ObjectID = "U0N-RF-bUt"; */
+"U0N-RF-bUt.title" = "認證";
+
+/* Class = "NSTextFieldCell"; title = "General"; ObjectID = "i9j-KH-c3D"; */
+"i9j-KH-c3D.title" = "一般";
+
+/* Class = "NSTextFieldCell"; title = "Feed URL"; ObjectID = "xPF-M9-oZG"; */
+"xPF-M9-oZG.title" = "訂閱頻道 URL";

--- a/Interfaces/zh-Hant.lproj/MainMenu.strings
+++ b/Interfaces/zh-Hant.lproj/MainMenu.strings
@@ -13,9 +13,6 @@
 /* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
 "24.title" = "視窗";
 
-/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
-"29.title" = "MainMenu";
-
 /* Class = "NSMenuItem"; title = "Vienna"; ObjectID = "56"; */
 "56.title" = "Vienna";
 
@@ -327,12 +324,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "隱藏狀態列";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
-"1307.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "1308"; */
-"1308.title" = "Item3";
 
 /* Class = "NSMenuItem"; title = "Show Filter Bar"; ObjectID = "1325"; */
 "1325.title" = "顯示過濾列";

--- a/Interfaces/zh-Hant.lproj/MainMenu.strings
+++ b/Interfaces/zh-Hant.lproj/MainMenu.strings
@@ -1,4 +1,3 @@
-
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "將此程式所有視窗移至最前";
 
@@ -116,21 +115,6 @@
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
 "173.title" = "重作";
 
-/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
-"184.title" = "拼字檢查";
-
-/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
-"fad-Nj-OFI.title" = "拼字檢查";
-
-/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
-"187.title" = "拼字檢查⋯";
-
-/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
-"189.title" = "檢查拼字";
-
-/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
-"191.title" = "在輸入時同步檢查拼字";
-
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
 "197.title" = "縮放";
 
@@ -179,9 +163,6 @@
 /* Class = "NSMenuItem"; title = "Refresh Selected Subscriptions"; ObjectID = "604"; */
 "604.title" = "重新整理所選訂閱頻道";
 
-/* Class = "NSMenuItem"; title = "Acknowledgements"; ObjectID = "682"; */
-"682.title" = "致謝聲明";
-
 /* Class = "NSMenuItem"; title = "New Subscription…"; ObjectID = "690"; */
 "690.title" = "新增訂閱頻道⋯";
 
@@ -215,9 +196,6 @@
 /* Class = "NSButtonCell"; title = "Export selected subscriptions"; ObjectID = "863"; */
 "863.title" = "輸出所選訂閱頻道";
 
-/* Class = "NSBox"; title = "Title"; ObjectID = "881"; */
-"881.title" = "Title";
-
 /* Class = "NSMenuItem"; title = "Vienna Web Site"; ObjectID = "929"; */
 "929.title" = "Vienna 官方網站";
 
@@ -229,12 +207,6 @@
 
 /* Class = "NSMenuItem"; title = "Empty Trash"; ObjectID = "961"; */
 "961.title" = "清空垃圾桶";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "973"; */
-"973.title" = "Title";
-
-/* Class = "NSBox"; title = "Title"; ObjectID = "978"; */
-"978.title" = "Title";
 
 /* Class = "NSMenuItem"; title = "Previous Tab"; ObjectID = "1008"; */
 "1008.title" = "前一個標籤頁";
@@ -290,10 +262,10 @@
 /* Class = "NSMenu"; title = "Layout"; ObjectID = "1109"; */
 "1109.title" = "版面配置";
 
-/* Class = "NSMenuItem"; title = "Report"; ObjectID = "1110"; */
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "1110"; */
 "1110.title" = "報告";
 
-/* Class = "NSMenuItem"; title = "Condensed"; ObjectID = "1116"; */
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "1116"; */
 "1116.title" = "精簡";
 
 /* Class = "NSMenuItem"; title = "Filter By"; ObjectID = "1117"; */
@@ -347,9 +319,6 @@
 /* Class = "NSMenuItem"; title = "Download Enclosure"; ObjectID = "1216"; */
 "1216.title" = "下載隨附項目";
 
-/* Class = "NSTabViewItem"; label = "Tab"; ObjectID = "1221"; */
-"1221.label" = "Tab";
-
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1257"; */
 "1257.title" = "自定工具列⋯";
 
@@ -358,9 +327,6 @@
 
 /* Class = "NSMenuItem"; title = "Hide Status Bar"; ObjectID = "1259"; */
 "1259.title" = "隱藏狀態列";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "1279"; */
-"1279.title" = "Box";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1307"; */
 "1307.title" = "OtherViews";
@@ -386,23 +352,11 @@
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
 "1339.title" = "Name";
 
-/* Class = "NSTextFieldCell"; title = "\n"; ObjectID = "1367"; */
-"1367.title" = "\n";
-
 /* Class = "NSButtonCell"; title = "Preserve group folders in exported file"; ObjectID = "1368"; */
 "1368.title" = "在輸出檔案中保留群組檔案夾";
 
-/* Class = "NSTextFieldCell"; title = "(label)"; ObjectID = "1373"; */
-"1373.title" = "(label)";
-
-/* Class = "NSButtonCell"; title = "(button)"; ObjectID = "1374"; */
-"1374.title" = "(button)";
-
-/* Class = "NSTextFieldCell"; title = "(filename)"; ObjectID = "1375"; */
-"1375.title" = "(filename)";
-
-/* Class = "NSTextFieldCell"; title = "Filter by:\n"; ObjectID = "1377"; */
-"1377.title" = "Filter by:\n";
+/* Class = "NSTextFieldCell"; title = "Filter by:"; ObjectID = "1377"; */
+"1377.title" = "Filter by:";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "1380"; */
 "1380.title" = "Radio";
@@ -434,8 +388,8 @@
 /* Class = "NSMenuItem"; title = "Reindex Database"; ObjectID = "1458"; */
 "1458.title" = "Reindex Database";
 
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "fad-Nj-OFI"; */
+"fad-Nj-OFI.title" = "拼字檢查";
+
 /* Class = "NSMenuItem"; title = "Mark Read"; ObjectID = "pKl-6f-Hlc"; */
 "pKl-6f-Hlc.title" = "標示為已閱讀";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "vZe-8N-E3r"; */
-"vZe-8N-E3r.title" = "Text Cell";

--- a/Interfaces/zh-Hant.lproj/RSSFeed.strings
+++ b/Interfaces/zh-Hant.lproj/RSSFeed.strings
@@ -1,41 +1,28 @@
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "6"; */
-"6.title" = "RSS Feed";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "44"; */
-"44.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "45"; */
-"45.title" = "URL";
-
-/* Class = "NSWindow"; title = "RSS Feed"; ObjectID = "49"; */
-"49.title" = "RSS Feed";
-
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "102"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "102"; */
 "102.title" = "取消";
 
-/* Class = "NSButtonCell"; title = "訂閱"; ObjectID = "103"; */
+/* Class = "NSButtonCell"; title = "Subscribe"; ObjectID = "103"; */
 "103.title" = "訂閱";
 
-/* Class = "NSTextFieldCell"; title = "來源：\n"; ObjectID = "104"; */
-"104.title" = "來源：\n";
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "104"; */
+"104.title" = "來源：";
 
-/* Class = "NSTextFieldCell"; title = "建立新的 RSS 訂閱頻道"; ObjectID = "106"; */
+/* Class = "NSTextFieldCell"; title = "Create a new subscription"; ObjectID = "106"; */
 "106.title" = "建立新的 RSS 訂閱頻道";
 
-/* Class = "NSTextFieldCell"; title = "請在下方輸入 RSS 的連結網址，或是從來源列表中進行選擇，以輸入新聞訂閱頻道的捷徑名稱。"; ObjectID = "107"; */
+/* Class = "NSTextFieldCell"; title = "Enter the link for the news feed below. Or choose from the Source list to enter a shortcut name for the news feed provided by the source."; ObjectID = "107"; */
 "107.title" = "請在下方輸入 RSS 的連結網址，或是從來源列表中進行選擇，以輸入新聞訂閱頻道的捷徑名稱。";
 
-/* Class = "NSTextFieldCell"; title = "URL："; ObjectID = "110"; */
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "110"; */
 "110.title" = "URL：";
 
-/* Class = "NSButtonCell"; title = "儲存"; ObjectID = "111"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "111"; */
 "111.title" = "儲存";
 
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "112"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "112"; */
 "112.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "編輯訂閱頻道"; ObjectID = "114"; */
+/* Class = "NSTextFieldCell"; title = "Edit subscription"; ObjectID = "114"; */
 "114.title" = "編輯訂閱頻道";
 
 /* Class = "NSButtonCell"; title = "Subscribe in Open Reader"; ObjectID = "116"; */

--- a/Interfaces/zh-Hant.lproj/SearchFolder.strings
+++ b/Interfaces/zh-Hant.lproj/SearchFolder.strings
@@ -1,66 +1,14 @@
+/* Class = "NSTextFieldCell"; title = "Smart folder name:"; ObjectID = "94"; */
+"94.title" = "智慧型檔案夾名稱：";
 
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "32"; */
-"32.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Field names go here"; ObjectID = "33"; */
-"33.title" = "Field names go here";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "34"; */
-"34.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Operators go here"; ObjectID = "56"; */
-"56.title" = "Operators go here";
-
-/* Class = "NSMenuItem"; title = "無"; ObjectID = "62"; */
-"62.title" = "無";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "64"; */
-"64.title" = "OtherViews";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "74"; */
-"74.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "75"; */
-"75.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "76"; */
-"76.title" = "Item2";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "80"; */
-"80.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "無"; ObjectID = "82"; */
-"82.title" = "無";
-
-/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "87"; */
-"87.title" = "OtherViews";
-
-/* Class = "NSMenuItem"; title = "Item1"; ObjectID = "88"; */
-"88.title" = "Item1";
-
-/* Class = "NSMenuItem"; title = "Item3"; ObjectID = "89"; */
-"89.title" = "Item3";
-
-/* Class = "NSMenuItem"; title = "Item2"; ObjectID = "90"; */
-"90.title" = "Item2";
-
-/* Class = "NSTextFieldCell"; title = "智慧型檔案夾名稱：\n"; ObjectID = "94"; */
-"94.title" = "智慧型檔案夾名稱：\n";
-
-/* Class = "NSButtonCell"; title = "儲存"; ObjectID = "96"; */
+/* Class = "NSButtonCell"; title = "Save"; ObjectID = "96"; */
 "96.title" = "儲存";
 
-/* Class = "NSButtonCell"; title = "取消"; ObjectID = "97"; */
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "取消";
 
-/* Class = "NSTextFieldCell"; title = "顯示符合"; ObjectID = "98"; */
+/* Class = "NSTextFieldCell"; title = "Show all articles that match"; ObjectID = "98"; */
 "98.title" = "顯示符合";
 
-/* Class = "NSTextFieldCell"; title = "條件的所有文章："; ObjectID = "100"; */
+/* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
 "100.title" = "條件的所有文章：";
-
-/* Class = "NSButtonCell"; title = "-"; ObjectID = "102"; */
-"102.title" = "-";
-
-/* Class = "NSButtonCell"; title = "+"; ObjectID = "104"; */
-"104.title" = "+";

--- a/Interfaces/zh-Hant.lproj/SyncingPreferencesView.strings
+++ b/Interfaces/zh-Hant.lproj/SyncingPreferencesView.strings
@@ -1,30 +1,17 @@
-
-/* Class = "NSTextFieldCell"; placeholderString = "Placeholder for server specific explanations"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.placeholderString" = "Placeholder for server specific explanations";
-
-/* Class = "NSTextFieldCell"; title = "Hint (Do Not Localise)"; ObjectID = "3WF-BJ-rBh"; */
-"3WF-BJ-rBh.title" = "Hint (Do Not Localise)";
-
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibExternalAccessibilityDescription" = "Visit the website";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "Ar5-Qc-YTe"; */
 "Ar5-Qc-YTe.ibShadowedToolTip" = "Visit the website";
 
-/* Class = "NSMenu"; title = "ServicesView"; ObjectID = "LVH-iR-bmO"; */
-"LVH-iR-bmO.title" = "ServicesView";
-
 /* Class = "NSButtonCell"; title = "Sync with an Open Reader server"; ObjectID = "Lkv-md-rEW"; */
 "Lkv-md-rEW.title" = "Sync with an Open Reader server";
 
-/* Class = "NSTextFieldCell"; title = "密碼："; ObjectID = "NKI-36-zCY"; */
+/* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "NKI-36-zCY"; */
 "NKI-36-zCY.title" = "密碼：";
 
-/* Class = "NSTextFieldCell"; title = "帳號："; ObjectID = "O2q-8o-CSb"; */
+/* Class = "NSTextFieldCell"; title = "Login:"; ObjectID = "O2q-8o-CSb"; */
 "O2q-8o-CSb.title" = "帳號：";
-
-/* Class = "NSMenuItem"; title = "URL"; ObjectID = "RMd-14-2Bl"; */
-"RMd-14-2Bl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "🌍"; ObjectID = "e0z-IA-uBQ"; */
 "e0z-IA-uBQ.title" = "🌍";


### PR DESCRIPTION
The transition to Auto Layout left some cruft in the localization files. In particular, I got rid of some placeholder strings in Interface Builder. These should now be gone in the localization files as well. In addition, the comments that precede strings are updated to include the English source string, which should help for future localization.

I did this using Xcode's export/import tools. I went over all files and don't believe that anything went wrong. The only thing I have not committed yet are changes to Localizable.strings files. Xcode insists on changing the format there, so I left those out for now.