### PR TITLE
Fix case mismatch in #import statement in ArticleController.h

### DIFF
--- a/src/ArticleController.h
+++ b/src/ArticleController.h
@@ -20,7 +20,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import "FoldersTree.h"
-#import "BacktrackArray.h"
+#import "BackTrackArray.h"
 #import "BaseView.h"
 #import "ArticleBaseView.h"
 #import "ArticleView.h"


### PR DESCRIPTION
Xcode 8.3 complains about this.