### PR TITLE
Fix CoreAnimation related warnings

### DIFF
--- a/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
@@ -114,6 +114,13 @@
             ReferencedContainer = "container:Vienna.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CA_DEBUG_TRANSACTIONS"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/src/ActivityLog.m
+++ b/src/ActivityLog.m
@@ -66,8 +66,10 @@
  */
 -(void)setStatus:(NSString *)aStatus
 {
-	status = aStatus;
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityLogChange" object:self];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		status = aStatus;
+		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityLogChange" object:self];
+	});
 }
 
 /* clearDetails
@@ -83,10 +85,13 @@
  */
 -(void)appendDetail:(NSString *)aString
 {
-	if (details == nil)
-		details = [[NSMutableArray alloc] init];
-	[details addObject:aString];
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityDetailChange" object:self];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (details == nil) {
+			details = [[NSMutableArray alloc] init];
+		}
+		[details addObject:aString];
+		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ActivityDetailChange" object:self];
+	});
 }
 
 /* details

--- a/src/GoogleReader.m
+++ b/src/GoogleReader.m
@@ -31,6 +31,7 @@
 #import "StringExtensions.h"
 #import "NSNotificationAdditions.h"
 #import "KeyChain.h"
+#import <QuartzCore/QuartzCore.h>
 
 #define TIMESTAMP [NSString stringWithFormat:@"%0.0f",[[NSDate date] timeIntervalSince1970]]
 
@@ -460,7 +461,9 @@ enum GoogleReaderStatus {
 {
 	dispatch_queue_t queue = [RefreshManager sharedManager].asyncQueue;
 	dispatch_async(queue, ^() {
-		
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+
 	ActivityItem *aItem = request.userInfo[@"log"];
 	Folder *refreshedFolder = request.userInfo[@"folder"];
 	LLog(@"Refresh Done: %@",[refreshedFolder feedURL]);
@@ -597,21 +600,16 @@ enum GoogleReaderStatus {
 		// Add to count of new articles so far
 		countOfNewArticles += newArticlesFromFeed;
 
-		// Unread count may have changed
-		dispatch_async(dispatch_get_main_queue(), ^{
-			AppController *controller = APPCONTROLLER;
-			[controller setStatusMessage:nil persist:NO];
-			[refreshedFolder clearNonPersistedFlag:MA_FFlag_Error];
-
-			// Send status to the activity log
-			if (newArticlesFromFeed == 0)
-				[aItem setStatus:NSLocalizedString(@"No new articles available", nil)];
-			else
-			{
-				aItem.status = [NSString stringWithFormat:NSLocalizedString(@"%d new articles retrieved", nil), newArticlesFromFeed];
-				[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_FoldersUpdated" object:@(refreshedFolder.itemId)];
-			}
-		});
+        [APPCONTROLLER setStatusMessage:nil persist:NO];
+        [refreshedFolder clearNonPersistedFlag:MA_FFlag_Error];
+        // Send status to the activity log
+        if (newArticlesFromFeed == 0) {
+            aItem.status = NSLocalizedString(@"No new articles available", nil);
+        } else {
+            aItem.status = [NSString stringWithFormat:NSLocalizedString(@"%d new articles retrieved", nil), newArticlesFromFeed];
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_FoldersUpdated"
+                                                                                object:@(refreshedFolder.itemId)];
+        }
 		
 	} else { //other HTTP status response...
 		[aItem appendDetail:[NSString stringWithFormat:NSLocalizedString(@"HTTP code %d reported from server", nil), request.responseStatusCode]];
@@ -624,6 +622,7 @@ enum GoogleReaderStatus {
 		[refreshedFolder clearNonPersistedFlag:MA_FFlag_Updating];
 		[refreshedFolder setNonPersistedFlag:MA_FFlag_Error];
 	}
+    [CATransaction commit];
 	}); //block for dispatch_async
 }
 

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -33,6 +33,7 @@
 #import "NSNotificationAdditions.h"
 #import "VTPG_Common.h"
 #import "FeedItem.h"
+#import <QuartzCore/QuartzCore.h>
 
 // Private functions
 @interface RefreshManager (Private)
@@ -264,9 +265,7 @@
 			[self refreshFolderIconCacheForSubscriptions:[[Database sharedManager] arrayOfFolders:folder.itemId]];
 		else if (IsRSSFolder(folder) || IsGoogleReaderFolder(folder))
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[self refreshFavIconForFolder:folder];
-			});
+			[self refreshFavIconForFolder:folder];
 		}
 	}
 }
@@ -608,13 +607,11 @@
 - (void)syncFinishedForFolder:(Folder *)folder 
 {
     [self setFolderUpdatingFlag:folder flag:NO];
-    dispatch_async(dispatch_get_main_queue(), ^{
-		// Unread count may have changed
-		AppController *controller = APPCONTROLLER;
-		[controller setStatusMessage:nil persist:NO];
-		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_FoldersUpdated"
-																object:@(folder.itemId)];
-	});
+	// Unread count may have changed
+	AppController *controller = APPCONTROLLER;
+	[controller setStatusMessage:nil persist:NO];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_FoldersUpdated"
+																		object:@(folder.itemId)];
 }
 
 /* folderRefreshRedirect
@@ -689,6 +686,8 @@
 -(void)folderRefreshCompleted:(ASIHTTPRequest *)connector
 {
 	dispatch_async(_queue, ^() {
+	[CATransaction begin];
+	[CATransaction setDisableActions:YES];
 		
 	Folder * folder = (Folder *)connector.userInfo[@"folder"];
 	ActivityItem *connectorItem = connector.userInfo[@"log"];
@@ -726,6 +725,7 @@
 		[connectorItem appendDetail:NSLocalizedString(@"Got HTTP status 304 - No news from last check", nil)];
 		[connectorItem setStatus:NSLocalizedString(@"No new articles available", nil)];
 		[self syncFinishedForFolder:folder];
+		[CATransaction commit];
 		return;
 	}
 	else if (isCancelled) 
@@ -774,6 +774,7 @@
 
 	[self syncFinishedForFolder:folder];
 
+	[CATransaction commit];
 	}); //block for dispatch_async on _queue
 };
 


### PR DESCRIPTION
Avoid “CoreAnimation: warning, deleted thread with uncommitted CATransaction”
messages, caused by updates to ActivityItem on background refresh threads.

- change the CA_DEBUG_TRANSACTIONS environment variable to 1 in order to
have exceptions or backtraces
- make sure all drawing action are performed on the main thread
- add explicit CATransaction-s.