### PR TITLE
Modernize the +parseXMLDate: method

### DIFF
--- a/src/NSDate+Vienna.m
+++ b/src/NSDate+Vienna.m
@@ -13,31 +13,33 @@
 * Note: for every four-digit year entry, we need an earlier two-digit year entry
 * so that NSDateFormatter parses two-digit years considering the two-digit-year start date.
 *
-* For the different date formats, see <http://unicode.org/reports/tr35/#Date_Format_Patterns>
-* IMPORTANT hack : remove in these strings any colon [:] beginning from character # 20 (first char is #0)
-* We do so because some servers incorrectly return strings with a colon (:) in timezone indication
-* which NSDateFormatter refuses to handle
+* For the different date formats, see <http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns>
 *
 */
 static NSString * kDateFormats[] = {
 	// 2010-09-28T15:31:25Z and 2010-09-28T17:31:25+02:00
-	@"yy-MM-dd'T'HH:mm:ssZZZ",     @"yyyy-MM-dd'T'HH:mm:ssZZZ",
+	@"yy-MM-dd'T'HH:mm:ssXXXX",       @"yyyy-MM-dd'T'HH:mm:ssXXXX",
+	@"yy-MM-dd'T'HH:mm:ssXXXXX",      @"yyyy-MM-dd'T'HH:mm:ssXXXXX",
 	// 2010-09-28T15:31:25.815+02:00
-	@"yy-MM-dd'T'HH:mm:ss.SSSZZZ", @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZ",
+	@"yy-MM-dd'T'HH:mm:ss.SSSXXXX",   @"yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
+	@"yy-MM-dd'T'HH:mm:ss.SSSXXXXX",  @"yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
 	// "Sat, 13 Dec 2008 18:45:15 EAT" and "Fri, 12 Dec 2008 18:45:15 -08:00"
-	@"EEE, dd MMM yy HH:mmss zzz", @"EEE, dd MMM yyyy HH:mmss zzz",
-	@"EEE, dd MMM yy HH:mmss ZZZ", @"EEE, dd MMM yyyy HH:mmss ZZZ",
-	@"EEE, dd MMM yy HH:mmss",     @"EEE, dd MMM yyyy HH:mmss",
-	// Required by compatibility with older OS X versions
-	@"yy-MM-dd'T'HH:mm:ss'Z'",     @"yyyy-MM-dd'T'HH:mm:ss'Z'",
-	@"yy-MM-dd'T'HH:mm:ss.SSS'Z'", @"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+	@"EEE, dd MMM yy HH:mm:ss zzz",   @"EEE, dd MMM yyyy HH:mm:ss zzz",
+	@"EEE, dd MMM yy HH:mm:ss XXXX",  @"EEE, dd MMM yyyy HH:mm:ss XXXX",
+	@"EEE, dd MMM yy HH:mm:ss XXXXX", @"EEE, dd MMM yyyy HH:mm:ss XXXXX",
+	@"EEE, dd MMM yy HH:mm:ss",       @"EEE, dd MMM yyyy HH:mm:ss",
 	// Other exotic and non standard date formats
-	@"yy-MM-dd HH:mm:ss ZZZ",      @"yyyy-MM-dd HH:mm:ss ZZZ",
-	@"yy-MM-dd HH:mm:ss zzz",      @"yyyy-MM-dd HH:mm:ss zzz",
-	@"EEE dd MMM yy HH:mmss zzz",  @"EEE dd MMM yyyy HH:mmss zzz",
-	@"EEE dd MMM yy HH:mmss ZZZ",  @"EEE dd MMM yyyy HH:mmss ZZZ",
-	@"EEE dd MMM yy HH:mmss",      @"EEE dd MMM yyyy HH:mmss",
-	@"EEEE dd MMMM yy",            @"EEEE dd MMMM yyyy",
+	@"yy-MM-dd HH:mm:ss XXXX",        @"yyyy-MM-dd HH:mm:ss XXXX",
+	@"yy-MM-dd HH:mm:ss XXXXX",       @"yyyy-MM-dd HH:mm:ss XXXXX",
+	@"yy-MM-dd HH:mm:ss zzz",         @"yyyy-MM-dd HH:mm:ss zzz",
+	@"EEE dd MMM yy HH:mm:ss zzz",    @"EEE dd MMM yyyy HH:mm:ss zzz",
+	@"EEE dd MMM yy HH:mm:ss XXXX",   @"EEE dd MMM yyyy HH:mm:ss XXXX",
+	@"EEE dd MMM yy HH:mm:ss XXXXX",  @"EEE dd MMM yyyy HH:mm:ss XXXXX",
+	@"EEE dd MMM yy HH:mm:ss",        @"EEE dd MMM yyyy HH:mm:ss",
+	@"EEEE dd MMMM yy",               @"EEEE dd MMMM yyyy",
+	@"dd MMM yy HH:mm:ss zzz",        @"dd MMM yyyy HH:mm:ss zzz",
+	@"dd MMM yy HH:mm:ss XXXX",       @"dd MMM yyyy HH:mm:ss XXXX",
+	@"dd MMM yy HH:mm:ss XXXXX",      @"dd MMM yyyy HH:mm:ss XXXXX",
 };
 static const size_t kNumberOfDateFormatters = sizeof(kDateFormats) / sizeof(kDateFormats[0]);
 
@@ -73,19 +75,7 @@ static NSLocale * enUSLocale;
 + (NSDate *)parseXMLDate:(NSString *)dateString
 {
 	NSDate *date ;
-    NSString *modifiedDateString ;
-	// Hack : remove colon in timezone as NSDateFormatter doesn't recognize them
-	if (dateString.length > 20)
-	{
-        modifiedDateString = [dateString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    	modifiedDateString = [modifiedDateString
-                            stringByReplacingOccurrencesOfString:@":" withString:@""
-                            options:0 range:NSMakeRange(20,modifiedDateString.length-20)];
-    }
-    else
-    {
-        modifiedDateString = dateString;
-    }
+    NSString *modifiedDateString = [dateString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
     // test with the date formatters we are aware of
     // exit as soon as we find a match
@@ -98,10 +88,7 @@ static NSLocale * enUSLocale;
         }
     }
 
-	// expensive last resort attempt
-	date = [NSDate dateWithNaturalLanguageString:dateString locale:enUSLocale];
 	return date;
-    
 }
 
 @end


### PR DESCRIPTION
Use the X symbol allowed by Unicode Technical Standard tr35-31
Remove a hack which is therefore not needed anymore
Remove deprecated NSDate -dateWithNaturalLanguageString:locale: method
Add other non standard date formats I encountered