### PR TITLE
Clean up some code relating to ViennaApp/AppController

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -440,7 +440,7 @@ CA
                             </menuItem>
                             <menuItem title="Quit Vienna" keyEquivalent="q" id="136">
                                 <connections>
-                                    <action selector="exitVienna:" target="233" id="1232"/>
+                                    <action selector="terminate:" target="-1" id="A3o-k6-T9E"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -376,7 +376,7 @@
                             <menuItem title="About Vienna" id="58">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="handleAbout:" target="233" id="950"/>
+                                    <action selector="orderFrontStandardAboutPanel:" target="-1" id="I3y-xZ-6an"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="196">

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -96,7 +96,6 @@
 @property(nonatomic, strong) IBOutlet FoldersTree * foldersTree;
 
 // Menu action items
--(IBAction)exitVienna:(id)sender;
 -(IBAction)reindexDatabase:(id)sender;
 -(IBAction)deleteMessage:(id)sender;
 -(IBAction)deleteFolder:(id)sender;

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -96,7 +96,6 @@
 @property(nonatomic, strong) IBOutlet FoldersTree * foldersTree;
 
 // Menu action items
--(IBAction)handleAbout:(id)sender;
 -(IBAction)exitVienna:(id)sender;
 -(IBAction)reindexDatabase:(id)sender;
 -(IBAction)deleteMessage:(id)sender;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -1730,20 +1730,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	} // @synchronized
 }
 
-/* handleAbout
- * Display our About Vienna... window.
- */
--(IBAction)handleAbout:(id)sender
-{
-	NSDictionary * fileAttributes = [NSBundle mainBundle].infoDictionary;
-	LOG_EXPR(fileAttributes);
-	NSString * version = fileAttributes[@"CFBundleShortVersionString"];
-	NSString * versionString = [NSString stringWithFormat:NSLocalizedString(@"Version %@", nil), version];
-	NSDictionary * d = @{@"ApplicationVersion": versionString, @"Version": @""};
-	[NSApp activateIgnoringOtherApps:YES];
-	[NSApp orderFrontStandardAboutPanelWithOptions:d];
-}
-
 /* emptyTrash
  * Delete all articles from the Trash folder.
  */
@@ -1862,7 +1848,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(refreshAllSubscriptions:))];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(markAllSubscriptionsRead:))];
 		[statusBarMenu addItem:[NSMenuItem separatorItem]];
-		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(handleAbout:))];
+		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(orderFrontStandardAboutPanel:))];
 		[statusBarMenu addItem:[NSMenuItem separatorItem]];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(exitVienna:))];
 		appStatusItem.menu = statusBarMenu;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -1834,14 +1834,16 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[appStatusItem setHighlightMode:YES];
 		
         NSMenu * statusBarMenu = [NSMenu new];
-		[statusBarMenu addItem:menuItemWithTitleAndAction(NSLocalizedString(@"Open Vienna", nil), @selector(openVienna:))];
-		[statusBarMenu addItem:[NSMenuItem separatorItem]];
+        [statusBarMenu addItemWithTitle:NSLocalizedString(@"Show Main Window…", @"Title of a menu item")
+                                 action:@selector(openVienna:)
+                          keyEquivalent:@""];
+        [statusBarMenu addItem:[NSMenuItem separatorItem]];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(refreshAllSubscriptions:))];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(markAllSubscriptionsRead:))];
-		[statusBarMenu addItem:[NSMenuItem separatorItem]];
-		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(orderFrontStandardAboutPanel:))];
-		[statusBarMenu addItem:[NSMenuItem separatorItem]];
-		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(terminate:))];
+        [statusBarMenu addItem:[NSMenuItem separatorItem]];
+        [statusBarMenu addItemWithTitle:NSLocalizedString(@"Quit Vienna", @"Title of a menu item")
+                                 action:@selector(terminate:)
+                          keyEquivalent:@""];
 		appStatusItem.menu = statusBarMenu;
 	}
 	else if (!prefs.showAppInStatusBar && appStatusItem != nil)
@@ -4085,7 +4087,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		else 
 			menuItem.state = NSOffState;
 		return YES;
-	}
+	} else if (theAction == @selector(openVienna:)) {
+        return mainWindow.isKeyWindow == false;
+    }
+
 	return YES;
 }
 

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -795,7 +795,6 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
 	return browserView;
 }
 
-
 /* folderMenu
  * Dynamically create the popup menu. This is one less thing to
  * explicitly localise in the NIB file.
@@ -821,14 +820,6 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
 	[folderMenu addItem:[NSMenuItem separatorItem]];
 	[folderMenu addItem:copyOfMenuItemWithAction(@selector(forceRefreshSelectedSubscriptions:))];	
 	return folderMenu;
-}
-
-/* exitVienna
- * Alias for the terminate command.
- */
--(IBAction)exitVienna:(id)sender
-{
-	[NSApp terminate:nil];
 }
 
 /* reindexDatabase
@@ -1850,7 +1841,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[statusBarMenu addItem:[NSMenuItem separatorItem]];
 		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(orderFrontStandardAboutPanel:))];
 		[statusBarMenu addItem:[NSMenuItem separatorItem]];
-		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(exitVienna:))];
+		[statusBarMenu addItem:copyOfMenuItemWithAction(@selector(terminate:))];
 		appStatusItem.menu = statusBarMenu;
 	}
 	else if (!prefs.showAppInStatusBar && appStatusItem != nil)

--- a/src/FoldersTree.m
+++ b/src/FoldersTree.m
@@ -27,7 +27,6 @@
 #import "StringExtensions.h"
 #import "FolderView.h"
 #import "PopupButton.h"
-#import "ViennaApp.h"
 #import "BrowserView.h"
 #import "GoogleReader.h"
 

--- a/src/HelperFunctions.h
+++ b/src/HelperFunctions.h
@@ -41,8 +41,6 @@ BOOL isAccessible(NSString * urlString);
 void runOKAlertPanel(NSString * titleString, NSString * bodyText, ...);
 void runOKAlertSheet(NSString * titleString, NSString * bodyText, ...);
 NSMenuItem * menuItemWithAction(SEL theSelector);
-NSMenuItem * menuItemWithTitleAndAction(NSString * theTitle, SEL theSelector);
-NSMenuItem * menuItemOfMenuWithAction(NSMenu * menu, SEL theSelector);
 NSMenuItem * copyOfMenuItemWithAction(SEL theSelector);
 NSString * getDefaultBrowser(void);
 NSURL * cleanedUpAndEscapedUrlFromString(NSString * theUrl);

--- a/src/HelperFunctions.m
+++ b/src/HelperFunctions.m
@@ -70,26 +70,6 @@ NSMenuItem * menuItemWithAction(SEL theSelector)
 	return nil;
 }
 
-/* menuWithAction
- * Returns the first NSMenuItem that matches the one that implements the corresponding
- * action in the application main menu. Returns nil if no match is found.
- */
-NSMenuItem * menuItemOfMenuWithAction(NSMenu * menu, SEL theSelector)
-{
-	NSArray * arrayOfMenus = menu.itemArray;
-	NSInteger count = arrayOfMenus.count;
-	NSInteger index;
-	
-	for (index = 0; index < count; ++index)
-	{
-		NSMenu * subMenu = [arrayOfMenus[index] submenu];
-		NSInteger itemIndex = [subMenu indexOfItemWithTarget:NSApp.delegate andAction:theSelector];
-		if (itemIndex >= 0)
-			return [subMenu itemAtIndex:itemIndex];
-	}
-	return nil;
-}
-
 /* percentEscape
  * Escape invalid and reserved URL characters to make string suitable 
  * for embedding in mailto: URLs and custom app-specific schemes like papers://
@@ -140,14 +120,6 @@ NSMenuItem * copyOfMenuItemWithAction(SEL theSelector)
 {
 	NSMenuItem * item = menuItemWithAction(theSelector);
 	return (item) ? [[NSMenuItem alloc] initWithTitle:item.title action:theSelector keyEquivalent:@""] : nil;
-}
-
-/* menuWithTitleAndAction
- * Returns an NSMenuItem with the specified menu and action.
- */
-NSMenuItem * menuItemWithTitleAndAction(NSString * theTitle, SEL theSelector)
-{
-	return [[NSMenuItem alloc] initWithTitle:theTitle action:theSelector keyEquivalent:@""];
 }
 
 /* loadMapFromPath

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -25,7 +25,6 @@
 #import "StringExtensions.h"
 #import "Preferences.h"
 #import "Constants.h"
-#import "ViennaApp.h"
 #import "GoogleReader.h"
 #import "Constants.h"
 #import "AppController.h"

--- a/src/ViennaApp.m
+++ b/src/ViennaApp.m
@@ -19,13 +19,15 @@
 //
 
 #import "ViennaApp.h"
+
 #import "AppController.h"
-#import "Preferences.h"
-#import "Import.h"
-#import "Export.h"
-#import "RefreshManager.h"
-#import "Constants.h"
 #import "BrowserPane.h"
+#import "Constants.h"
+#import "Debug.h"
+#import "Export.h"
+#import "Import.h"
+#import "Preferences.h"
+#import "RefreshManager.h"
 
 @implementation ViennaApp
 
@@ -330,6 +332,20 @@
 	AppController * controller = APPCONTROLLER;
 	NSInteger folderId = newCurrentFolder.itemId;
 	[controller selectFolder:folderId];
+}
+
+/**
+ * Show a modified About panel and print the Info.plist contents.
+ */
+- (void)orderFrontStandardAboutPanel:(id)sender {
+    NSDictionary *fileAttributes = NSBundle.mainBundle.infoDictionary;
+    LOG_EXPR(fileAttributes);
+
+    NSString *shortVersion = fileAttributes[@"CFBundleShortVersionString"];
+    NSString *version = [NSString stringWithFormat:NSLocalizedString(@"Version %@", nil), shortVersion];
+    NSDictionary *options = @{@"ApplicationVersion": version, @"Version": @""};
+
+    [self orderFrontStandardAboutPanelWithOptions:options];
 }
 
 /* Accessor getters


### PR DESCRIPTION
Replaces `-handleAbout` and `-exitVienna` with standard NSApplication methods.