### PR TITLE
Fix for filterString not being on main thread

### DIFF
--- a/src/ArticleController.m
+++ b/src/ArticleController.m
@@ -524,8 +524,9 @@
  */
 - (void)getArticlesWithCompletionBlock:(void(^)(NSArray * resultArray))completionBlock {
 	Folder * folder = [[Database sharedManager] folderFromID:currentFolderId];
+    NSString *filterString = APPCONTROLLER.filterString;
     dispatch_async(queue, ^{
-        NSArray * articleArray = [folder articlesWithFilter:APPCONTROLLER.filterString];    
+        NSArray * articleArray = [folder articlesWithFilter:filterString];
 
         // call the completion block with the result when finished
         if (completionBlock) {


### PR DESCRIPTION
Simple fix for filterString not being called on the main thread.
Found using XCode thread sanitisation.