### PR TITLE
Use FMDB git URL to fix pod install errors

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,12 +4,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'Vienna' do
 	pod 'MASPreferences', '~> 1.1.4'
 	pod 'ASIHTTPRequest', '~> 1.8', :inhibit_warnings => true
-	pod 'FMDB', '~> 2.7.2'
+	pod 'FMDB', :git => 'https://github.com/ccgus/fmdb.git', :tag => '2.7.2'
 	pod 'Sparkle', '~> 1.17.0'
 end
 
 target 'Vienna Tests' do
-	pod 'FMDB', '~> 2.7.2'
+	pod 'FMDB', :git => 'https://github.com/ccgus/fmdb.git', :tag => '2.7.2'
 	pod 'Sparkle', '~> 1.17.0'
 	pod 'OCMock'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,10 +21,20 @@ PODS:
 
 DEPENDENCIES:
   - ASIHTTPRequest (~> 1.8)
-  - FMDB (~> 2.7.2)
+  - FMDB (from `https://github.com/ccgus/fmdb.git`, tag `2.7.2`)
   - MASPreferences (~> 1.1.4)
   - OCMock
   - Sparkle (~> 1.17.0)
+
+EXTERNAL SOURCES:
+  FMDB:
+    :git: https://github.com/ccgus/fmdb.git
+    :tag: 2.7.2
+
+CHECKOUT OPTIONS:
+  FMDB:
+    :git: https://github.com/ccgus/fmdb.git
+    :tag: 2.7.2
 
 SPEC CHECKSUMS:
   ASIHTTPRequest: ec013992946676b7978dcbde6396d57312d21db4
@@ -33,6 +43,6 @@ SPEC CHECKSUMS:
   OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   Sparkle: ccfb47699feea7b40b51cf3176f69404e5b1da6c
 
-PODFILE CHECKSUM: a66f3654b17e683f6288e842cb8447c6fbf2bbd8
+PODFILE CHECKSUM: 3c541f2c9e9462ce44c66bab887f126852bd8eb5
 
 COCOAPODS: 1.2.1

--- a/Pods/Local Podspecs/FMDB.podspec.json
+++ b/Pods/Local Podspecs/FMDB.podspec.json
@@ -1,0 +1,81 @@
+{
+  "name": "FMDB",
+  "version": "2.7.2",
+  "summary": "A Cocoa / Objective-C wrapper around SQLite.",
+  "homepage": "https://github.com/ccgus/fmdb",
+  "license": "MIT",
+  "authors": {
+    "August Mueller": "gus@flyingmeat.com"
+  },
+  "source": {
+    "git": "https://github.com/ccgus/fmdb.git",
+    "tag": "2.7.2"
+  },
+  "requires_arc": true,
+  "default_subspecs": "standard",
+  "platforms": {
+    "osx": null,
+    "ios": null,
+    "tvos": null,
+    "watchos": null
+  },
+  "subspecs": [
+    {
+      "name": "standard",
+      "libraries": "sqlite3",
+      "source_files": "src/fmdb/FM*.{h,m}",
+      "exclude_files": "src/fmdb.m"
+    },
+    {
+      "name": "FTS",
+      "source_files": "src/extra/fts3/*.{h,m}",
+      "dependencies": {
+        "FMDB/standard": [
+
+        ]
+      }
+    },
+    {
+      "name": "standalone",
+      "xcconfig": {
+        "OTHER_CFLAGS": "$(inherited) -DFMDB_SQLITE_STANDALONE"
+      },
+      "dependencies": {
+        "sqlite3": [
+
+        ]
+      },
+      "source_files": "src/fmdb/FM*.{h,m}",
+      "exclude_files": "src/fmdb.m"
+    },
+    {
+      "name": "standalone-fts",
+      "xcconfig": {
+        "OTHER_CFLAGS": "$(inherited) -DFMDB_SQLITE_STANDALONE"
+      },
+      "source_files": [
+        "src/fmdb/FM*.{h,m}",
+        "src/extra/fts3/*.{h,m}"
+      ],
+      "exclude_files": "src/fmdb.m",
+      "dependencies": {
+        "sqlite3/fts": [
+
+        ]
+      }
+    },
+    {
+      "name": "SQLCipher",
+      "dependencies": {
+        "SQLCipher": [
+
+        ]
+      },
+      "source_files": "src/fmdb/FM*.{h,m}",
+      "exclude_files": "src/fmdb.m",
+      "xcconfig": {
+        "OTHER_CFLAGS": "$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1"
+      }
+    }
+  ]
+}

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -21,10 +21,20 @@ PODS:
 
 DEPENDENCIES:
   - ASIHTTPRequest (~> 1.8)
-  - FMDB (~> 2.7.2)
+  - FMDB (from `https://github.com/ccgus/fmdb.git`, tag `2.7.2`)
   - MASPreferences (~> 1.1.4)
   - OCMock
   - Sparkle (~> 1.17.0)
+
+EXTERNAL SOURCES:
+  FMDB:
+    :git: https://github.com/ccgus/fmdb.git
+    :tag: 2.7.2
+
+CHECKOUT OPTIONS:
+  FMDB:
+    :git: https://github.com/ccgus/fmdb.git
+    :tag: 2.7.2
 
 SPEC CHECKSUMS:
   ASIHTTPRequest: ec013992946676b7978dcbde6396d57312d21db4
@@ -33,6 +43,6 @@ SPEC CHECKSUMS:
   OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   Sparkle: ccfb47699feea7b40b51cf3176f69404e5b1da6c
 
-PODFILE CHECKSUM: a66f3654b17e683f6288e842cb8447c6fbf2bbd8
+PODFILE CHECKSUM: 3c541f2c9e9462ce44c66bab887f126852bd8eb5
 
 COCOAPODS: 1.2.1

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -194,9 +194,9 @@
 /* Begin PBXFileReference section */
 		01329B6798803336D0F7580D98301B99 /* MASPreferencesWindowController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MASPreferencesWindowController.m; path = Framework/MASPreferencesWindowController.m; sourceTree = "<group>"; };
 		03847BCD3E58D4B73A953903E1740D73 /* ASICloudFilesRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ASICloudFilesRequest.m; path = Classes/CloudFiles/ASICloudFilesRequest.m; sourceTree = "<group>"; };
-		07538A6EF2F8C2F7185FDA2A95B42307 /* libPods-Vienna Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Vienna Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		07538A6EF2F8C2F7185FDA2A95B42307 /* libPods-Vienna Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-Vienna Tests.a"; path = "libPods-Vienna Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		092E9FD06B1502D577C773157537DA71 /* FMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabaseAdditions.m; path = src/fmdb/FMDatabaseAdditions.m; sourceTree = "<group>"; };
-		0D5A8F827FD645F8BE6921ED826419A2 /* libMASPreferences.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMASPreferences.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D5A8F827FD645F8BE6921ED826419A2 /* libMASPreferences.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libMASPreferences.a; path = libMASPreferences.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E232973A6968FDEAA8A2341AFA022D3 /* OCMLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMLocation.m; path = Source/OCMock/OCMLocation.m; sourceTree = "<group>"; };
 		0E4A7ED34AD00B970F7B6FF5BC918772 /* OCMVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMVerifier.h; path = Source/OCMock/OCMVerifier.h; sourceTree = "<group>"; };
 		0F778B66E08044B4010D9F0451C2FF43 /* FMDB-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FMDB-dummy.m"; sourceTree = "<group>"; };
@@ -254,7 +254,7 @@
 		6A47FB445C0964D2937A6D90514095ED /* MASPreferencesViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASPreferencesViewController.h; path = Framework/MASPreferencesViewController.h; sourceTree = "<group>"; };
 		6C2EAC038A81AD18BF37C981B41DA7F7 /* FMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMDatabaseAdditions.h; path = src/fmdb/FMDatabaseAdditions.h; sourceTree = "<group>"; };
 		701E964B8ACCD46A2876495AEC6E50E0 /* FMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabasePool.m; path = src/fmdb/FMDatabasePool.m; sourceTree = "<group>"; };
-		70E96F471B741AE255937BEBBF702A78 /* libPods-Vienna.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Vienna.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		70E96F471B741AE255937BEBBF702A78 /* libPods-Vienna.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-Vienna.a"; path = "libPods-Vienna.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7155E115EE81818D5DC90CFC4A43C65A /* ASICloudFilesContainer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ASICloudFilesContainer.m; path = Classes/CloudFiles/ASICloudFilesContainer.m; sourceTree = "<group>"; };
 		71A29036F20754B747A21C9CA7B6893B /* OCProtocolMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCProtocolMockObject.h; path = Source/OCMock/OCProtocolMockObject.h; sourceTree = "<group>"; };
 		752D83549810717CFCF118BE8EA965D7 /* ASINetworkQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ASINetworkQueue.h; path = Classes/ASINetworkQueue.h; sourceTree = "<group>"; };
@@ -279,7 +279,7 @@
 		925D2777F5CFE349B9F6B73B4EE80C84 /* ASICloudFilesCDNRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ASICloudFilesCDNRequest.m; path = Classes/CloudFiles/ASICloudFilesCDNRequest.m; sourceTree = "<group>"; };
 		9301CF50E9CBE3BABF021211080702A9 /* OCClassMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCClassMockObject.h; path = Source/OCMock/OCClassMockObject.h; sourceTree = "<group>"; };
 		9364E17567149F84486A90021ACFB330 /* ASIS3Bucket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ASIS3Bucket.h; path = Classes/S3/ASIS3Bucket.h; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		94E91C6967EAEB72669694C93C63706A /* OCMStubRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMStubRecorder.m; path = Source/OCMock/OCMStubRecorder.m; sourceTree = "<group>"; };
 		959AAB99EC5CA11F7AA932424405CC92 /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Source/OCMock/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
 		98362CE93B54C7203B8B8E1C2ACB6A03 /* OCMPassByRefSetter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMPassByRefSetter.m; path = Source/OCMock/OCMPassByRefSetter.m; sourceTree = "<group>"; };
@@ -341,7 +341,7 @@
 		DFB363CCC8F535D775558677076212F6 /* OCMConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMConstraint.h; path = Source/OCMock/OCMConstraint.h; sourceTree = "<group>"; };
 		DFFCC8AFD06666403F27E6E5AA69E88D /* OCMExpectationRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExpectationRecorder.m; path = Source/OCMock/OCMExpectationRecorder.m; sourceTree = "<group>"; };
 		E168EC49E4FB23A5D8228A6FDF9A362F /* OCMBoxedReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBoxedReturnValueProvider.m; path = Source/OCMock/OCMBoxedReturnValueProvider.m; sourceTree = "<group>"; };
-		E16A4696E64CA31B2E4079C2B6883A9C /* libFMDB.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFMDB.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E16A4696E64CA31B2E4079C2B6883A9C /* libFMDB.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libFMDB.a; path = libFMDB.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E376D80A2B1ACEBA00A8A4F2D6A0D315 /* OCMVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMVerifier.m; path = Source/OCMock/OCMVerifier.m; sourceTree = "<group>"; };
 		E412330A8E018FE965D135D0AF3C6464 /* ASICloudFilesObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ASICloudFilesObject.m; path = Classes/CloudFiles/ASICloudFilesObject.m; sourceTree = "<group>"; };
 		E743E72967C6ECEEDFAE2BD878E699C4 /* OCMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMockObject.h; path = Source/OCMock/OCMockObject.h; sourceTree = "<group>"; };
@@ -363,12 +363,12 @@
 		F2D1FF338E0CF88B6F05886DE6AFCBB2 /* OCMFunctionsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctionsPrivate.h; path = Source/OCMock/OCMFunctionsPrivate.h; sourceTree = "<group>"; };
 		F3574C34A24A569A82452A2BF1ED3E6E /* FMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabaseQueue.m; path = src/fmdb/FMDatabaseQueue.m; sourceTree = "<group>"; };
 		F38DF72B393D6D78579BE28D88F5EFA5 /* OCMock-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OCMock-prefix.pch"; sourceTree = "<group>"; };
-		F4B56C64F94168F4BEE51F9AD9D39EDD /* libOCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4B56C64F94168F4BEE51F9AD9D39EDD /* libOCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libOCMock.a; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4DCD032A94E41B49F004031B45B86AC /* OCMBlockCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockCaller.h; path = Source/OCMock/OCMBlockCaller.h; sourceTree = "<group>"; };
 		F65A7A9C979415D065953E52A3E902D1 /* ASINetworkQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ASINetworkQueue.m; path = Classes/ASINetworkQueue.m; sourceTree = "<group>"; };
 		F81AE75D375F03ECE7B5BCF947E8AEF8 /* Pods-Vienna.development.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Vienna.development.xcconfig"; sourceTree = "<group>"; };
 		FA927A57F0412AF53028A0B14F0CE51B /* OCMock-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OCMock-dummy.m"; sourceTree = "<group>"; };
-		FAD7161BA585CF43DB19C695966F7D14 /* libASIHTTPRequest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libASIHTTPRequest.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAD7161BA585CF43DB19C695966F7D14 /* libASIHTTPRequest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libASIHTTPRequest.a; path = libASIHTTPRequest.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBE8856F8A2F91A912F951B99E8E9781 /* OCMArg.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArg.h; path = Source/OCMock/OCMArg.h; sourceTree = "<group>"; };
 		FC3E80C5B4A6ADF1840B897BCCA2798A /* ASIFormDataRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ASIFormDataRequest.m; path = Classes/ASIFormDataRequest.m; sourceTree = "<group>"; };
 		FCE7BBE5340BD038CB86129C34BFCA11 /* NSObject+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+OCMAdditions.h"; path = "Source/OCMock/NSObject+OCMAdditions.h"; sourceTree = "<group>"; };
@@ -504,6 +504,7 @@
 				37FD01074F5DB37AF469286F7DCF88AF /* Resources */,
 				49E6FF2479BB7B53C9E4BF5107359DA1 /* Support Files */,
 			);
+			name = MASPreferences;
 			path = MASPreferences;
 			sourceTree = "<group>";
 		};
@@ -599,6 +600,7 @@
 				27A16AD6E0FE47B8A6F42FC0FB3E924E /* OCProtocolMockObject.m */,
 				ED5EAB3AE2314115B8A5C5948B5CFA30 /* Support Files */,
 			);
+			name = OCMock;
 			path = OCMock;
 			sourceTree = "<group>";
 		};
@@ -742,6 +744,7 @@
 				575D78F1A4DA52628F229E3599FC127B /* S3 */,
 				254F49C0552D079A89FA168C396A4292 /* Support Files */,
 			);
+			name = ASIHTTPRequest;
 			path = ASIHTTPRequest;
 			sourceTree = "<group>";
 		};
@@ -778,6 +781,7 @@
 				59D0E67C6F6311265DAC9D43EE709B82 /* SUVersionDisplayProtocol.h */,
 				835B24318F6D6A2428D650A5329FCD9A /* Frameworks */,
 			);
+			name = Sparkle;
 			path = Sparkle;
 			sourceTree = "<group>";
 		};
@@ -787,6 +791,7 @@
 				A7AAD9610083E3431E97381E29C6B636 /* standard */,
 				FDB2FFD763B42B91A6DEA4E074BA4CFD /* Support Files */,
 			);
+			name = FMDB;
 			path = FMDB;
 			sourceTree = "<group>";
 		};
@@ -1028,7 +1033,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1234,9 +1239,7 @@
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_RELEASE=1",
 					"$(inherited)",
@@ -1456,11 +1459,9 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_DEBUG=1",
@@ -1786,9 +1787,7 @@
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_DEPLOYMENT=1",
 					"$(inherited)",
@@ -1958,9 +1957,7 @@
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_STATIC_ANALYZER=1",
 					"$(inherited)",
@@ -2104,10 +2101,7 @@
 				CODE_SIGNING_REQUIRED = NO;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_DEVELOPMENT=1",
 					"$(inherited)",
@@ -2119,7 +2113,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
 				PROVISIONING_PROFILE_SPECIFIER = NO_SIGNING/;
 				STRIP_INSTALLED_PRODUCT = NO;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
Specifying the github URL to version 2.7.2 of FMDB allows us to work around the cocoapods installation errors on Travis CI.
