### PR TITLE
Disabled cocoapods cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ notifications:
 
 # for container-based infrastructure
 sudo: false
-cache: cocoapods
+# cache: cocoapods


### PR DESCRIPTION
Cocoapods cache was often out of date and would produce errors when trying to run `pod install` on Travis.

`pod install` was not required to be run because we keep the cocoapods files in our git repository. Usually `pod install` is not run on Travis if there is a `Pods/` directory and `Podfile.lock` but the `cache: cocoapods` line seems to override this.
