### PR TITLE
Fix ‘Next Unread’ command (continued)

### DIFF
--- a/src/ArticleController.m
+++ b/src/ArticleController.m
@@ -408,7 +408,7 @@
 		}
 	}
 
-	if (currentFolderExhausted  && ([[Database sharedManager] countOfUnread] > 1 || currentArticle.read) )
+	if (currentFolderExhausted  && ([[Database sharedManager] countOfUnread] > 1 || currentArticle == nil || currentArticle.read) )
 	{
 		// try other folders
 		NSInteger nextFolderWithUnread = [self.foldersTree nextFolderWithUnread:currentFolderId];


### PR DESCRIPTION
Handle when current folder does not contain any unread article and
no article is selected.