### PR TITLE
Remove ArticleController and FoldersTree from Interface Builder

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="17A291m" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
@@ -20,8 +20,8 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="302" y="347" width="942" height="625"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1080"/>
-            <value key="minSize" type="size" width="213" height="107"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>
+            <value key="minSize" type="size" width="700" height="350"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="942" height="625"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1170,7 +1170,7 @@ CA
         </menu>
         <customObject id="233" userLabel="AppController" customClass="AppController">
             <connections>
-                <outlet property="articleController" destination="1164" id="1165"/>
+                <outlet property="articleController" destination="1164" id="4Nq-qN-LcY"/>
                 <outlet property="browserView" destination="1227" id="1231"/>
                 <outlet property="closeAllTabsItem" destination="1036" id="1038"/>
                 <outlet property="closeTabItem" destination="1023" id="1035"/>

--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -1170,7 +1170,7 @@ CA
         </menu>
         <customObject id="233" userLabel="AppController" customClass="AppController">
             <connections>
-                <outlet property="articleController" destination="1164" id="4Nq-qN-LcY"/>
+                <outlet property="articleListView" destination="971" id="zOq-cv-uLu"/>
                 <outlet property="browserView" destination="1227" id="1231"/>
                 <outlet property="closeAllTabsItem" destination="1036" id="1038"/>
                 <outlet property="closeTabItem" destination="1023" id="1035"/>
@@ -1194,6 +1194,7 @@ CA
                 <outlet property="statusBarDisclosureView" destination="659-iz-w4S" id="gjn-93-Mdy"/>
                 <outlet property="statusText" destination="917" id="919"/>
                 <outlet property="stylesMenu" destination="826" id="1051"/>
+                <outlet property="unifiedListView" destination="1148" id="O5e-id-8Cu"/>
             </connections>
         </customObject>
         <customView id="860" userLabel="ExportSaveAccessory">
@@ -1301,7 +1302,6 @@ CA
                 <constraint firstAttribute="bottom" secondItem="972" secondAttribute="bottom" id="vXN-hg-P2Z"/>
             </constraints>
             <connections>
-                <outlet property="articleController" destination="1164" id="1167"/>
                 <outlet property="articleList" destination="977" id="996"/>
                 <outlet property="articleText" destination="1DK-2K-uuy" id="ggQ-XF-qtz"/>
                 <outlet property="controller" destination="233" id="1169"/>
@@ -1356,19 +1356,11 @@ CA
                 </scrollView>
             </subviews>
             <connections>
-                <outlet property="articleController" destination="1164" id="1168"/>
                 <outlet property="articleList" destination="NgO-hM-mCz" id="x5w-1V-UjV"/>
                 <outlet property="controller" destination="233" id="1170"/>
             </connections>
             <point key="canvasLocation" x="1066" y="109"/>
         </customView>
-        <customObject id="1164" userLabel="ArticleController" customClass="ArticleController">
-            <connections>
-                <outlet property="articleListView" destination="971" id="CtF-Wy-tWn"/>
-                <outlet property="foldersTree" destination="ugm-kC-yFY" id="sgV-i3-mJ1"/>
-                <outlet property="unifiedListView" destination="1148" id="BZB-bx-zs0"/>
-            </connections>
-        </customObject>
         <customObject id="1175" userLabel="SUUpdater" customClass="SUUpdater"/>
         <customView id="1227" userLabel="BrowserView" customClass="BrowserView">
             <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>

--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -96,10 +96,6 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                         </tableColumn>
                                                     </tableColumns>
-                                                    <connections>
-                                                        <outlet property="dataSource" destination="ugm-kC-yFY" id="ufn-bW-ljC"/>
-                                                        <outlet property="delegate" destination="ugm-kC-yFY" id="JKg-Jf-3i7"/>
-                                                    </connections>
                                                 </outlineView>
                                             </subviews>
                                             <nil key="backgroundColor"/>
@@ -1186,8 +1182,8 @@ CA
                 <outlet property="filterSearchField" destination="1304" id="1315"/>
                 <outlet property="filterViewPopUp" destination="1306" id="1319"/>
                 <outlet property="filtersMenu" destination="1117" id="1135"/>
-                <outlet property="foldersTree" destination="ugm-kC-yFY" id="lcl-Mo-hfE"/>
                 <outlet property="mainWindow" destination="21" id="239"/>
+                <outlet property="outlineView" destination="Kk7-ax-B3r" id="vFt-XT-QbW"/>
                 <outlet property="searchField" destination="1252" id="1253"/>
                 <outlet property="sortByMenu" destination="387" id="1054"/>
                 <outlet property="spinner" destination="918" id="920"/>
@@ -1471,12 +1467,6 @@ CA
             </connections>
             <point key="canvasLocation" x="-209" y="43"/>
         </customView>
-        <customObject id="ugm-kC-yFY" customClass="FoldersTree">
-            <connections>
-                <outlet property="controller" destination="233" id="FRY-S5-mjJ"/>
-                <outlet property="outlineView" destination="Kk7-ax-B3r" id="O2z-Mf-33v"/>
-            </connections>
-        </customObject>
     </objects>
     <resources>
         <image name="filter-icon" width="16" height="16"/>

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -43,6 +43,8 @@
 @class ArticleController;
 @class DownloadWindow;
 @class Article;
+@class UnifiedDisplayView;
+@class ArticleListView;
 
 @interface AppController : NSObject <NSApplicationDelegate,NSWindowDelegate,NSToolbarDelegate,NSMenuDelegate>
 {
@@ -93,7 +95,9 @@
     ViennaSparkleDelegate * _sparkleDelegate;
 }
 
-@property (nonatomic) IBOutlet ArticleController *articleController;
+@property (nonatomic) ArticleController *articleController;
+@property (nonatomic, weak) IBOutlet UnifiedDisplayView *unifiedListView;
+@property (nonatomic, weak) IBOutlet ArticleListView *articleListView;
 @property (nonatomic, strong) NewSubscription *rssFeed;
 @property (readonly, weak) FoldersTree *foldersTree;
 @property (readonly, copy, nonatomic) NSMenu *searchFieldMenu;

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -99,7 +99,7 @@
 @property (nonatomic, weak) IBOutlet UnifiedDisplayView *unifiedListView;
 @property (nonatomic, weak) IBOutlet ArticleListView *articleListView;
 @property (nonatomic, strong) NewSubscription *rssFeed;
-@property (readonly, weak) FoldersTree *foldersTree;
+@property (nonatomic) FoldersTree *foldersTree;
 @property (readonly, copy, nonatomic) NSMenu *searchFieldMenu;
 
 // Menu action items

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -47,7 +47,6 @@
 @interface AppController : NSObject <NSApplicationDelegate,NSWindowDelegate,NSToolbarDelegate,NSMenuDelegate>
 {
 	IBOutlet BJRWindowWithToolbar * mainWindow;
-	IBOutlet ArticleController * articleController;
 	IBOutlet NSView * exportSaveAccessory;
 	IBOutlet NSSearchField * filterSearchField;
 	IBOutlet NSPopUpButton * filterViewPopUp;
@@ -94,6 +93,7 @@
     ViennaSparkleDelegate * _sparkleDelegate;
 }
 
+@property (nonatomic) IBOutlet ArticleController *articleController;
 @property (nonatomic, strong) NewSubscription *rssFeed;
 @property (readonly, weak) FoldersTree *foldersTree;
 @property (readonly, copy, nonatomic) NSMenu *searchFieldMenu;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -155,24 +155,6 @@ static void MySleepCallBack(void * x, io_service_t y, natural_t messageType, voi
  */
 -(void)awakeFromNib
 {
-	Preferences * prefs = [Preferences standardPreferences];
-    
-    self.articleController.foldersTree = self.foldersTree;
-    self.articleController.unifiedListView = self.unifiedListView;
-    self.articleController.articleListView = self.articleListView;
-
-	// Restore the most recent layout
-	[self setLayout:prefs.layout withRefresh:NO];
-	
-	// Set the delegates and title
-	mainWindow.title = self.appName;
-	[NSApplication sharedApplication].delegate = self;
-	mainWindow.minSize = NSMakeSize(MA_Default_Main_Window_Min_Width, MA_Default_Main_Window_Min_Height);
-	
-	// Initialise the plugin manager now that the UI is ready
-	pluginManager = [[PluginManager alloc] init];
-	[pluginManager resetPlugins];
-	
     // We need to register the handlers early to catch events fired on launch.
     NSAppleEventManager *em = [NSAppleEventManager sharedAppleEventManager];
     [em setEventHandler:self
@@ -365,8 +347,23 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
  */
 -(void)applicationDidFinishLaunching:(NSNotification *)aNot
 {
-	
-	Preferences * prefs = [Preferences standardPreferences];
+    Preferences * prefs = [Preferences standardPreferences];
+
+    self.articleController.foldersTree = self.foldersTree;
+    self.articleController.unifiedListView = self.unifiedListView;
+    self.articleController.articleListView = self.articleListView;
+
+    // Restore the most recent layout
+    [self setLayout:prefs.layout withRefresh:NO];
+
+    // Set the delegates and title
+    mainWindow.title = self.appName;
+    [NSApplication sharedApplication].delegate = self;
+    mainWindow.minSize = NSMakeSize(MA_Default_Main_Window_Min_Width, MA_Default_Main_Window_Min_Height);
+
+    // Initialise the plugin manager now that the UI is ready
+    pluginManager = [[PluginManager alloc] init];
+    [pluginManager resetPlugins];
 	
 	// Register a bunch of notifications
 	NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -226,7 +226,7 @@ static void MySleepCallBack(void * x, io_service_t y, natural_t messageType, voi
 		NSString * previousArticleGuid = [prefs stringForKey:MAPref_CachedArticleGUID];
 		if (previousArticleGuid.blank)
 			previousArticleGuid = nil;
-		[articleController selectFolderAndArticle:previousFolderId guid:previousArticleGuid];
+		[self.articleController selectFolderAndArticle:previousFolderId guid:previousArticleGuid];
 
 		[mainWindow makeFirstResponder:(previousArticleGuid != nil) ? [browserView primaryTabItemView].mainView : self.foldersTree.mainView];
 
@@ -596,7 +596,7 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
 		[browserView saveOpenTabs];
 		
 		// Remember the article list column position, sizes, etc.
-		[articleController saveTableSettings];
+		[self.articleController saveTableSettings];
 		[self.foldersTree saveFolderSettings];
 		
 		// Finally save preferences
@@ -853,10 +853,11 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
  */
 -(void)setLayout:(NSInteger)newLayout withRefresh:(BOOL)refreshFlag
 {
-	[articleController setLayout:newLayout];
-    if (refreshFlag)
-        [articleController.mainArticleView refreshFolder:MA_Refresh_RedrawList];
-	[browserView setPrimaryTabItemView:articleController.mainArticleView];
+	[self.articleController setLayout:newLayout];
+    if (refreshFlag) {
+        [self.articleController.mainArticleView refreshFolder:MA_Refresh_RedrawList];
+    }
+	[browserView setPrimaryTabItemView:self.articleController.mainArticleView];
 	self.foldersTree.mainView.nextKeyView = [browserView primaryTabItemView].mainView;
     if (self.selectedArticle == nil)
         [mainWindow makeFirstResponder:self.foldersTree.mainView];
@@ -1193,7 +1194,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)downloadEnclosure:(id)sender
 {
-	for (Article * currentArticle in articleController.markedArticleRange)
+	for (Article * currentArticle in self.articleController.markedArticleRange)
 	{
 		if (currentArticle.hasEnclosure)
 		{
@@ -1771,7 +1772,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(Article *)selectedArticle
 {
-	return articleController.selectedArticle;
+	return self.articleController.selectedArticle;
 }
 
 /* currentFolderId
@@ -1780,7 +1781,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(NSInteger)currentFolderId
 {
-	return articleController.currentFolderId;
+	return self.articleController.currentFolderId;
 }
 
 /* selectFolder
@@ -1931,7 +1932,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	self.filterString = @"";
 	
 	// Call through the controller to display the new folder.
-	[articleController displayFolder:newFolderId];
+	[self.articleController displayFolder:newFolderId];
 	[self updateSearchPlaceholderAndSearchMethod];
 	
 	// Make sure article viewer is active
@@ -1965,7 +1966,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	[self updateAlternateMenuTitle];
 	[self.foldersTree updateAlternateMenuTitle];
-	[articleController updateAlternateMenuTitle];
+	[self.articleController updateAlternateMenuTitle];
 	[self updateNewArticlesNotification];
 }
 
@@ -2014,8 +2015,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Field * field = menuItem.representedObject;
 	
 	field.visible = !field.visible;
-	[articleController updateVisibleColumns];
-	[articleController saveTableSettings];
+	[self.articleController updateVisibleColumns];
+	[self.articleController saveTableSettings];
 }
 
 /* doSortColumn
@@ -2027,7 +2028,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Field * field = menuItem.representedObject;
 	
 	NSAssert1(field, @"Somehow got a nil representedObject for Sort column sub-menu item '%@'", [menuItem title]);
-	[articleController sortByIdentifier:field.name];
+	[self.articleController sortByIdentifier:field.name];
 }
 
 /* doSortDirection
@@ -2040,7 +2041,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	NSAssert1(ascendingNumber, @"Somehow got a nil representedObject for Sort direction sub-menu item '%@'", [menuItem title]);
 	BOOL ascending = ascendingNumber.boolValue;
-	[articleController sortAscending:ascending];
+	[self.articleController sortAscending:ascending];
 }
 
 /* doOpenScriptsFolder
@@ -2108,7 +2109,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)handleFolderNameChange:(NSNotification *)nc
 {
 	NSInteger folderId = ((NSNumber *)nc.object).integerValue;
-	if (folderId == articleController.currentFolderId)
+	if (folderId == self.articleController.currentFolderId)
 		[self updateSearchPlaceholderAndSearchMethod];
 }
 
@@ -2198,7 +2199,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)viewArticlePages:(id)sender inPreferredBrowser:(BOOL)usePreferredBrowser
 {
-	NSArray * articleArray = articleController.markedArticleRange;
+	NSArray * articleArray = self.articleController.markedArticleRange;
 	Article * currentArticle;
 	
 	if (articleArray.count > 0) 
@@ -2223,7 +2224,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[self openURLs:urls inPreferredBrowser:usePreferredBrowser];
 
         if (([Preferences standardPreferences].markReadInterval > 0.0f) && !db.readOnly) {
-            [articleController markReadByArray:articlesWithLinks readFlag:YES];
+            [self.articleController markReadByArray:articlesWithLinks readFlag:YES];
         }
 	}
 }
@@ -2327,7 +2328,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 				{
 					[browserView setActiveTabToPrimaryTab];
 					if (self.selectedArticle == nil)
-						[articleController ensureSelectedArticle:NO];
+						[self.articleController ensureSelectedArticle:NO];
 					[mainWindow makeFirstResponder:(self.selectedArticle != nil) ? [browserView primaryTabItemView].mainView : self.foldersTree.mainView];
 					return YES;
 				}
@@ -2341,7 +2342,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 				[self deleteFolder:self];
 				return YES;
 			}
-			else if (mainWindow.firstResponder == (articleController.mainArticleView).mainView)
+			else if (mainWindow.firstResponder == (self.articleController.mainArticleView).mainView)
 			{
 				[self deleteMessage:self];
 				return YES;
@@ -2510,8 +2511,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)markSelectedFoldersRead:(NSArray *)arrayOfFolders
 {
-	if (!db.readOnly)
-		[articleController markAllReadByArray:arrayOfFolders withUndo:YES withRefresh:YES];
+    if (!db.readOnly) {
+		[self.articleController markAllReadByArray:arrayOfFolders withUndo:YES withRefresh:YES];
+    }
 }
 
 /* createNewGoogleReaderSubscription
@@ -2633,11 +2635,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)restoreMessage:(id)sender
 {
-	Folder * folder = [db folderFromID:articleController.currentFolderId];
+	Folder * folder = [db folderFromID:self.articleController.currentFolderId];
 	if (folder.type == VNAFolderTypeTrash && self.selectedArticle != nil && !db.readOnly)
 	{
-		NSArray * articleArray = articleController.markedArticleRange;
-		[articleController markDeletedByArray:articleArray deleteFlag:NO];
+		NSArray * articleArray = self.articleController.markedArticleRange;
+		[self.articleController markDeletedByArray:articleArray deleteFlag:NO];
 		[self clearUndoStack];
 	}
 }
@@ -2650,10 +2652,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	if (self.selectedArticle != nil && !db.readOnly)
 	{
-		Folder * folder = [db folderFromID:articleController.currentFolderId];
+		Folder * folder = [db folderFromID:self.articleController.currentFolderId];
 		if (folder.type != VNAFolderTypeTrash) {
-			NSArray * articleArray = articleController.markedArticleRange;
-			[articleController markDeletedByArray:articleArray deleteFlag:YES];
+			NSArray * articleArray = self.articleController.markedArticleRange;
+			[self.articleController markDeletedByArray:articleArray deleteFlag:YES];
 		} else {
             NSAlert *alert = [NSAlert new];
             alert.messageText = NSLocalizedString(@"Delete selected message", nil);
@@ -2662,8 +2664,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
             [alert addButtonWithTitle:NSLocalizedString(@"Cancel", "Title of a button on an alert")];
             [alert beginSheetModalForWindow:mainWindow completionHandler:^(NSModalResponse returnCode) {
                 if (returnCode == NSAlertFirstButtonReturn) {
-                    NSArray *articleArray = articleController.markedArticleRange;
-                    [articleController deleteArticlesByArray:articleArray];
+                    NSArray *articleArray = self.articleController.markedArticleRange;
+                    [self.articleController deleteArticlesByArray:articleArray];
 
                     // Blow away the undo stack here since undo actions may refer to
                     // articles that have been deleted. This is a bit of a cop-out but
@@ -2703,7 +2705,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	[browserView setActiveTabToPrimaryTab];
 	if (db.countOfUnread > 0)
-		[articleController displayFirstUnread];
+		[self.articleController displayFirstUnread];
 	[mainWindow makeFirstResponder:(self.selectedArticle != nil) ? [browserView primaryTabItemView].mainView : self.foldersTree.mainView];
 }
 
@@ -2714,7 +2716,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	[browserView setActiveTabToPrimaryTab];
 	if (db.countOfUnread > 0)
-		[articleController displayNextUnread];
+		[self.articleController displayNextUnread];
 	[mainWindow makeFirstResponder:(self.selectedArticle != nil) ? [browserView primaryTabItemView].mainView : self.foldersTree.mainView];
 }
 
@@ -2735,10 +2737,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	if (!db.readOnly)
 	{
-		[articleController markAllReadByArray:self.foldersTree.selectedFolders withUndo:YES withRefresh:YES];
-		NSInteger nextFolderInTree = [self.foldersTree nextFolderWithUnread:articleController.currentFolderId];
+		[self.articleController markAllReadByArray:self.foldersTree.selectedFolders withUndo:YES withRefresh:YES];
+		NSInteger nextFolderInTree = [self.foldersTree nextFolderWithUnread:self.articleController.currentFolderId];
 		[self.foldersTree selectFolder:nextFolderInTree];
-        [articleController ensureSelectedArticle:NO];
+        [self.articleController ensureSelectedArticle:NO];
 	}
 }
 
@@ -2749,8 +2751,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)markAllRead:(id)sender
 {
-	if (!db.readOnly)
-		[articleController markAllReadByArray:self.foldersTree.selectedFolders withUndo:YES withRefresh:YES];
+    if (!db.readOnly) {
+		[self.articleController markAllReadByArray:self.foldersTree.selectedFolders withUndo:YES withRefresh:YES];
+    }
 }
 
 /* markAllSubscriptionsRead
@@ -2760,7 +2763,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	if (!db.readOnly)
 	{
-		[articleController markAllReadByArray:[self.foldersTree folders:0] withUndo:YES withRefresh:YES];
+		[self.articleController markAllReadByArray:[self.foldersTree folders:0] withUndo:YES withRefresh:YES];
 	}
 }
 
@@ -2772,8 +2775,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Article * theArticle = self.selectedArticle;
 	if (theArticle != nil && !db.readOnly)
 	{
-		NSArray * articleArray = articleController.markedArticleRange;
-		[articleController markReadByArray:articleArray readFlag:!theArticle.read];
+		NSArray * articleArray = self.articleController.markedArticleRange;
+		[self.articleController markReadByArray:articleArray readFlag:!theArticle.read];
 	}
 }
 
@@ -2785,8 +2788,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Article * theArticle = self.selectedArticle;
 	if (theArticle != nil && !db.readOnly)
 	{
-		NSArray * articleArray = articleController.markedArticleRange;
-		[articleController markReadByArray:articleArray readFlag:YES];
+		NSArray * articleArray = self.articleController.markedArticleRange;
+		[self.articleController markReadByArray:articleArray readFlag:YES];
 	}
 }
 
@@ -2798,8 +2801,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Article * theArticle = self.selectedArticle;
 	if (theArticle != nil && !db.readOnly)
 	{
-		NSArray * articleArray = articleController.markedArticleRange;
-		[articleController markReadByArray:articleArray readFlag:NO];
+		NSArray * articleArray = self.articleController.markedArticleRange;
+		[self.articleController markReadByArray:articleArray readFlag:NO];
 	}
 }
 
@@ -2811,8 +2814,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Article * theArticle = self.selectedArticle;
 	if (theArticle != nil && !db.readOnly)
 	{
-		NSArray * articleArray = articleController.markedArticleRange;
-		[articleController markFlaggedByArray:articleArray flagged:!theArticle.flagged];
+		NSArray * articleArray = self.articleController.markedArticleRange;
+		[self.articleController markFlaggedByArray:articleArray flagged:!theArticle.flagged];
 	}
 }
 
@@ -2908,7 +2911,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		// and there's more than one folder being deleted, we delete the folder currently
 		// being displayed last so that the MA_Notify_FolderDeleted handlers that only
 		// refresh the display if the current folder is being deleted only trips once.
-		if (folder.itemId == articleController.currentFolderId && index < count - 1)
+		if (folder.itemId == self.articleController.currentFolderId && index < count - 1)
 		{
 			[selectedFolders insertObject:folder atIndex:count];
 			++count;
@@ -3201,12 +3204,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	if ([Preferences standardPreferences].layout == MA_Layout_Unified)
 	{
 		[filterSearchField.cell setSendsWholeSearchString:YES];
-		((NSSearchFieldCell *)filterSearchField.cell).placeholderString = articleController.searchPlaceholderString;
+		((NSSearchFieldCell *)filterSearchField.cell).placeholderString = self.articleController.searchPlaceholderString;
 	}
 	else
 	{
 		[filterSearchField.cell setSendsWholeSearchString:NO];
-		((NSSearchFieldCell *)filterSearchField.cell).placeholderString = articleController.searchPlaceholderString;
+		((NSSearchFieldCell *)filterSearchField.cell).placeholderString = self.articleController.searchPlaceholderString;
 	}
 }
 
@@ -3327,10 +3330,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	if (!theSearchString.blank)
 	{
 		[db setSearchString:theSearchString];
-		if (self.foldersTree.actualSelection != db.searchFolderId)
+        if (self.foldersTree.actualSelection != db.searchFolderId) {
 			[self.foldersTree selectFolder:db.searchFolderId];
-		else
-			[articleController reloadArrayOfArticles];
+        } else {
+			[self.articleController reloadArrayOfArticles];
+        }
 	}
 }
 
@@ -3342,8 +3346,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)refreshAllFolderIcons:(id)sender
 {
 	LOG_EXPR([self.foldersTree folders:0]);
-	if (!self.connecting)
+    if (!self.connecting) {
 		[[RefreshManager sharedManager] refreshFolderIconCacheForSubscriptions:[self.foldersTree folders:0]];
+    }
 }
 
 /* refreshAllSubscriptions
@@ -3424,7 +3429,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	else
 	{
 		// ... otherwise, iterate over the currently selected articles.
-		NSArray * articleArray = articleController.markedArticleRange;
+		NSArray * articleArray = self.articleController.markedArticleRange;
 		if (articleArray.count > 0) 
 		{
 			if (articleArray.count == 1)
@@ -3500,13 +3505,13 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	// If the active tab is a web view, blog the URL
 	NSView<BaseView> * theView = browserView.activeTabItemView;
-	if ([theView isKindOfClass:[BrowserPane class]])
+    if ([theView isKindOfClass:[BrowserPane class]]) {
 		[self sendBlogEvent:externalEditorBundleIdentifier title:[browserView tabItemViewTitle:browserView.activeTabItemView] url:theView.viewLink body:APP.currentTextSelection author:@"" guid:@""];
-	else
-	{
+    } else {
 		// Get the currently selected articles from the ArticleView and iterate over them.
-		for (Article * currentArticle in articleController.markedArticleRange)
+        for (Article * currentArticle in self.articleController.markedArticleRange) {
 			[self sendBlogEvent:externalEditorBundleIdentifier title:currentArticle.title url:currentArticle.link body:APP.currentTextSelection author:currentArticle.author guid:currentArticle.guid];
+        }
 	}
 }
 
@@ -3741,7 +3746,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	SEL	theAction = menuItem.action;
 	BOOL isMainWindowVisible = mainWindow.visible;
 	BOOL isAnyArticleView = browserView.activeTabItemView == [browserView primaryTabItemView];
-	BOOL isArticleView = browserView.activeTabItemView == articleController.mainArticleView;
+	BOOL isArticleView = browserView.activeTabItemView == self.articleController.mainArticleView;
 	BOOL flag;
 	
 	if ([self validateCommonToolbarAndMenuItems:theAction validateFlag:&flag])
@@ -3809,20 +3814,22 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	else if (theAction == @selector(doSortColumn:))
 	{
 		Field * field = menuItem.representedObject;
-		if ([field.name isEqualToString:articleController.sortColumnIdentifier])
+        if ([field.name isEqualToString:self.articleController.sortColumnIdentifier]) {
 			menuItem.state = NSOnState;
-		else
+        } else {
 			menuItem.state = NSOffState;
+        }
 		return isMainWindowVisible && isAnyArticleView;
 	}
 	else if (theAction == @selector(doSortDirection:))
 	{
 		NSNumber * ascendingNumber = menuItem.representedObject;
 		BOOL ascending = ascendingNumber.integerValue;
-		if (ascending == articleController.sortIsAscending)
+        if (ascending == self.articleController.sortIsAscending) {
 			menuItem.state = NSOnState;
-		else
+        } else {
 			menuItem.state = NSOffState;
+        }
 		return isMainWindowVisible && isAnyArticleView;
 	}
 	else if (theAction == @selector(unsubscribeFeed:))
@@ -4014,18 +4021,20 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	}
 	else if (theAction == @selector(mailLinkToArticlePage:))
 	{
-		if (articleController.markedArticleRange.count > 1)
+        if (self.articleController.markedArticleRange.count > 1) {
 			[menuItem setTitle:NSLocalizedString(@"Send Links", nil)];
-		else
+        } else {
 			[menuItem setTitle:NSLocalizedString(@"Send Link", nil)];
+        }
 		return flag;
 	}
 	else if (theAction == @selector(downloadEnclosure:))
 	{
-		if (articleController.markedArticleRange.count > 1)
+        if (self.articleController.markedArticleRange.count > 1) {
 			[menuItem setTitle:NSLocalizedString(@"Download Enclosures", nil)];
-		else
+        } else {
 			[menuItem setTitle:NSLocalizedString(@"Download Enclosure", nil)];
+        }
 		return (self.selectedArticle.hasEnclosure && isMainWindowVisible);
 	}
 	else if (theAction == @selector(newTab:))

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -157,6 +157,7 @@ static void MySleepCallBack(void * x, io_service_t y, natural_t messageType, voi
 {
 	Preferences * prefs = [Preferences standardPreferences];
     
+    self.articleController.foldersTree = self.foldersTree;
     self.articleController.unifiedListView = self.unifiedListView;
     self.articleController.articleListView = self.articleListView;
 

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -65,7 +65,7 @@
 #import "ArticleListView.h"
 #import "UnifiedDisplayView.h"
 #import "ArticleView.h"
-
+#import "FolderView.h"
 #import "Vienna-Swift.h"
 
 @interface AppController () <InfoPanelControllerDelegate, ActivityPanelControllerDelegate>
@@ -114,7 +114,7 @@
 @property (nonatomic) IBOutlet ActivityPanelController *activityPanelController;
 @property (nonatomic) DirectoryMonitor *directoryMonitor;
 @property (nonatomic) PreferencesWindowController *preferencesWindowController;
-@property (weak, nonatomic) IBOutlet FoldersTree *foldersTree;
+@property (weak, nonatomic) IBOutlet FolderView *outlineView;
 
 @end
 
@@ -348,6 +348,11 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
 -(void)applicationDidFinishLaunching:(NSNotification *)aNot
 {
     Preferences * prefs = [Preferences standardPreferences];
+
+    self.foldersTree.controller = self;
+    self.foldersTree.outlineView = self.outlineView;
+    self.outlineView.delegate = self.foldersTree;
+    self.outlineView.dataSource = self.foldersTree;
 
     self.articleController.foldersTree = self.foldersTree;
     self.articleController.unifiedListView = self.unifiedListView;
@@ -4303,6 +4308,13 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     return _articleController;
 }
 
+// MARK: Folders Tree
+- (FoldersTree *)foldersTree {
+    if (!_foldersTree) {
+        _foldersTree = [FoldersTree new];
+    }
+    return _foldersTree;
+}
 
 #pragma mark Dealloc
 

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -63,6 +63,7 @@
 #import "Folder.h"
 #import "BrowserView.h"
 #import "ArticleListView.h"
+#import "UnifiedDisplayView.h"
 #import "ArticleView.h"
 
 #import "Vienna-Swift.h"
@@ -155,6 +156,9 @@ static void MySleepCallBack(void * x, io_service_t y, natural_t messageType, voi
 -(void)awakeFromNib
 {
 	Preferences * prefs = [Preferences standardPreferences];
+    
+    self.articleController.unifiedListView = self.unifiedListView;
+    self.articleController.articleListView = self.articleListView;
 
 	// Restore the most recent layout
 	[self setLayout:prefs.layout withRefresh:NO];
@@ -485,7 +489,9 @@ static void MySleepCallBack(void * refCon, io_service_t service, natural_t messa
     if([[NSUserDefaults standardUserDefaults] objectForKey:MAPref_SendSystemProfileInfo] == nil) {
         [_sparkleDelegate showSystemProfileInfoAlert];
     }
-
+    
+    
+    
 	// Do safe initialisation.
 	[self performSelector:@selector(doSafeInitialisation)
 			   withObject:nil
@@ -4290,6 +4296,15 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 - (void)activityPanelControllerDidSelectFolder:(Folder *)folder {
     [self selectFolder:folder.itemId];
 }
+
+// MARK: article controller
+- (ArticleController *)articleController {
+    if (!_articleController) {
+        _articleController = [[ArticleController alloc] init];
+    }
+    return _articleController;
+}
+
 
 #pragma mark Dealloc
 

--- a/src/ArticleController.h
+++ b/src/ArticleController.h
@@ -39,8 +39,6 @@
  */
 @interface ArticleController : NSObject
 {
-	IBOutlet ArticleListView * articleListView;
-	IBOutlet UnifiedDisplayView * unifiedListView;
 	NSView<ArticleBaseView, BaseView> * mainArticleView;
 	NSArray * currentArrayOfArticles;
 	NSArray * folderArrayOfArticles;
@@ -58,6 +56,8 @@
 }
 
 @property (nonatomic, strong) IBOutlet FoldersTree * foldersTree;
+@property (nonatomic, weak) IBOutlet ArticleListView *articleListView;
+@property (nonatomic, weak) IBOutlet UnifiedDisplayView *unifiedListView;
 @property (nonatomic, strong) NSView<ArticleBaseView, BaseView> * mainArticleView;
 @property (nonatomic, copy) NSArray * currentArrayOfArticles;
 @property (nonatomic, copy) NSArray * folderArrayOfArticles;

--- a/src/ArticleController.h
+++ b/src/ArticleController.h
@@ -56,8 +56,8 @@
 }
 
 @property (nonatomic, strong) IBOutlet FoldersTree * foldersTree;
-@property (nonatomic, weak) IBOutlet ArticleListView *articleListView;
-@property (nonatomic, weak) IBOutlet UnifiedDisplayView *unifiedListView;
+@property (nonatomic, strong) IBOutlet ArticleListView *articleListView;
+@property (nonatomic, strong) IBOutlet UnifiedDisplayView *unifiedListView;
 @property (nonatomic, strong) NSView<ArticleBaseView, BaseView> * mainArticleView;
 @property (nonatomic, copy) NSArray * currentArrayOfArticles;
 @property (nonatomic, copy) NSArray * folderArrayOfArticles;

--- a/src/ArticleController.h
+++ b/src/ArticleController.h
@@ -55,9 +55,9 @@
 	BOOL requireSelectArticleAfterReload;
 }
 
-@property (nonatomic, strong) IBOutlet FoldersTree * foldersTree;
-@property (nonatomic, strong) IBOutlet ArticleListView *articleListView;
-@property (nonatomic, strong) IBOutlet UnifiedDisplayView *unifiedListView;
+@property (nonatomic, strong) FoldersTree * foldersTree;
+@property (nonatomic, strong) ArticleListView *articleListView;
+@property (nonatomic, strong) UnifiedDisplayView *unifiedListView;
 @property (nonatomic, strong) NSView<ArticleBaseView, BaseView> * mainArticleView;
 @property (nonatomic, copy) NSArray * currentArrayOfArticles;
 @property (nonatomic, copy) NSArray * folderArrayOfArticles;

--- a/src/ArticleController.m
+++ b/src/ArticleController.m
@@ -150,11 +150,11 @@
 	{
 		case MA_Layout_Report:
 		case MA_Layout_Condensed:
-			self.mainArticleView = articleListView;
+			self.mainArticleView = self.articleListView;
 			break;
 
 		case MA_Layout_Unified:
-			self.mainArticleView = unifiedListView;
+			self.mainArticleView = self.unifiedListView;
 			break;
 	}
 
@@ -198,13 +198,13 @@
  */
  -(void)updateAlternateMenuTitle
 {
-	if (mainArticleView ==  articleListView)
+	if (mainArticleView ==  self.articleListView)
 	{
-		[articleListView updateAlternateMenuTitle];
+		[self.articleListView updateAlternateMenuTitle];
 	}
 	else
 	{
-		[unifiedListView updateAlternateMenuTitle];
+		[self.unifiedListView updateAlternateMenuTitle];
 	}
 }
 
@@ -213,8 +213,9 @@
  */
 -(void)updateVisibleColumns
 {
-    if (mainArticleView ==  articleListView)
-        [articleListView updateVisibleColumns];
+    if (mainArticleView ==  self.articleListView) {
+        [self.articleListView updateVisibleColumns];
+    }
 }
 
 /* selectedArticle

--- a/src/ArticleListView.h
+++ b/src/ArticleListView.h
@@ -25,7 +25,6 @@
 #import "ArticleBaseView.h"
 
 @class AppController;
-@class ArticleController;
 @class ArticleView;
 @class MessageListView;
 @class StdEnclosureView;
@@ -33,7 +32,6 @@
 @interface ArticleListView : NSView<BaseView, ArticleBaseView, NSTableViewDelegate, NSTableViewDataSource, WebUIDelegate, WebFrameLoadDelegate>
 {
 	IBOutlet AppController * controller;
-	IBOutlet ArticleController * articleController;
 	IBOutlet MessageListView * articleList;
 	IBOutlet ArticleView * articleText;
 	IBOutlet NSSplitView * splitView2;

--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -349,7 +349,7 @@
 {
 	NSInteger row = articleList.clickedRow;
 	NSInteger column = articleList.clickedColumn;
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	
 	if (row >= 0 && row < (NSInteger)allArticles.count)
 	{
@@ -360,12 +360,12 @@
 			NSString * columnName = ((NSTableColumn *)columns[column]).identifier;
 			if ([columnName isEqualToString:MA_Field_Read])
 			{
-				[articleController markReadByArray:@[theArticle] readFlag:!theArticle.read];
+				[controller.articleController markReadByArray:@[theArticle] readFlag:!theArticle.read];
 				return;
 			}
 			if ([columnName isEqualToString:MA_Field_Flagged])
 			{
-				[articleController markFlaggedByArray:@[theArticle] flagged:!theArticle.flagged];
+				[controller.articleController markFlaggedByArray:@[theArticle] flagged:!theArticle.flagged];
 				return;
 			}
 			if ([columnName isEqualToString:MA_Field_HasEnclosure])
@@ -385,7 +385,7 @@
 {
 	if (currentSelectedRow != -1 && articleList.clickedRow != -1)
 	{
-		Article * theArticle = articleController.allArticles[currentSelectedRow];
+		Article * theArticle = controller.articleController.allArticles[currentSelectedRow];
 		[controller openURLFromString:theArticle.link inPreferredBrowser:YES];
 	}
 }
@@ -432,7 +432,7 @@
 	if (singleSelection)
 	{
 		NSUInteger nextRow = articleList.selectedRowIndexes.firstIndex;
-		NSUInteger articlesCount = articleController.allArticles.count;
+		NSUInteger articlesCount = controller.articleController.allArticles.count;
 
 		currentSelectedRow = -1;
 		if (nextRow >= articlesCount)
@@ -576,8 +576,8 @@
 	Preferences * prefs = [Preferences standardPreferences];
 	
 	// Remember the current folder and article
-	NSString * guid = (currentSelectedRow >= 0 && currentSelectedRow < articleController.allArticles.count) ? [articleController.allArticles[currentSelectedRow] guid] : @"";
-	[prefs setInteger:articleController.currentFolderId forKey:MAPref_CachedFolderID];
+	NSString * guid = (currentSelectedRow >= 0 && currentSelectedRow < controller.articleController.allArticles.count) ? [controller.articleController.allArticles[currentSelectedRow] guid] : @"";
+	[prefs setInteger:controller.articleController.currentFolderId forKey:MAPref_CachedFolderID];
 	[prefs setString:guid forKey:MAPref_CachedArticleGUID];
 
 	// An array we need for the settings
@@ -658,7 +658,7 @@
  */
 -(void)showSortDirection
 {
-	NSString * sortColumnIdentifier = articleController.sortColumnIdentifier;
+	NSString * sortColumnIdentifier = controller.articleController.sortColumnIdentifier;
 	
 	for (NSTableColumn * column in articleList.tableColumns)
 	{
@@ -692,7 +692,7 @@
 	    return NO;
 	}
 
-	for (Article * thisArticle in articleController.allArticles)
+	for (Article * thisArticle in controller.articleController.allArticles)
 	{
 		if ([thisArticle.guid isEqualToString:guid])
 		{
@@ -734,7 +734,7 @@
  */
 -(BOOL)canGoForward
 {
-	return articleController.canGoForward;
+	return controller.articleController.canGoForward;
 }
 
 /* canGoBack
@@ -742,7 +742,7 @@
  */
 -(BOOL)canGoBack
 {
-	return articleController.canGoBack;
+	return controller.articleController.canGoBack;
 }
 
 /* handleGoForward
@@ -750,7 +750,7 @@
  */
 -(IBAction)handleGoForward:(id)sender
 {
-	[articleController goForward];
+	[controller.articleController goForward];
 }
 
 /* handleGoBack
@@ -758,7 +758,7 @@
  */
 -(IBAction)handleGoBack:(id)sender
 {
-	[articleController goBack];
+	[controller.articleController goBack];
 }
 
 - (BOOL)acceptsFirstResponder
@@ -780,7 +780,7 @@
  */
 -(Article *)selectedArticle
 {
-	return (currentSelectedRow >= 0 && currentSelectedRow < articleController.allArticles.count) ? articleController.allArticles[currentSelectedRow] : nil;
+	return (currentSelectedRow >= 0 && currentSelectedRow < controller.articleController.allArticles.count) ? controller.articleController.allArticles[currentSelectedRow] : nil;
 }
 
 /* printDocument
@@ -805,7 +805,7 @@
 -(void)handleArticleListFontChange:(NSNotification *)note
 {
 	[self setTableViewFont];
-	if (self == articleController.mainArticleView)
+	if (self == controller.articleController.mainArticleView)
 	{
 		[articleList reloadData];
 	}
@@ -816,7 +816,7 @@
  */
 -(void)handleLoadFullHTMLChange:(NSNotification *)note
 {
-	if (self == articleController.mainArticleView)
+	if (self == controller.articleController.mainArticleView)
 		[self refreshArticlePane];
 }
 
@@ -825,7 +825,7 @@
  */
 -(void)handleReadingPaneChange:(NSNotificationCenter *)nc
 {
-	if (self == articleController.mainArticleView)
+	if (self == controller.articleController.mainArticleView)
 	{
 		[self setOrientation:[Preferences standardPreferences].layout];
 		[self updateVisibleColumns];
@@ -853,7 +853,7 @@
  */
 -(void)makeRowSelectedAndVisible:(NSInteger)rowIndex
 {
-	if (articleController.allArticles.count == 0u)
+	if (controller.articleController.allArticles.count == 0u)
 	{
 		currentSelectedRow = -1;
 		[articleList deselectAll:self];
@@ -898,7 +898,7 @@
 	if (currentRow < 0)
 		currentRow = 0;
 	
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	NSInteger totalRows = allArticles.count;
 	Article * theArticle;
 	while (currentRow < totalRows)
@@ -964,7 +964,7 @@
 	BOOL result = [self viewNextUnreadInCurrentFolder:-1];
 	if (!result)
 	{
-		NSInteger count = articleController.allArticles.count;
+		NSInteger count = controller.articleController.allArticles.count;
 		if (count > 0)
 			[self makeRowSelectedAndVisible:0];
 	}
@@ -985,20 +985,22 @@
  */
 -(void)performFindPanelAction:(NSInteger)actionTag
 {
-	[articleController reloadArrayOfArticles];
+	[controller.articleController reloadArrayOfArticles];
 	
 	// This action is send continuously by the filter field, so make sure not the mark read while searching
-	if (currentSelectedRow < 0 && articleController.allArticles.count > 0 )
+	if (currentSelectedRow < 0 && controller.articleController.allArticles.count > 0 )
 	{
 		BOOL shouldSelectArticle = YES;
 		if ([Preferences standardPreferences].markReadInterval > 0.0f)
 		{
-			Article * article = articleController.allArticles[0u];
-			if (!article.read)
+			Article * article = controller.articleController.allArticles[0u];
+            if (!article.read) {
 				shouldSelectArticle = NO;
+            }
 		}
-		if (shouldSelectArticle)
+        if (shouldSelectArticle) {
 			[self makeRowSelectedAndVisible:0];
+        }
 	}
 }
 
@@ -1017,11 +1019,11 @@
         case MA_Refresh_RedrawList:
             break;
         case MA_Refresh_ReapplyFilter:
-            [articleController refilterArrayOfArticles];
-            [articleController sortArticles];
+            [controller.articleController refilterArrayOfArticles];
+            [controller.articleController sortArticles];
             break;
         case MA_Refresh_SortAndRedraw:
-            [articleController sortArticles];
+            [controller.articleController sortArticles];
             break;
     }
 
@@ -1084,9 +1086,9 @@
 	[self refreshArticlePane];
 	
 	// If we mark read after an interval, start the timer here.
-	if (currentSelectedRow >= 0 && currentSelectedRow < articleController.allArticles.count)
+	if (currentSelectedRow >= 0 && currentSelectedRow < controller.articleController.allArticles.count)
 	{
-		Article * theArticle = articleController.allArticles[currentSelectedRow];
+		Article * theArticle = controller.articleController.allArticles[currentSelectedRow];
 		if (!theArticle.read && !blockMarkRead)
 		{
 			[markReadTimer invalidate];
@@ -1115,14 +1117,14 @@
 	}
 	else
 	{
-		NSArray * allArticles = articleController.allArticles;
+		NSArray * allArticles = controller.articleController.allArticles;
 		NSAssert(currentSelectedRow < (NSInteger)[allArticles count], @"Out of range row index received");
 		
 		[self refreshImmediatelyArticleAtCurrentRow];
 		
 		// Add this to the backtrack list
 		NSString * guid = [allArticles[currentSelectedRow] guid];
-		[articleController addBacktrack:guid];
+		[controller.articleController addBacktrack:guid];
 	}
 }
 
@@ -1131,7 +1133,7 @@
  */
 -(void)handleRefreshArticle:(NSNotification *)nc
 {
-	if (self == articleController.mainArticleView && !isAppInitialising)
+	if (self == controller.articleController.mainArticleView && !isAppInitialising)
 		[self refreshArticlePane];
 }
 
@@ -1263,12 +1265,12 @@
  */
 -(void)markCurrentRead:(NSTimer *)aTimer
 {
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	if (currentSelectedRow >=0 && currentSelectedRow < (NSInteger)allArticles.count && ![Database sharedManager].readOnly)
 	{
 		Article * theArticle = allArticles[currentSelectedRow];
 		if (!theArticle.read)
-			[articleController markReadByArray:@[theArticle] readFlag:YES];
+			[controller.articleController markReadByArray:@[theArticle] readFlag:YES];
 	}
 }
 
@@ -1278,7 +1280,7 @@
  */
 -(NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView
 {
-	return articleController.allArticles.count;
+	return controller.articleController.allArticles.count;
 }
 
 /* objectValueForTableColumn [datasource]
@@ -1288,7 +1290,7 @@
 -(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
 {
 	Database * db = [Database sharedManager];
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	Article * theArticle;
 	
 	if(rowIndex < 0 || rowIndex >= allArticles.count)
@@ -1462,7 +1464,7 @@
 -(void)tableView:(NSTableView *)tableView didClickTableColumn:(NSTableColumn *)tableColumn
 {
 	NSString * columnName = tableColumn.identifier;
-	[articleController sortByIdentifier:columnName];
+	[controller.articleController sortByIdentifier:columnName];
 	[self showSortDirection];
 }
 
@@ -1554,7 +1556,7 @@
 	for (index = 0; index < count; ++index)
 	{
 		NSInteger msgIndex = [rows[index] integerValue];
-		Article * thisArticle = articleController.allArticles[msgIndex];
+		Article * thisArticle = controller.articleController.allArticles[msgIndex];
 		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
 		NSString * msgTitle = thisArticle.title;
@@ -1614,7 +1616,7 @@
 		articleArray = [NSMutableArray arrayWithCapacity:rowIndexes.count];
 		while (rowIndex != NSNotFound)
 		{
-			[articleArray addObject:articleController.allArticles[rowIndex]];
+			[articleArray addObject:controller.articleController.allArticles[rowIndex]];
 			rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
 		}
 	}

--- a/src/FoldersTree.h
+++ b/src/FoldersTree.h
@@ -20,7 +20,13 @@
 
 @import Cocoa;
 
-@interface FoldersTree : NSView
+@class AppController;
+@class FolderView;
+
+@interface FoldersTree : NSView <NSOutlineViewDelegate, NSOutlineViewDataSource>
+
+@property (weak, nonatomic) AppController *controller;
+@property (weak, nonatomic) FolderView *outlineView;
 
 -(void)initialiseFoldersTree;
 -(void)saveFolderSettings;

--- a/src/FoldersTree.h
+++ b/src/FoldersTree.h
@@ -23,7 +23,7 @@
 @class AppController;
 @class FolderView;
 
-@interface FoldersTree : NSView <NSOutlineViewDelegate, NSOutlineViewDataSource>
+@interface FoldersTree : NSObject <NSOutlineViewDelegate, NSOutlineViewDataSource>
 
 @property (weak, nonatomic) AppController *controller;
 @property (weak, nonatomic) FolderView *outlineView;

--- a/src/FoldersTree.m
+++ b/src/FoldersTree.m
@@ -33,10 +33,7 @@
 #import "TreeNode.h"
 #import "Folder.h"
 
-@interface FoldersTree () <NSOutlineViewDataSource>
-
-@property (weak, nonatomic) IBOutlet AppController *controller;
-@property (weak, nonatomic) IBOutlet FolderView *outlineView;
+@interface FoldersTree ()
 
 @property (nonatomic, readonly, copy) NSArray *archiveState;
 @property (nonatomic) TreeNode *rootNode;
@@ -84,10 +81,10 @@
 	return self;
 }
 
-/* awakeFromNib
- * Do things that only make sense once the NIB is loaded.
+/* initialiseFoldersTree
+ * Do the things to initialize the folder tree from the database
  */
--(void)awakeFromNib
+-(void)initialiseFoldersTree
 {
 	NSTableColumn * tableColumn;
 	ImageAndTextCell * imageAndTextCell;
@@ -126,13 +123,7 @@
 	[self.outlineView scrollRowToVisible:self.outlineView.selectedRow];
 
     [self.outlineView accessibilitySetOverrideValue:NSLocalizedString(@"Folders", nil) forAttribute:NSAccessibilityDescriptionAttribute];
-}
 
-/* initialiseFoldersTree
- * Do the things to initialize the folder tree from the database
- */
--(void)initialiseFoldersTree
-{
 	// Want tooltips
 	[self.outlineView setEnableTooltips:YES];
 	

--- a/src/FoldersTree.m
+++ b/src/FoldersTree.m
@@ -68,8 +68,8 @@
 
 @implementation FoldersTree
 
-- (instancetype)initWithFrame:(NSRect)frameRect {
-	if (self = [super initWithFrame:frameRect]) {
+- (instancetype)init {
+	if (self = [super init]) {
 		// Root node is never displayed since we always display from
 		// the second level down. It simply provides a convenient way
 		// of containing the other nodes.

--- a/src/UnifiedDisplayView.h
+++ b/src/UnifiedDisplayView.h
@@ -24,13 +24,11 @@
 #import "BaseView.h"
 
 @class AppController;
-@class ArticleController;
 @class ExtendedTableView;
 
 @interface UnifiedDisplayView : NSView<BaseView, ArticleBaseView, NSTableViewDelegate, NSTableViewDataSource>
 {
 	IBOutlet AppController * controller;
-	IBOutlet ArticleController * articleController;
     IBOutlet ExtendedTableView *articleList;
 
 	NSInteger currentSelectedRow;

--- a/src/UnifiedDisplayView.m
+++ b/src/UnifiedDisplayView.m
@@ -263,7 +263,7 @@
 			ArticleCellView * cell = (ArticleCellView *)obj;
 			[cell setInProgress:NO];
 			NSUInteger row= cell.articleRow;
-			NSArray * allArticles = articleController.allArticles;
+			NSArray * allArticles = controller.articleController.allArticles;
 			if (row < (NSInteger)allArticles.count)
 			{
 				[articleList reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
@@ -292,8 +292,8 @@
 		{
 			ArticleCellView * cell = (ArticleCellView *)objView;
 			NSUInteger row= [articleList rowForView:objView];
-			if (row == cell.articleRow && row < articleController.allArticles.count
-			  && cell.folderId == [articleController.allArticles[row] folderId])
+			if (row == cell.articleRow && row < controller.articleController.allArticles.count
+			  && cell.folderId == [controller.articleController.allArticles[row] folderId])
 			{	//relevant cell
                 NSString* outputHeight;
                 NSString* bodyHeight;
@@ -340,7 +340,7 @@
             }
             else {	//non relevant cell
                 [cell setInProgress:NO];
-                if (row < articleController.allArticles.count)
+                if (row < controller.articleController.allArticles.count)
                 {
                     [articleList reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
                 }
@@ -394,7 +394,7 @@
 	if (singleSelection)
 	{
 		NSUInteger nextRow =articleList.selectedRowIndexes.firstIndex;
-		NSUInteger articlesCount = articleController.allArticles.count;
+		NSUInteger articlesCount = controller.articleController.allArticles.count;
 
 		currentSelectedRow = -1;
 		if (nextRow >= articlesCount)
@@ -426,7 +426,7 @@
 	    return NO;
 	}
 
-	for (Article * thisArticle in articleController.allArticles)
+	for (Article * thisArticle in controller.articleController.allArticles)
 	{
 		if ([thisArticle.guid isEqualToString:guid])
 		{
@@ -464,15 +464,15 @@
  */
 -(void)performFindPanelAction:(NSInteger)actionTag
 {
-	[articleController reloadArrayOfArticles];
+	[controller.articleController reloadArrayOfArticles];
 
 	// This action is send continuously by the filter field, so make sure not the mark read while searching
-	if (currentSelectedRow < 0 && articleController.allArticles.count > 0 )
+	if (currentSelectedRow < 0 && controller.articleController.allArticles.count > 0 )
 	{
 		BOOL shouldSelectArticle = YES;
 		if ([Preferences standardPreferences].markReadInterval > 0.0f)
 		{
-			Article * article = articleController.allArticles[0u];
+			Article * article = controller.articleController.allArticles[0u];
 			if (!article.read)
 				shouldSelectArticle = NO;
 		}
@@ -519,8 +519,8 @@
 	Preferences * prefs = [Preferences standardPreferences];
 
 	// Remember the current folder and article
-	NSString * guid = (currentSelectedRow >= 0 && currentSelectedRow < articleController.allArticles.count) ? [articleController.allArticles[currentSelectedRow] guid] : @"";
-	[prefs setInteger:articleController.currentFolderId forKey:MAPref_CachedFolderID];
+	NSString * guid = (currentSelectedRow >= 0 && currentSelectedRow < controller.articleController.allArticles.count) ? [controller.articleController.allArticles[currentSelectedRow] guid] : @"";
+	[prefs setInteger:controller.articleController.currentFolderId forKey:MAPref_CachedFolderID];
 	[prefs setString:guid forKey:MAPref_CachedArticleGUID];
 }
 
@@ -546,7 +546,7 @@
  */
 -(Article *)selectedArticle
 {
-	return (currentSelectedRow >= 0 && currentSelectedRow < articleController.allArticles.count) ? articleController.allArticles[currentSelectedRow] : nil;
+	return (currentSelectedRow >= 0 && currentSelectedRow < controller.articleController.allArticles.count) ? controller.articleController.allArticles[currentSelectedRow] : nil;
 }
 
 /* printDocument
@@ -562,7 +562,7 @@
  */
 -(void)handleReadingPaneChange:(NSNotificationCenter *)nc
 {
-	if (self == articleController.mainArticleView)
+	if (self == controller.articleController.mainArticleView)
 	{
 		[articleList reloadData];
 	}
@@ -574,7 +574,7 @@
  */
 -(void)makeRowSelectedAndVisible:(NSInteger)rowIndex
 {
-	if (articleController.allArticles.count == 0u)
+	if (controller.articleController.allArticles.count == 0u)
 	{
 		currentSelectedRow = -1;
 	}
@@ -607,7 +607,7 @@
 	if (currentRow < 0)
 		currentRow = 0;
 
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	NSInteger totalRows = allArticles.count;
 	Article * theArticle;
 	while (currentRow < totalRows)
@@ -632,7 +632,7 @@
 	BOOL result = [self viewNextUnreadInCurrentFolder:-1];
 	if (!result)
 	{
-		NSInteger count = articleController.allArticles.count;
+		NSInteger count = controller.articleController.allArticles.count;
 		if (count > 0)
 			[self makeRowSelectedAndVisible:0];
 	}
@@ -663,11 +663,11 @@
         case MA_Refresh_RedrawList:
             break;
         case MA_Refresh_ReapplyFilter:
-            [articleController refilterArrayOfArticles];
-            [articleController sortArticles];
+            [controller.articleController refilterArrayOfArticles];
+            [controller.articleController sortArticles];
             break;
         case MA_Refresh_SortAndRedraw:
-            [articleController sortArticles];
+            [controller.articleController sortArticles];
             break;
     }
 
@@ -707,12 +707,12 @@
  */
 -(void)markCurrentRead:(NSTimer *)aTimer
 {
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	if (currentSelectedRow >=0 && currentSelectedRow < (NSInteger)allArticles.count && ![Database sharedManager].readOnly)
 	{
 		Article * theArticle = allArticles[currentSelectedRow];
 		if (!theArticle.read)
-			[articleController markReadByArray:@[theArticle] readFlag:YES];
+			[controller.articleController markReadByArray:@[theArticle] readFlag:YES];
 	}
 }
 
@@ -725,7 +725,7 @@
  */
 -(NSInteger)numberOfRowsInTableView:(NSTableView*)aTableView
 {
-	return articleController.allArticles.count;
+	return controller.articleController.allArticles.count;
 }
 
 - (CGFloat)tableView:(NSTableView *)aListView heightOfRow:(NSInteger)row
@@ -763,7 +763,7 @@
 		cellView.identifier = LISTVIEW_CELL_IDENTIFIER;
 	}
 
-	NSArray * allArticles = articleController.allArticles;
+	NSArray * allArticles = controller.articleController.allArticles;
 	if (row < 0 || row >= allArticles.count)
 	    return nil;
 
@@ -819,7 +819,7 @@
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound)
 	{
-		Article * thisArticle = articleController.allArticles[msgIndex];
+		Article * thisArticle = controller.articleController.allArticles[msgIndex];
 		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
 		NSString * msgTitle = thisArticle.title;
@@ -928,7 +928,7 @@
 		articleArray = [NSMutableArray arrayWithCapacity:rowIndexes.count];
 		while (rowIndex != NSNotFound)
 		{
-			[articleArray addObject:articleController.allArticles[rowIndex]];
+			[articleArray addObject:controller.articleController.allArticles[rowIndex]];
 			rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
 		}
 	}
@@ -945,11 +945,11 @@
 
 -(BOOL)becomeFirstResponder
 {
-    if (currentSelectedRow >= 0 && currentSelectedRow < articleController.allArticles.count)
+    if (currentSelectedRow >= 0 && currentSelectedRow < controller.articleController.allArticles.count)
     {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:currentSelectedRow] byExtendingSelection:NO];
     }
-    else if (articleController.allArticles.count != 0u)
+    else if (controller.articleController.allArticles.count != 0u)
     {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
 		currentSelectedRow = 0;


### PR DESCRIPTION
This PR addresses some of the problems I have mentioned in #930. In a nutshell, it removes the ArticleController and FoldersTree objects from Interface Builder. Instead, these objects are now created in AppController in `-applicationDidFinishLaunching:` and then passed to other objects via dependency injection. This should simplify the initialisation sequence.

This PR will help splitting MainMenu.xib into two files:
- MainMenu.xib for the NSApplication/NSApplicationDelegate scene
- MainWindowController.xib for the window-controller scene

Please review and test, so that I can refactor MainWindowController for this.