### PR TITLE
Move ExportSaveAccessory into own view controller and XIB file

### DIFF
--- a/Interfaces/Base.lproj/ExportAccessoryViewController.xib
+++ b/Interfaces/Base.lproj/ExportAccessoryViewController.xib
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13122.19" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13122.19"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="View Controller" customClass="ExportAccessoryViewController" customModule="Vienna" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="5Ip-vg-DTq" id="CLl-b4-5Yc"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="5Ip-vg-DTq">
+            <rect key="frame" x="0.0" y="0.0" width="399" height="105"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <subviews>
+                <stackView orientation="vertical" alignment="leading" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dfe-em-I6F">
+                    <rect key="frame" x="20" y="20" width="359" height="65"/>
+                    <beginningViews>
+                        <button verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FlF-oZ-7c5">
+                            <rect key="frame" x="-1" y="48" width="362" height="18"/>
+                            <buttonCell key="cell" type="radio" title="Export all subscriptions" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="6rj-zb-zOa">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <binding destination="-2" name="value" keyPath="exportAllFeedsRadioButtonState" id="JOv-3U-eZM"/>
+                            </connections>
+                        </button>
+                        <button verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nVN-JX-IXr">
+                            <rect key="frame" x="-1" y="24" width="362" height="18"/>
+                            <buttonCell key="cell" type="radio" title="Export selected subscriptions" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="KgE-bb-aJn">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <binding destination="-2" name="value" keyPath="exportAllFeedsRadioButtonState" id="iIw-J6-HWL">
+                                    <dictionary key="options">
+                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                    </dictionary>
+                                </binding>
+                            </connections>
+                        </button>
+                        <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ohs-sN-wc7">
+                            <rect key="frame" x="-2" y="-2" width="363" height="21"/>
+                            <buttonCell key="cell" type="check" title="Preserve group folders in exported file" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="IYg-Pm-bcI">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <binding destination="-2" name="value" keyPath="preserveFoldersCheckboxButtonState" id="6J6-7J-CjO"/>
+                            </connections>
+                        </button>
+                    </beginningViews>
+                    <constraints>
+                        <constraint firstItem="ohs-sN-wc7" firstAttribute="leading" secondItem="dfe-em-I6F" secondAttribute="leading" constant="1" id="5ru-FF-4cy"/>
+                    </constraints>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+            </subviews>
+            <constraints>
+                <constraint firstItem="dfe-em-I6F" firstAttribute="top" secondItem="5Ip-vg-DTq" secondAttribute="top" constant="20" symbolic="YES" id="3Cp-sa-OBV"/>
+                <constraint firstAttribute="bottom" secondItem="dfe-em-I6F" secondAttribute="bottom" constant="20" symbolic="YES" id="5g7-XD-pat"/>
+                <constraint firstAttribute="trailing" secondItem="dfe-em-I6F" secondAttribute="trailing" constant="20" symbolic="YES" id="Dbs-pa-gMX"/>
+                <constraint firstItem="dfe-em-I6F" firstAttribute="leading" secondItem="5Ip-vg-DTq" secondAttribute="leading" constant="20" symbolic="YES" id="Ejr-sT-WRH"/>
+            </constraints>
+            <point key="canvasLocation" x="198.5" y="84.5"/>
+        </customView>
+    </objects>
+</document>

--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -1173,10 +1173,6 @@ CA
                 <outlet property="closeWindowItem" destination="935" id="1034"/>
                 <outlet property="columnsMenu" destination="442" id="1050"/>
                 <outlet property="currentFilterTextField" destination="1403" id="1405"/>
-                <outlet property="exportAll" destination="862" id="865"/>
-                <outlet property="exportSaveAccessory" destination="860" id="864"/>
-                <outlet property="exportSelected" destination="863" id="866"/>
-                <outlet property="exportWithGroups" destination="1052" id="1053"/>
                 <outlet property="filterDisclosureView" destination="cTN-D0-dY2" id="i7U-gE-GBj"/>
                 <outlet property="filterIconInStatusBarButton" destination="1400" id="1407"/>
                 <outlet property="filterSearchField" destination="1304" id="1315"/>
@@ -1193,43 +1189,6 @@ CA
                 <outlet property="unifiedListView" destination="1148" id="O5e-id-8Cu"/>
             </connections>
         </customObject>
-        <customView id="860" userLabel="ExportSaveAccessory">
-            <rect key="frame" x="0.0" y="0.0" width="399" height="94"/>
-            <autoresizingMask key="autoresizingMask"/>
-            <subviews>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1052">
-                    <rect key="frame" x="18" y="15" width="363" height="18"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <buttonCell key="cell" type="check" title="Preserve group folders in exported file" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1368">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                </button>
-                <matrix verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" autosizesCells="NO" translatesAutoresizingMaskIntoConstraints="NO" id="861">
-                    <rect key="frame" x="18" y="37" width="363" height="38"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    <size key="cellSize" width="363" height="18"/>
-                    <size key="intercellSpacing" width="4" height="2"/>
-                    <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="1380">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <cells>
-                        <column>
-                            <buttonCell type="radio" title="Export all subscriptions" imagePosition="left" alignment="left" state="on" inset="2" id="862">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <buttonCell type="radio" title="Export selected subscriptions" imagePosition="left" alignment="left" tag="1" inset="2" id="863">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                        </column>
-                    </cells>
-                </matrix>
-            </subviews>
-        </customView>
         <customView id="971" userLabel="ArticleDisplayView" customClass="ArticleListView">
             <rect key="frame" x="0.0" y="0.0" width="700" height="629"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		EA1A7620148FA32B004A6B8F /* googleFeed.tiff in Resources */ = {isa = PBXBuildFile; fileRef = EA1A761F148FA32B004A6B8F /* googleFeed.tiff */; };
 		EA43C70914A370DB00F2D843 /* VTPG_Common.m in Sources */ = {isa = PBXBuildFile; fileRef = EA43C70814A370DB00F2D843 /* VTPG_Common.m */; };
 		EACE4C90147FA2B000A17997 /* PSMTabBarControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EACE4C8E147FA2B000A17997 /* PSMTabBarControl.framework */; };
+		F6094E331F10107800677D3B /* ExportAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6094E311F10107800677D3B /* ExportAccessoryViewController.swift */; };
 		F6164C591E32A6660086261C /* DisclosureView.m in Sources */ = {isa = PBXBuildFile; fileRef = F6164C581E32A6660086261C /* DisclosureView.m */; };
 		F6257FF51E28485F0035E43C /* Downloads.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6257FF71E28485F0035E43C /* Downloads.xib */; };
 		F625801C1E2853B90035E43C /* ActivityViewer.xib in Resources */ = {isa = PBXBuildFile; fileRef = F625801E1E2853B90035E43C /* ActivityViewer.xib */; };
@@ -340,6 +341,7 @@
 		F648C2B91E7F3C2500CE4043 /* DirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EB26021E58D37100570B22 /* DirectoryMonitor.swift */; };
 		F64C2CCC1E83825D00ED4E04 /* DateFormatterExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = F64C2CCB1E83825D00ED4E04 /* DateFormatterExtension.m */; };
 		F65D6D711E74619E00A30974 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 4398241E1666B3DB00FFE219 /* Credits.rtf */; };
+		F6832F631F10C4C9007920D4 /* ExportAccessoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6832F651F10C4C9007920D4 /* ExportAccessoryViewController.xib */; };
 		F69140E41E71B94200D51BFF /* AppController+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = F69140E31E71B94200D51BFF /* AppController+Notifications.m */; };
 		F6A7DE341E47138B0017BE5E /* advanced.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2A1E47138B0017BE5E /* advanced.html */; };
 		F6A7DE351E47138B0017BE5E /* faq.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2C1E47138B0017BE5E /* faq.html */; };
@@ -812,6 +814,7 @@
 		EACE4C8E147FA2B000A17997 /* PSMTabBarControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PSMTabBarControl.framework; path = 3rdparty/PSMTabBarControl.framework; sourceTree = "<group>"; };
 		ED69423919E1DC034EA80E25 /* Pods-Vienna Tests.staticanalyzer.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vienna Tests.staticanalyzer.xcconfig"; path = "Pods/Target Support Files/Pods-Vienna Tests/Pods-Vienna Tests.staticanalyzer.xcconfig"; sourceTree = "<group>"; };
 		F1ECA9ED54D2517E7BEDCBB7 /* Pods-Vienna Tests.development.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vienna Tests.development.xcconfig"; path = "Pods/Target Support Files/Pods-Vienna Tests/Pods-Vienna Tests.development.xcconfig"; sourceTree = "<group>"; };
+		F6094E311F10107800677D3B /* ExportAccessoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExportAccessoryViewController.swift; path = src/ExportAccessoryViewController.swift; sourceTree = "<group>"; };
 		F6164C571E32A6660086261C /* DisclosureView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DisclosureView.h; path = src/DisclosureView.h; sourceTree = "<group>"; };
 		F6164C581E32A6660086261C /* DisclosureView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DisclosureView.m; path = src/DisclosureView.m; sourceTree = "<group>"; };
 		F6257FE31E283F250035E43C /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/SyncingPreferencesView.strings; sourceTree = "<group>"; };
@@ -1004,6 +1007,7 @@
 		F648C2B71E7F3BEA00CE4043 /* DirectoryMonitorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoryMonitorTests.swift; sourceTree = "<group>"; };
 		F64C2CCA1E83825D00ED4E04 /* DateFormatterExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DateFormatterExtension.h; path = src/DateFormatterExtension.h; sourceTree = "<group>"; };
 		F64C2CCB1E83825D00ED4E04 /* DateFormatterExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DateFormatterExtension.m; path = src/DateFormatterExtension.m; sourceTree = "<group>"; };
+		F6832F641F10C4C9007920D4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/ExportAccessoryViewController.xib; sourceTree = "<group>"; };
 		F68F724A1E2A0937007FADA5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		F69140E21E71B94200D51BFF /* AppController+Notifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AppController+Notifications.h"; path = "src/AppController+Notifications.h"; sourceTree = "<group>"; };
 		F69140E31E71B94200D51BFF /* AppController+Notifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "AppController+Notifications.m"; path = "src/AppController+Notifications.m"; sourceTree = "<group>"; };
@@ -1479,6 +1483,7 @@
 				F62581441E29B90A0035E43C /* SearchPanel.xib */,
 				F6D572AD1E26AA8200CDA909 /* EmptyTrashWarning.xib */,
 				F6D572B01E26AA8A00CDA909 /* FeedCredentials.xib */,
+				F6832F651F10C4C9007920D4 /* ExportAccessoryViewController.xib */,
 				F6D572B31E26AA9000CDA909 /* GroupFolder.xib */,
 				F6D572B91E26AAA100CDA909 /* RSSFeed.xib */,
 				F6D572BC1E26AAA900CDA909 /* SearchFolder.xib */,
@@ -2072,6 +2077,7 @@
 			children = (
 				43502863165DE9DF0018EDB7 /* EmptyTrashWarning.h */,
 				43502864165DE9DF0018EDB7 /* EmptyTrashWarning.m */,
+				F6094E311F10107800677D3B /* ExportAccessoryViewController.swift */,
 				43502867165DE9DF0018EDB7 /* FeedCredentials.h */,
 				43502868165DE9DF0018EDB7 /* FeedCredentials.m */,
 				43502875165DE9DF0018EDB7 /* NewGroupFolder.h */,
@@ -2261,6 +2267,7 @@
 				AA3F7B4208711F6A00D2B96F /* comments_header.tiff in Resources */,
 				AA20DC9E0882CCC300A226F5 /* unread.tiff in Resources */,
 				AA6321510885F0BB006382D3 /* comments.tiff in Resources */,
+				F6832F631F10C4C9007920D4 /* ExportAccessoryViewController.xib in Resources */,
 				AA67F3990897377C008BBC37 /* stopRefresh.tiff in Resources */,
 				AA2A1DFD089F2B940038770C /* trashFolder.tiff in Resources */,
 				AAF6C3A308B06BA00077BAB8 /* StandardURLs.plist in Resources */,
@@ -2692,6 +2699,7 @@
 				4350289B165DE9E00018EDB7 /* ArticleView.m in Sources */,
 				4350289C165DE9E00018EDB7 /* BrowserPane.m in Sources */,
 				4350289D165DE9E00018EDB7 /* BrowserPaneTemplate.m in Sources */,
+				F6094E331F10107800677D3B /* ExportAccessoryViewController.swift in Sources */,
 				F6EB261C1E5BA59300570B22 /* PreferencesWindowController.m in Sources */,
 				4350289E165DE9E00018EDB7 /* BrowserView.m in Sources */,
 				F628DFE31ED2698A00FACFD3 /* FilterView.swift in Sources */,
@@ -3059,6 +3067,15 @@
 				F69140FE1E71D74800D51BFF /* zh-Hans */,
 			);
 			name = MainMenu.xib;
+			path = Interfaces;
+			sourceTree = "<group>";
+		};
+		F6832F651F10C4C9007920D4 /* ExportAccessoryViewController.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F6832F641F10C4C9007920D4 /* Base */,
+			);
+			name = ExportAccessoryViewController.xib;
 			path = Interfaces;
 			sourceTree = "<group>";
 		};

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -49,13 +49,9 @@
 @interface AppController : NSObject <NSApplicationDelegate,NSWindowDelegate,NSToolbarDelegate,NSMenuDelegate>
 {
 	IBOutlet BJRWindowWithToolbar * mainWindow;
-	IBOutlet NSView * exportSaveAccessory;
 	IBOutlet NSSearchField * filterSearchField;
 	IBOutlet NSPopUpButton * filterViewPopUp;
 	IBOutlet BrowserView * browserView;
-	IBOutlet NSButtonCell * exportAll;
-	IBOutlet NSButtonCell * exportSelected;
-	IBOutlet NSButton * exportWithGroups;
 	IBOutlet NSSearchField * searchField;
 	IBOutlet NSTextField * statusText;
 	IBOutlet ClickableProgressIndicator * spinner;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -1265,34 +1265,31 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)exportSubscriptions:(id)sender
 {
-    NSSavePanel * panel = [NSSavePanel savePanel];
-    
+    NSSavePanel *panel = [NSSavePanel savePanel];
+
+    // Create the accessory view
+    ExportAccessoryViewController *accessoryController = [[ExportAccessoryViewController alloc] initWithNibName:@"ExportAccessoryViewController"
+                                                                                                         bundle:nil];
+
     // If multiple selections in the folder list, default to selected folders
     // for simplicity.
-    if (self.foldersTree.countOfSelectedFolders > 1)
-    {
-        exportSelected.state = NSOnState;
-        exportAll.state = NSOffState;
-    }
-    else
-    {
-        exportSelected.state = NSOffState;
-        exportAll.state = NSOnState;
+    if (self.foldersTree.countOfSelectedFolders > 1) {
+        accessoryController.mode = ExportModeSelectedFeeds;
+    } else {
+        accessoryController.mode = ExportModeAllFeeds;
     }
     
-    // Localise the strings
-    [exportAll setTitle:NSLocalizedString(@"Export all subscriptions", nil)];
-    [exportSelected setTitle:NSLocalizedString(@"Export selected subscriptions", nil)];
-    [exportWithGroups setTitle:NSLocalizedString(@"Preserve group folders in exported file", nil)];
-    
-    panel.accessoryView = exportSaveAccessory;
+    panel.accessoryView = accessoryController.view;
     panel.allowedFileTypes = @[@"opml"];
     [panel beginSheetModalForWindow:mainWindow completionHandler:^(NSInteger returnCode) {
         if (returnCode == NSFileHandlingPanelOKButton)
         {
             [panel orderOut:self];
             
-            NSInteger countExported = [Export exportToFile:panel.URL.path fromFoldersTree:self.foldersTree selection:(exportSelected.state == NSOnState) withGroups:(exportWithGroups.state == NSOnState)];
+            NSInteger countExported = [Export exportToFile:panel.URL.path
+                                           fromFoldersTree:self.foldersTree
+                                                 selection:accessoryController.mode == ExportModeSelectedFeeds
+                                                withGroups:accessoryController.preserveFolders];
             
             if (countExported < 0)
             {

--- a/src/ExportAccessoryViewController.swift
+++ b/src/ExportAccessoryViewController.swift
@@ -1,0 +1,61 @@
+//
+//  ExportAccessoryViewController.swift
+//  Vienna
+//
+//  Copyright 2017
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Cocoa
+
+final class ExportAccessoryViewController: NSViewController {
+
+    // MARK: Bindings
+
+    @objc private dynamic var exportAllFeedsRadioButtonState = NSOnState
+    @objc private dynamic var preserveFoldersCheckboxButtonState = NSOnState
+
+    // MARK: Export options
+
+    /// The export mode to use.
+    var mode: ExportMode {
+        get {
+            return exportAllFeedsRadioButtonState == NSOnState ? .allFeeds : .selectedFeeds
+        }
+        set {
+            exportAllFeedsRadioButtonState = newValue == .allFeeds ? NSOnState : NSOffState
+        }
+    }
+
+    /// Whether folders should be preserved.
+    var preserveFolders: Bool {
+        get {
+            return preserveFoldersCheckboxButtonState == NSOnState
+        }
+        set {
+            preserveFoldersCheckboxButtonState = newValue ? NSOnState : NSOffState
+        }
+    }
+
+    // MARK: Nested types
+
+    @objc enum ExportMode: Int {
+        /// All feeds should be exported.
+        case allFeeds
+
+        /// Only the currently selected feeds should be exported.
+        case selectedFeeds
+    }
+
+}


### PR DESCRIPTION
This removes 4 more needless outlets from MainMenu.xib. The implementation uses Cocoa bindings.