### PR TITLE
Add OverlayStatusBar class

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		F65D6D711E74619E00A30974 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 4398241E1666B3DB00FFE219 /* Credits.rtf */; };
 		F6832F631F10C4C9007920D4 /* ExportAccessoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6832F651F10C4C9007920D4 /* ExportAccessoryViewController.xib */; };
 		F69140E41E71B94200D51BFF /* AppController+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = F69140E31E71B94200D51BFF /* AppController+Notifications.m */; };
+		F69964F71F13029600FC8493 /* OverlayStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69964F61F13029500FC8493 /* OverlayStatusBar.swift */; };
 		F6A7DE341E47138B0017BE5E /* advanced.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2A1E47138B0017BE5E /* advanced.html */; };
 		F6A7DE351E47138B0017BE5E /* faq.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2C1E47138B0017BE5E /* faq.html */; };
 		F6A7DE361E47138B0017BE5E /* intro.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2E1E47138B0017BE5E /* intro.html */; };
@@ -1029,6 +1030,7 @@
 		F69140FC1E71D74400D51BFF /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		F69140FD1E71D74600D51BFF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		F69140FE1E71D74800D51BFF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
+		F69964F61F13029500FC8493 /* OverlayStatusBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OverlayStatusBar.swift; path = src/OverlayStatusBar.swift; sourceTree = "<group>"; };
 		F6A7DDCA1E470E980017BE5E /* Vienna.help */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Vienna.help; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6A7DDCC1E470E980017BE5E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F6A7DE2B1E47138B0017BE5E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = en; path = Resources/en.lproj/advanced.html; sourceTree = "<group>"; };
@@ -1834,6 +1836,7 @@
 				AAFAF3FC088056D800DAFF04 /* KeyChain.m */,
 				3A23F13315276935008AF863 /* NSNotificationAdditions.h */,
 				4350283D165DE7F60018EDB7 /* NSNotificationAdditions.m */,
+				F69964F61F13029500FC8493 /* OverlayStatusBar.swift */,
 				AAD794E4088A25D200E2CE5E /* PopUpButtonExtensions.h */,
 				AAD794E5088A25D200E2CE5E /* PopUpButtonExtensions.m */,
 				AAF3B14006095E7B0025CC7F /* StringExtensions.h */,
@@ -2732,6 +2735,7 @@
 				435028B3165DE9E00018EDB7 /* StdEnclosureView.m in Sources */,
 				435028B4165DE9E00018EDB7 /* TabbedWebView.m in Sources */,
 				435028B6165DE9E00018EDB7 /* TreeNode.m in Sources */,
+				F69964F71F13029600FC8493 /* OverlayStatusBar.swift in Sources */,
 				435028B7165DE9E00018EDB7 /* UnifiedDisplayView.m in Sources */,
 				435028B8165DE9E00018EDB7 /* URLHandlerCommand.m in Sources */,
 				435028B9165DE9E00018EDB7 /* ViennaApp.m in Sources */,

--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -39,8 +39,11 @@
 #import "StdEnclosureView.h"
 #import "BrowserView.h"
 #import "Database.h"
+#import "Vienna-Swift.h"
 
 @interface ArticleListView ()
+
+@property (nonatomic) OverlayStatusBar *statusBar;
 
 -(void)initTableView;
 -(BOOL)copyTableSelection:(NSArray *)rows toPasteboard:(NSPasteboard *)pboard;
@@ -154,6 +157,10 @@
 	
 	// Done initialising
 	isAppInitialising = NO;
+
+    // Create a status bar.
+    self.statusBar = [OverlayStatusBar new];
+    [articleText addSubview:self.statusBar];
 }
 
 // MARK: - WebUIDelegate methods
@@ -200,10 +207,10 @@
  * Called from the webview when the user positions the mouse over an element. If it's a link
  * then echo the URL to the status bar like Safari does.
  */
--(void)webView:(WebView *)sender mouseDidMoveOverElement:(NSDictionary *)elementInformation modifierFlags:(NSUInteger)modifierFlags
-{
-	NSURL * url = [elementInformation valueForKey:@"WebElementLinkURL"];
-	[controller setStatusMessage:(url ? url.absoluteString : @"") persist:NO];
+- (void)webView:(WebView *)sender mouseDidMoveOverElement:(NSDictionary *)elementInformation
+  modifierFlags:(NSUInteger)modifierFlags {
+    NSURL *url = [elementInformation valueForKey:@"WebElementLinkURL"];
+    self.statusBar.label = url.absoluteString;
 }
 
 /* contextMenuItemsForElement

--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -1621,8 +1621,6 @@
 	if (frame == articleText.mainFrame)
 	{
 		[self setError:nil];
-		[controller setStatusMessage:NSLocalizedString( isLoadingHTMLArticle ? @"Loading HTML article…" : @"", nil) persist:YES];
-		
 	}
 	
 }
@@ -1685,7 +1683,6 @@
 {
 	if (isLoadingHTMLArticle)
 	{
-		[controller setStatusMessage:NSLocalizedString(@"Article load completed", nil) persist:YES];
 		isLoadingHTMLArticle = NO;
 		[articleList setNeedsDisplay];
 	}

--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -196,16 +196,6 @@
 	return alertResponse == NSAlertFirstButtonReturn;
 }
 
-/* setStatusText
- * Called from the webview when some JavaScript writes status text. Echo this to
- * our status bar.
- */
--(void)webView:(WebView *)sender setStatusText:(NSString *)text
-{
-	if (controller.browserView.activeTabItemView == self)
-		[controller setStatusMessage:text persist:NO];
-}
-
 /* mouseDidMoveOverElement
  * Called from the webview when the user positions the mouse over an element. If it's a link
  * then echo the URL to the status bar like Safari does.

--- a/src/BrowserPane.m
+++ b/src/BrowserPane.m
@@ -256,16 +256,6 @@
 	[(self.webPane).mainFrame loadRequest:[NSURLRequest requestWithURL:url]];
 }
 
-/* setStatusText
- * Called from the webview when some JavaScript writes status text. Echo this to
- * our status bar.
- */
--(void)webView:(WebView *)sender setStatusText:(NSString *)text
-{
-	if (controller.browserView.activeTabItemView == self)
-		[controller setStatusMessage:text persist:NO];
-}
-
 /* mouseDidMoveOverElement
  * Called from the webview when the user positions the mouse over an element. If it's a link
  * then echo the URL to the status bar like Safari does.

--- a/src/BrowserPane.m
+++ b/src/BrowserPane.m
@@ -30,6 +30,7 @@
 #import "Folder.h"
 #import "BrowserView.h"
 #import "SSTextField.h"
+#import "Vienna-Swift.h"
 
 @implementation BrowserPaneButtonCell
 
@@ -63,6 +64,8 @@
 @end
 
 @interface BrowserPane ()
+
+@property (nonatomic) OverlayStatusBar *statusBar;
 
 -(void)endFrameLoad;
 -(void)showRssPageButton:(BOOL)showButton;
@@ -123,7 +126,7 @@
 {
 	// Create our webview
 	[webPane initTabbedWebView];
-	webPane.UIDelegate = self;
+    webPane.UIDelegate = self;
 	webPane.frameLoadDelegate = self;
 	
 	// Make web preferences 16pt Arial to match Safari
@@ -160,6 +163,10 @@
 	[forwardButton.cell accessibilitySetOverrideValue:NSLocalizedString(@"Go forward to the next page", nil) forAttribute:NSAccessibilityTitleAttribute];
 	[rssPageButton setToolTip:NSLocalizedString(@"Subscribe to the feed for this page", nil)];
 	[rssPageButton.cell accessibilitySetOverrideValue:NSLocalizedString(@"Subscribe to the feed for this page", nil) forAttribute:NSAccessibilityTitleAttribute];
+
+    // Create a status bar.
+    self.statusBar = [OverlayStatusBar new];
+    [self addSubview:self.statusBar];
 }
 
 /* setController
@@ -260,10 +267,10 @@
  * Called from the webview when the user positions the mouse over an element. If it's a link
  * then echo the URL to the status bar like Safari does.
  */
--(void)webView:(WebView *)sender mouseDidMoveOverElement:(NSDictionary *)elementInformation modifierFlags:(NSUInteger)modifierFlags
-{
-	NSURL * url = [elementInformation valueForKey:@"WebElementLinkURL"];
-	[controller setStatusMessage:(url ? url.absoluteString : @"") persist:NO];
+- (void)webView:(WebView *)sender mouseDidMoveOverElement:(NSDictionary *)elementInformation
+  modifierFlags:(NSUInteger)modifierFlags {
+    NSURL *url = [elementInformation valueForKey:@"WebElementLinkURL"];
+    self.statusBar.label = url.absoluteString;
 }
 
 /* didStartProvisionalLoadForFrame

--- a/src/OverlayStatusBar.swift
+++ b/src/OverlayStatusBar.swift
@@ -1,0 +1,391 @@
+//
+//  OverlayStatusBar.swift
+//  Vienna
+//
+//  Copyright 2017
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Cocoa
+
+/// An overlay status bar can show context-specific information above a view.
+/// It is supposed to be a subview of another view. Once added, it will set its
+/// own frame and constraints. Removing the status bar from its superview will
+/// unwind the constraints.
+///
+/// Setting or unsetting the `label` property will show or hide the status bar
+/// accordingly. It will not hide by itself.
+final class OverlayStatusBar: NSView {
+
+    // MARK: Subviews
+
+    private var backgroundView: NSView = {
+        let backgroundView: NSView
+        if #available(OSX 10.10, *) {
+            let view = NSVisualEffectView(frame: NSZeroRect)
+            view.wantsLayer = true
+            view.blendingMode = .withinWindow
+            backgroundView = view
+        } else {
+            backgroundView = NSView(frame: NSZeroRect)
+            backgroundView.wantsLayer = true
+            backgroundView.layer?.backgroundColor = CGColor(gray: 0, alpha: 0.65)
+        }
+
+        backgroundView.alphaValue = 0
+        backgroundView.layer?.cornerRadius = 3
+
+        return backgroundView
+    }()
+
+    private var addressField: NSTextField = {
+        let addressField: NSTextField
+        if #available(macOS 10.12, *) {
+            addressField = NSTextField(labelWithString: "")
+        } else {
+            addressField = NSTextField(frame: NSZeroRect)
+            addressField.isBezeled = false
+            addressField.isSelectable = false
+            addressField.drawsBackground = false
+
+            if #available(OSX 10.10, *) {
+                addressField.textColor = .labelColor
+            }
+        }
+
+        if #available(OSX 10.11, *) {
+            addressField.font = .systemFont(ofSize: 12, weight: NSFontWeightMedium)
+        } else if #available(OSX 10.10, *) {
+            addressField.font = NSFont(name: "Helvetica Neue Medium", size: 12)
+        } else {
+            addressField.font = .systemFont(ofSize: 11)
+        }
+
+        if #available(OSX 10.10, *) {
+            addressField.lineBreakMode = .byTruncatingMiddle
+
+            if #available(OSX 10.11, *) {
+                addressField.allowsDefaultTighteningForTruncation = true
+            }
+        } else {
+            addressField.cell?.lineBreakMode = .byTruncatingMiddle
+            addressField.cell?.backgroundStyle = .dark
+        }
+
+        return addressField
+    }()
+
+    // MARK: Initialization
+
+    init() {
+        super.init(frame: NSRect(x: 0, y: 0, width: 240, height: 26))
+
+        // Make sure that no other constraints are created.
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        addressField.translatesAutoresizingMaskIntoConstraints = false
+
+        // The text field should always be among the first views to shrink.
+        addressField.setContentCompressionResistancePriority(NSLayoutPriorityFittingSizeCompression, for: .horizontal)
+
+        addSubview(backgroundView)
+        backgroundView.addSubview(addressField)
+
+        // Set the constraints.
+        var backgroundViewConstraints: [NSLayoutConstraint] = []
+        backgroundViewConstraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-3-[view]-3-|",
+                                                                    metrics: nil, views: ["view": backgroundView])
+        backgroundViewConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-3-[view]-3-|",
+                                                                    metrics: nil, views: ["view": backgroundView])
+
+        var addressFieldConstraints: [NSLayoutConstraint] = []
+        addressFieldConstraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-2-[label]-2-|",
+                                                               metrics: nil, views: ["label": addressField])
+        addressFieldConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-6-[label]-6-|",
+                                                               metrics: nil, views: ["label": addressField])
+
+        if #available(OSX 10.10, *) {
+            NSLayoutConstraint.activate(backgroundViewConstraints)
+            NSLayoutConstraint.activate(addressFieldConstraints)
+        } else {
+            addConstraints(backgroundViewConstraints)
+            backgroundView.addConstraints(addressFieldConstraints)
+        }
+    }
+
+    // Make this initialiser unavailable.
+    private convenience override init(frame frameRect: NSRect) {
+        self.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("\(#function) has not been implemented")
+    }
+
+    // MARK: Setting the view hierarchy
+
+    // When the status bar is added to the view hierarchy of another view,
+    // perform additional setup, such as setting the constraints and creating
+    // a tracking area for mouse movements.
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+
+        guard let superview = superview else {
+            return
+        }
+
+        // Layer-backing will make sure that the visual-effect view redraws.
+        if #available(OSX 10.10, *) {
+            superview.wantsLayer = true
+        }
+
+        var baseContraints: [NSLayoutConstraint] = []
+        baseContraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|->=0-[view]-0-|",
+                                                         options: [], metrics: nil, views: ["view": self])
+        baseContraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|->=0-[view]->=0-|",
+                                                         options: [], metrics: nil, views: ["view": self])
+
+        if #available(OSX 10.10, *) {
+            NSLayoutConstraint.activate(baseContraints)
+        } else {
+            superview.addConstraints(baseContraints)
+        }
+
+        // Pin the view to the left side.
+        pin(to: .leadingEdge, of: superview)
+
+        startTrackingMouse(on: superview)
+    }
+
+    // If the status bar is removed from the view hierarchy, then the tracking
+    // area must be removed too.
+    override func viewWillMove(toSuperview newSuperview: NSView?) {
+        if let superview = superview {
+            stopTrackingMouse(on: superview)
+
+            isShown = false
+            position = nil
+        }
+    }
+
+    // MARK: Pinning the status bar
+
+    private enum Position {
+        case leadingEdge, trailingEdge
+    }
+
+    private var position: Position?
+
+    private var leadingConstraints: [NSLayoutConstraint]?
+    private var trailingConstraints: [NSLayoutConstraint]?
+
+    // The status bar is pinned simply by setting and unsetting constraints.
+    private func pin(to position: Position, of positioningView: NSView) {
+        guard position != self.position else {
+            return
+        }
+
+        let oldConstraints: [NSLayoutConstraint]?
+        let newConstraints: [NSLayoutConstraint]
+        switch position {
+        case .leadingEdge:
+            oldConstraints = trailingConstraints
+
+            if let leadingConstraints = leadingConstraints {
+                newConstraints = leadingConstraints
+            } else {
+                let constraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[view]",
+                                                                 options: [], metrics: nil, views: ["view": self])
+                newConstraints = constraints
+                leadingConstraints = constraints
+            }
+        case .trailingEdge:
+            oldConstraints = leadingConstraints
+
+            if let trailingConstraints = trailingConstraints {
+                newConstraints = trailingConstraints
+            } else {
+                let constraints = NSLayoutConstraint.constraints(withVisualFormat: "H:[view]-0-|",
+                                                                 options: [], metrics: nil, views: ["view": self])
+                newConstraints = constraints
+                trailingConstraints = constraints
+            }
+        }
+
+        // Remove existing constraints.
+        if let oldConstraints = oldConstraints {
+            if #available(OSX 10.10, *) {
+                NSLayoutConstraint.deactivate(oldConstraints)
+            } else {
+                positioningView.removeConstraints(oldConstraints)
+            }
+        }
+
+        // Add new constraints.
+        if #available(OSX 10.10, *) {
+            NSLayoutConstraint.activate(newConstraints)
+        } else {
+            positioningView.addConstraints(newConstraints)
+        }
+
+        self.position = position
+    }
+
+    // MARK: Handling status updates
+
+    /// The label to show. Setting this property will show or hide the status
+    /// bar. It will remain visible until the label is set to `nil`.
+    var label: String? {
+        didSet {
+            // This closure is meant to be called very often. It should not
+            // cause any expensive computations.
+            if let label = label, !label.isEmpty {
+                if label != addressField.stringValue {
+                    addressField.stringValue = label
+                }
+
+                isShown = true
+            } else {
+                isShown = false
+            }
+        }
+    }
+
+    private var isShown = false {
+        didSet {
+            guard isShown != oldValue else {
+                return
+            }
+
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = 0.4
+
+                backgroundView.animator().alphaValue = isShown ? 1 : 0
+            })
+        }
+    }
+
+    // MARK: Setting up mouse tracking
+
+    private var trackingArea: NSTrackingArea?
+
+    private func startTrackingMouse(on trackingView: NSView) {
+        if let trackingArea = self.trackingArea, trackingView.trackingAreas.contains(trackingArea) {
+            return
+        }
+
+        let rect = trackingView.bounds
+        let size = CGSize(width: rect.maxX, height: frame.height + 15)
+        let origin = CGPoint(x: rect.minX, y: rect.minY)
+
+        let trackingArea = NSTrackingArea(rect: NSRect(origin: origin, size: size),
+                                          options: [.mouseEnteredAndExited, .mouseMoved,
+                                                    .activeInKeyWindow],
+                                          owner: self, userInfo: nil)
+        self.trackingArea = trackingArea
+
+        trackingView.addTrackingArea(trackingArea)
+    }
+
+    // Remove the tracking area and unset the reference.
+    private func stopTrackingMouse(on trackingView: NSView) {
+        if let trackingArea = trackingArea {
+            trackingView.removeTrackingArea(trackingArea)
+            self.trackingArea = nil
+        }
+    }
+
+    // This method is called often, thus only change the tracking area when
+    // the superview's bounds width and the tracking area's width do not match.
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+
+        guard let superview = superview, let trackingArea = trackingArea else {
+            return
+        }
+
+        if superview.trackingAreas.contains(trackingArea), trackingArea.rect.width != superview.bounds.width {
+            stopTrackingMouse(on: superview)
+            startTrackingMouse(on: superview)
+        }
+    }
+
+    // MARK: Responding to mouse movement
+
+    private var widthConstraint: NSLayoutConstraint?
+
+    // Once the mouse enters the tracking area, the width of the status bar
+    // should shrink. This is done by adding a width constraint.
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+
+        guard let superview = superview, event.trackingArea == trackingArea else {
+            return
+        }
+
+        // Add the width constraint, if not already added.
+        if widthConstraint == nil {
+            let widthConstraint = NSLayoutConstraint(item: self, attribute: .width, relatedBy: .lessThanOrEqual,
+                                                     toItem: nil, attribute: .notAnAttribute, multiplier: 1,
+                                                     constant: superview.bounds.midX - 8)
+            self.widthConstraint = widthConstraint
+
+            if #available(OSX 10.10, *) {
+                widthConstraint.isActive = true
+            } else {
+                addConstraint(widthConstraint)
+            }
+        }
+    }
+
+    // Pin the status bar to the side, opposite of the mouse's position.
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+
+        guard let superview = superview else {
+            return
+        }
+
+        // Map the mouse location to the superview's bounds.
+        let point = superview.convert(event.locationInWindow, from: nil)
+
+        if point.x <= superview.bounds.midX {
+            pin(to: .trailingEdge, of: superview)
+        } else {
+            pin(to: .leadingEdge, of: superview)
+        }
+    }
+
+    // Once the mouse exits the tracking area, the status bar's intrinsic width
+    // should be restored, by removing the width constraint and pinning the view
+    // back to the left side.
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+
+        guard let superview = superview, event.trackingArea == trackingArea else {
+            return
+        }
+
+        pin(to: .leadingEdge, of: superview)
+
+        if let constraint = widthConstraint {
+            removeConstraint(constraint)
+
+            // Delete the constraint to make sure that a new one is created,
+            // appropriate for the superview size (which may change).
+            widthConstraint = nil
+        }
+    }
+
+}

--- a/src/UnifiedDisplayView.m
+++ b/src/UnifiedDisplayView.m
@@ -174,16 +174,6 @@
 	return alertResponse == NSAlertFirstButtonReturn;
 }
 
-/* setStatusText
- * Called from the webview when some JavaScript writes status text. Echo this to
- * our status bar.
- */
--(void)webView:(WebView *)sender setStatusText:(NSString *)text
-{
-	if (controller.browserView.activeTabItemView == self)
-		[controller setStatusMessage:text persist:NO];
-}
-
 /* mouseDidMoveOverElement
  * Called from the webview when the user positions the mouse over an element. If it's a link
  * then echo the URL to the status bar like Safari does.

--- a/src/UnifiedDisplayView.m
+++ b/src/UnifiedDisplayView.m
@@ -33,6 +33,7 @@
 #import "BrowserView.h"
 #import "TableViewExtensions.h"
 #import "Database.h"
+#import "Vienna-Swift.h"
 
 #define LISTVIEW_CELL_IDENTIFIER		@"ArticleCellView"
 // 300 seems a reasonable value to avoid calculating too many frames before being able to update display
@@ -42,6 +43,8 @@
 #define YPOS_IN_CELL	2.0
 
 @interface UnifiedDisplayView ()
+
+@property (nonatomic) OverlayStatusBar *statusBar;
 
 -(void)initTableView;
 -(void)handleReadingPaneChange:(NSNotificationCenter *)nc;
@@ -120,6 +123,9 @@
 	[articleList setDelegate:self];
 	[articleList setDataSource:self];
     [articleList accessibilitySetOverrideValue:NSLocalizedString(@"Articles", nil) forAttribute:NSAccessibilityDescriptionAttribute];
+
+    self.statusBar = [OverlayStatusBar new];
+    [articleList.enclosingScrollView addSubview:self.statusBar];
 }
 
 /* dealloc
@@ -178,10 +184,10 @@
  * Called from the webview when the user positions the mouse over an element. If it's a link
  * then echo the URL to the status bar like Safari does.
  */
--(void)webView:(WebView *)sender mouseDidMoveOverElement:(NSDictionary *)elementInformation modifierFlags:(NSUInteger)modifierFlags
-{
-	NSURL * url = [elementInformation valueForKey:@"WebElementLinkURL"];
-	[controller setStatusMessage:(url ? url.absoluteString : @"") persist:NO];
+- (void)webView:(WebView *)sender mouseDidMoveOverElement:(NSDictionary *)elementInformation
+  modifierFlags:(NSUInteger)modifierFlags {
+    NSURL *url = [elementInformation valueForKey:@"WebElementLinkURL"];
+    self.statusBar.label = url.absoluteString;
 }
 
 /* contextMenuItemsForElement


### PR DESCRIPTION
This PR adds a new OverlayStatusBar class that replaces the status-bar functionality lost in #930. It is mimicked after Safari's status bar. The implementation is an NSView that is meant to be added as a subview to another view. The only thing that needs to be done is setting (_and_ clearing) the `label`. It was specifically made for `webView(_:mouseDidMoveOverElement:modifierFlags:)`.

The status bar is attached to the bottom of the view and will track mouse movements. If the pointer gets too close to the bottom, then the bar shrinks and flips to the other side of the view.

I have tried my best to make the functionality stable and efficient, to avoid performance penalties. However, I would appreciate if you can thoroughly test it.

This is how it looks in Sierra:
![screen shot 2017-07-10 at 21 05 23](https://user-images.githubusercontent.com/15073177/28035068-866d695a-65b3-11e7-83aa-a35bd0b35e72.png)
![screen shot 2017-07-10 at 21 07 34](https://user-images.githubusercontent.com/15073177/28035517-2ee51f50-65b5-11e7-910c-83df31c52f3e.png)

This in Mavericks:
![screen shot 2017-07-11 at 22 52 23](https://user-images.githubusercontent.com/15073177/28117860-4b3156e6-670f-11e7-91e4-0f76da5947bb.png)

This status bar can be improved:
* The URL can be formatted. In Safari, the scheme and hostname are emphasised and the HTTP scheme is usually hidden (but not HTTPS). Safari also has custom messages for other schemes, such as `mailto:`, frames, and `rel` anchors.
* When the status bar gets too narrow, it should attempt to show the hostname, rather than truncating the middle part indiscriminately.

This PR also removes a couple of other status messages:
* The JavaScript `window.console` writes (`webview(_:setStatusText:`) have been mostly dropped from dedicated browsers (for good reasons, IMO).
* The progress indication when loading an article webpage is probably better implemented elsewhere to begin with. This is something I hope to address when refactoring the tab controller.

This still needs to be done:
- [x] Connect to User Defaults