### PR TITLE
Add SwiftLint support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,38 @@
+# SwiftLint 0.20.1
+
+included:
+  - src
+
+disabled_rules:
+  - line_length
+  - todo
+
+opt_in_rules:
+  - attributes
+  - closure_end_indentation
+  - closure_spacing
+  - conditional_returns_on_newline
+  - empty_count
+  - explicit_init
+#  - explicit_top_level_acl
+#  - explicit_type_interface
+  - extension_access_modifier
+  - fatal_error_message
+#  - file_header
+  - first_where
+  - force_unwrapping
+  - implicit_return
+  - implicitly_unwrapped_optional
+  - multiline_parameters
+  - nimble_operator
+#  - no_extension_access_modifier
+  - number_separator
+  - object_literal
+  - operator_usage_whitespace
+  - overridden_super_call
+  - private_outlet
+  - prohibited_super_call
+  - redundant_nil_coalescing
+  - sorted_imports
+  - switch_case_on_newline
+  - vertical_parameter_alignment_on_call

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: objective-c
 osx_image: xcode8.3
-xcode_workspace: Vienna.xcworkspace
-xcode_scheme: Vienna
 
-script: xcodebuild -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" test | xcpretty
+jobs:
+  include:
+    # testing
+    - script: xcodebuild -workspace Vienna.xcworkspace -scheme Vienna test | xcpretty
+
+    # linting
+    - before_script: swiftlint version
+      script: swiftlint --lenient --reporter emoji
 
 notifications:
   webhooks:
-      urls:
-      on_failure: always
-      on_start: never
-
-# for container-based infrastructure
-sudo: false
-# cache: cocoapods
+    urls:
+    on_failure: always
+    on_start: never

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -56,6 +56,17 @@
 			name = "Archive and Prep for Upload";
 			productName = Release;
 		};
+		F63B7CFF1F1BA146002F71BF /* SwiftLint */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = F63B7D031F1BA147002F71BF /* Build configuration list for PBXAggregateTarget "SwiftLint" */;
+			buildPhases = (
+				F63B7D041F1BA154002F71BF /* SwiftLint */,
+			);
+			dependencies = (
+			);
+			name = SwiftLint;
+			productName = Linting;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -1918,6 +1929,9 @@
 					8D15AC270486D014006FF6A4 = {
 						LastSwiftMigration = 0820;
 					};
+					F63B7CFF1F1BA146002F71BF = {
+						CreatedOnToolsVersion = 9.0;
+					};
 					F6A7DDC91E470E980017BE5E = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = 3T4TM2W828;
@@ -1964,6 +1978,7 @@
 				52BA63FC0DE9E2E10008B3E1 /* Version Notes */,
 				430C4AF71661F07C0079C9FC /* Code Sign ID */,
 				EAAF335414BDE402002A8837 /* Archive and Prep for Upload */,
+				F63B7CFF1F1BA146002F71BF /* SwiftLint */,
 			);
 		};
 /* End PBXProject section */
@@ -2242,6 +2257,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
 			shellScript = ". configs/scripts/Release-for-upload.sh";
+		};
+		F63B7D041F1BA154002F71BF /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --quiet\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			showEnvVarsInLog = 0;
 		};
 		F6B123401E474EC500973699 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3466,6 +3496,27 @@
 			};
 			name = Deployment;
 		};
+		F63B7D001F1BA147002F71BF /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Development;
+		};
+		F63B7D011F1BA147002F71BF /* Deployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Deployment;
+		};
+		F63B7D021F1BA147002F71BF /* StaticAnalyzer */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = StaticAnalyzer;
+		};
 		F6A7DDCD1E470E980017BE5E /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3686,6 +3737,16 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Deployment;
+		};
+		F63B7D031F1BA147002F71BF /* Build configuration list for PBXAggregateTarget "SwiftLint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F63B7D001F1BA147002F71BF /* Development */,
+				F63B7D011F1BA147002F71BF /* Deployment */,
+				F63B7D021F1BA147002F71BF /* StaticAnalyzer */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Development;
 		};
 		F6A7DDD01E470E980017BE5E /* Build configuration list for PBXNativeTarget "Vienna Help" */ = {
 			isa = XCConfigurationList;

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
@@ -62,12 +62,27 @@
                ReferencedContainer = "container:Vienna.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F63B7CFF1F1BA146002F71BF"
+               BuildableName = "SwiftLint"
+               BlueprintName = "SwiftLint"
+               ReferencedContainer = "container:Vienna.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -98,6 +113,7 @@
       buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/src/DirectoryMonitor.swift
+++ b/src/DirectoryMonitor.swift
@@ -67,7 +67,7 @@ final class DirectoryMonitor: NSObject {
             if #available(macOS 10.12, *) {
                 os_log("Restarting directory monitor", log: .default, type: .debug)
             } else {
-                NSLog("Restarting directory monitor");
+                NSLog("Restarting directory monitor")
             }
         }
 
@@ -170,7 +170,7 @@ enum DirectoryMonitorError: LocalizedError {
 
 private extension FSEventStreamRef {
 
-    init(allocator: CFAllocator? = kCFAllocatorDefault, callback: @escaping FSEventStreamCallback, context: UnsafeMutablePointer<FSEventStreamContext>? = nil, directories: [URL], startAt: FSEventStreamEventId = FSEventStreamEventId.now, latency: TimeInterval = 0, configuration: FileSystemEventStreamConfiguration = .none) throws {
+    init(allocator: CFAllocator? = kCFAllocatorDefault, callback: @escaping FSEventStreamCallback, context: UnsafeMutablePointer<FSEventStreamContext>? = nil, directories: [URL], startAt: FSEventStreamEventId = .now, latency: TimeInterval = 0, configuration: FileSystemEventStreamConfiguration = .none) throws {
         let directories = directories.map({ $0.path as CFString }) as CFArray
 
         if let stream = FSEventStreamCreate(allocator, callback, context, directories, startAt, latency, configuration.rawValue) {
@@ -180,7 +180,7 @@ private extension FSEventStreamRef {
         }
     }
 
-    func schedule(runLoop: RunLoop = RunLoop.current, runLoopMode: CFRunLoopMode = CFRunLoopMode.defaultMode!) {
+    func schedule(runLoop: RunLoop = .current, runLoopMode: CFRunLoopMode = .defaultMode) {
         FSEventStreamScheduleWithRunLoop(self, runLoop.getCFRunLoop(), runLoopMode.rawValue)
     }
 
@@ -238,7 +238,7 @@ private struct FileSystemEventStreamConfiguration: OptionSet {
     private static func flag(_ flag: Int) -> FileSystemEventStreamConfiguration {
         return self.init(rawValue: FSEventStreamCreateFlags(flag))
     }
-    
+
 }
 
 private enum FileSystemEventStreamError: Error {

--- a/src/ExportAccessoryViewController.swift
+++ b/src/ExportAccessoryViewController.swift
@@ -50,7 +50,8 @@ final class ExportAccessoryViewController: NSViewController {
 
     // MARK: Nested types
 
-    @objc enum ExportMode: Int {
+    @objc
+    enum ExportMode: Int {
         /// All feeds should be exported.
         case allFeeds
 

--- a/src/FilterView.swift
+++ b/src/FilterView.swift
@@ -21,6 +21,7 @@ import Cocoa
 
 final class FilterView: GradientView {
 
+    // swiftlint:disable private_outlet
     @IBOutlet private(set) var filterSearchField: NSSearchField!
     @IBOutlet private(set) var filterViewPopUp: NSPopUpButton!
 

--- a/src/MainWindowController.swift
+++ b/src/MainWindowController.swift
@@ -23,6 +23,7 @@ final class MainWindowController: NSWindowController {
 
     // MARK: Transitional outlets
 
+    // swiftlint:disable private_outlet
     @IBOutlet var outlineView: FolderView?
     @IBOutlet var browserView: BrowserView?
     @IBOutlet var articleListView: ArticleListView?
@@ -187,7 +188,7 @@ extension MainWindowController: NSToolbarDelegate {
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [String] {
         let firstIdentifiers = ["Subscribe", "PreviousButton", "NextButton",
-            "SkipFolder", "MarkAllItemsAsRead","Refresh", "MailLink", "EmptyTrash",
+            "SkipFolder", "MarkAllItemsAsRead", "Refresh", "MailLink", "EmptyTrash",
             "GetInfo", "Action", "Styles", "SearchItem"]
         let pluginIdentifiers = pluginManager?.toolbarItems ?? []
         let lastIdentifiers = [NSToolbarSpaceItemIdentifier, NSToolbarFlexibleSpaceItemIdentifier]
@@ -211,10 +212,8 @@ extension MainWindowController: NSMenuDelegate {
 
     // This method is presently only called for the style menu.
     func menuNeedsUpdate(_ menu: NSMenu) {
-        for menuItem in menu.items {
-            if menuItem.action == #selector(AppController.doSelectStyle(_:)) {
-                menu.removeItem(menuItem)
-            }
+        for menuItem in menu.items where menuItem.action == #selector(AppController.doSelectStyle(_:)) {
+            menu.removeItem(menuItem)
         }
 
         if let styles = (Array(ArticleView.loadStylesMap().keys) as? [String])?.sorted() {

--- a/src/OverlayStatusBar.swift
+++ b/src/OverlayStatusBar.swift
@@ -33,12 +33,12 @@ final class OverlayStatusBar: NSView {
     private var backgroundView: NSView = {
         let backgroundView: NSView
         if #available(OSX 10.10, *) {
-            let view = NSVisualEffectView(frame: NSZeroRect)
+            let view = NSVisualEffectView(frame: NSRect.zero)
             view.wantsLayer = true
             view.blendingMode = .withinWindow
             backgroundView = view
         } else {
-            backgroundView = NSView(frame: NSZeroRect)
+            backgroundView = NSView(frame: NSRect.zero)
             backgroundView.wantsLayer = true
             backgroundView.layer?.backgroundColor = CGColor(gray: 0, alpha: 0.65)
         }
@@ -54,7 +54,7 @@ final class OverlayStatusBar: NSView {
         if #available(macOS 10.12, *) {
             addressField = NSTextField(labelWithString: "")
         } else {
-            addressField = NSTextField(frame: NSZeroRect)
+            addressField = NSTextField(frame: NSRect.zero)
             addressField.isBezeled = false
             addressField.isSelectable = false
             addressField.drawsBackground = false
@@ -111,9 +111,9 @@ final class OverlayStatusBar: NSView {
 
         var addressFieldConstraints: [NSLayoutConstraint] = []
         addressFieldConstraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-2-[label]-2-|",
-                                                               metrics: nil, views: ["label": addressField])
+                                                                  metrics: nil, views: ["label": addressField])
         addressFieldConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-6-[label]-6-|",
-                                                               metrics: nil, views: ["label": addressField])
+                                                                  metrics: nil, views: ["label": addressField])
 
         if #available(OSX 10.10, *) {
             NSLayoutConstraint.activate(backgroundViewConstraints)

--- a/src/PluginToolbarItem.swift
+++ b/src/PluginToolbarItem.swift
@@ -27,7 +27,7 @@ final class PluginToolbarItem: ButtonToolbarItem {
     override init(itemIdentifier: String) {
         super.init(itemIdentifier: itemIdentifier)
 
-        let button = PluginToolbarItemButton(frame: NSMakeRect(0, 0, 41, 25))
+        let button = PluginToolbarItemButton(frame: NSRect(x: 0, y: 0, width: 41, height: 25))
         button.bezelStyle = .texturedRounded
         button.toolbarItem = self
         view = button


### PR DESCRIPTION
This adds support for [SwiftLint](https://github.com/realm/SwiftLint). I created a new build target for this, which I added to the Vienna scheme. Travis will also check it, but not cause any build failures.

I opted into almost all rules, except a couple that I think are too stringent or limiting. I commented those out. In a nutshell, these pertain to explicit type declarations (Swift infers types) and explicit access modifiers.