### PR TITLE
General Preferences - Standardise download location path

### DIFF
--- a/src/Preferences.m
+++ b/src/Preferences.m
@@ -27,8 +27,6 @@
 // Initial paths
 NSString * MA_ApplicationSupportFolder = @"~/Library/Application Support/Vienna";
 NSString * MA_ScriptsFolder = @"~/Library/Scripts/Applications/Vienna";
-NSString * MA_EnclosureDownloadFolder = @"~/Desktop";
-NSString * MA_DefaultDownloadsFolder = @"~/Desktop";
 NSString * MA_DefaultStyleName = @"Default";
 NSString * MA_Database_Name = @"messages.db";
 NSString * MA_ImagesFolder_Name = @"Images";
@@ -272,7 +270,9 @@ static Preferences * _standardPreferences = nil;
 	defaultValues[MAPref_FilterMode] = @MA_Filter_All;
 	defaultValues[MAPref_MinimumFontSize] = @(MA_Default_MinimumFontSize);
 	defaultValues[MAPref_AutoExpireDuration] = @(MA_Default_AutoExpireDuration);
-	defaultValues[MAPref_DownloadsFolder] = MA_DefaultDownloadsFolder;
+    defaultValues[MAPref_DownloadsFolder] = [NSFileManager.defaultManager
+                                             URLsForDirectory:NSDesktopDirectory
+                                             inDomains:NSUserDomainMask].firstObject.absoluteString;
 	defaultValues[MAPref_ArticleSortDescriptors] = defaultArticleSortDescriptors;
 	defaultValues[MAPref_LastRefreshDate] = [NSDate distantPast];
 	defaultValues[MAPref_Layout] = @MA_Layout_Report;

--- a/src/Preferences/GeneralPreferencesViewController.m
+++ b/src/Preferences/GeneralPreferencesViewController.m
@@ -119,7 +119,7 @@
     [expireDuration selectItemAtIndex:[expireDuration indexOfItemWithTag:prefs.autoExpireDuration]];
     
     // Set download folder
-    [self updateDownloadsPopUp:prefs.downloadFolder];
+    [self updateDownloadsPopUp:prefs.downloadFolder.stringByStandardizingPath];
     
     // Set whether the application is shown in the menu bar
     showAppInMenuBar.state = prefs.showAppInStatusBar ? NSOnState : NSOffState;


### PR DESCRIPTION
This PR fixes the cosmetic issue of the icon in General Preferences being a generic icon after a default install of Vienna.
![screen shot 2017-07-11 at 20 30 41](https://user-images.githubusercontent.com/799345/28409691-ad32233c-6d7e-11e7-80b1-eba3beb7969b.png)

The cause of this was the default download location being set to `~/Desktop` which caused `[[NSWorkspace sharedWorkspace] iconForFile:downloadFolderPath];` to not be able to find a real icon. 

The path needed to be expanded so I chose to use `stringByStandardizingPath` instead of only `stringByExpandingTildeInPath` because `stringByStandardizingPath` expands the tilde as well as doing some other clean up. We rarely call this so the extra functionality provided by `stringByStandardizingPath` won't cause any performance impact.

![screen shot 2017-07-20 at 19 15 21](https://user-images.githubusercontent.com/799345/28410054-d53926c2-6d7f-11e7-8069-106c457dd6ed.png)

I chose to try to correct any path that was in the preferences instead of changing the initial path from `~/Desktop` because we don't know what value a user might try to this to using scripts etc and this might prevent problems in the future.  
