### PR TITLE
Cleanup base Localizable.strings file

### DIFF
--- a/Interfaces/Base.lproj/Localizable.strings
+++ b/Interfaces/Base.lproj/Localizable.strings
@@ -1,93 +1,14 @@
-/* No comment provided by engineer. */
-"%@ Info" = "%@ Info";
-
 /* Progress in bytes, e.g. 1 KB of 1 MB */
 "%@ of %@" = "%1$@ of %2$@";
 
-/* Number of bytes received, e.g. 1 MB received */
-"%@ received" = "%@ received";
-
 /* {existing authors},{new author name} */
 "%@, %@" = "%1$@, %2$@";
-
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d new articles retrieved";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d subscriptions successfully exported";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d subscriptions successfully imported";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d unread articles";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u articles";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u unread";
-
-/* No comment provided by engineer. */
-"(No title)" = "(No title)";
-
-/* No comment provided by engineer. */
-"(Untitled Feed)" = "(Untitled Feed)";
-
-/* No comment provided by engineer. */
-"A folder with that name already exists" = "A folder with that name already exists";
-
-/* No comment provided by engineer. */
-"A new plugin has been installed. It is now available from the menu and you can add it to the toolbar." = "A new plugin has been installed. It is now available from the menu and you can add it to the toolbar.";
-
-/* Toolbar item name for the Advanced preference pane */
-"Advanced" = "Advanced";
-
-/* No comment provided by engineer. */
-"After 2 Days" = "After 2 Days";
-
-/* No comment provided by engineer. */
-"After 2 Weeks" = "After 2 Weeks";
-
-/* No comment provided by engineer. */
-"After a Day" = "After a Day";
-
-/* No comment provided by engineer. */
-"After a Month" = "After a Month";
-
-/* No comment provided by engineer. */
-"After a Week" = "After a Week";
 
 /* Already subscribed body */
 "Already subscribed body" = "You are already subscribed to that feed";
 
 /* Already subscribed title */
 "Already subscribed title" = "Error";
-
-/* No comment provided by engineer. */
-"An error occurred when this feed was last refreshed" = "An error occurred when this feed was last refreshed";
-
-/* Toolbar item name for the Appearance preference pane */
-"Appearance" = "Appearance";
-
-/* No comment provided by engineer. */
-"AppleScript Error in '%@' script" = "AppleScript Error in '%@' script";
-
-/* No comment provided by engineer. */
-"Articles" = "Articles";
-
-/* No comment provided by engineer. */
-"Ascending" = "Ascending";
-
-/* No comment provided by engineer. */
-"Authenticating on Open Reader" = "Authenticating on Open Reader";
-
-/* Data field name visible in menu/article list/smart folder definition */
-"Author" = "Author";
-
-/* Title of a button on an alert
-   Title of a popup menu item */
-"Cancel" = "Cancel";
 
 /* No comment provided by engineer. */
 "Cannot create database folder text" = "Vienna was trying to create the folder \"%@\" but an error occurred. Check the permissions on the folders on the path specified.";
@@ -114,50 +35,10 @@
 "Cannot open export file message text" = "The specified export output file could not be created. Check that it is not locked and no other application is using it.";
 
 /* No comment provided by engineer. */
-"Cannot rename folder" = "Cannot rename folder";
-
-/* No comment provided by engineer. */
 "Clear" = "Clear Recent Searches";
 
 /* No comment provided by engineer. */
-"Click the Open button to open this file." = "Click the Open button to open this file.";
-
-/* No comment provided by engineer. */
-"Click the Play button to play this enclosure in iTunes." = "Click the Play button to play this enclosure in iTunes.";
-
-/* No comment provided by engineer. */
-"Connecting to %@" = "Connecting to %@";
-
-/* No comment provided by engineer. */
-"Connecting to Open Reader server to retrieve %@" = "Connecting to Open Reader server to retrieve %@";
-
-/* No comment provided by engineer. */
-"Copy Link to Clipboard" = "Copy Link to Clipboard";
-
-/* No comment provided by engineer. */
-"Copy Page Link to Clipboard" = "Copy Page Link to Clipboard";
-
-/* Copy URL */
-"Copy URL" = "Copy URL";
-
-/* No comment provided by engineer. */
 "Credentials Prompt" = "The subscription for \"%@\" requires a user name and password for access.";
-
-/* No comment provided by engineer. */
-"Database Upgrade" = "Database Upgrade";
-
-/* Data field name visible in menu/article list/smart folder definition */
-"Date" = "Date";
-
-/* Title of a button on an alert
-   Title of a menu item */
-"Delete" = "Delete";
-
-/* Title of a menu item */
-"Delete Article" = "Delete Article";
-
-/* No comment provided by engineer. */
-"Delete Open Reader RSS feed" = "Delete Open Reader RSS feed";
 
 /* No comment provided by engineer. */
 "Delete Open Reader RSS feed text" = "Unsubscribing from an Open Reader RSS feed will also remove your locally cached articles.";
@@ -172,13 +53,7 @@
 "Delete folder status" = "Deleting folder \"%@\"…";
 
 /* No comment provided by engineer. */
-"Delete group folder" = "Delete group folder";
-
-/* No comment provided by engineer. */
 "Delete group folder text" = "Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone.";
-
-/* No comment provided by engineer. */
-"Delete multiple folders" = "Delete multiple folders";
 
 /* No comment provided by engineer. */
 "Delete multiple folders text" = "Are you sure you want to delete all %d selected folders? This operation cannot be undone.";
@@ -190,49 +65,13 @@
 "Delete selected message text" = "This operation cannot be undone.";
 
 /* No comment provided by engineer. */
-"Delete smart folder" = "Delete smart folder";
-
-/* No comment provided by engineer. */
 "Delete smart folder text" = "Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search.";
-
-/* Data field name visible in smart folder definition */
-"Deleted" = "Deleted";
-
-/* Title of a menu item */
-"Delete…" = "Delete…";
-
-/* No comment provided by engineer. */
-"Descending" = "Descending";
-
-/* No comment provided by engineer. */
-"Do you really want to import the subscriptions from the specified OPML file?" = "Do you really want to import the subscriptions from the specified OPML file?";
-
-/* No comment provided by engineer. */
-"Download" = "Download";
-
-/* Title of a menu item */
-"Download Enclosure" = "Download Enclosure";
-
-/* Title of a menu item */
-"Download Enclosures" = "Download Enclosures";
-
-/* Notification title */
-"Download completed" = "Download completed";
-
-/* Notification title */
-"Download failed" = "Download failed";
 
 /* No comment provided by engineer. */
 "Downloads Running" = "One or more downloads are in progress";
 
 /* No comment provided by engineer. */
 "Downloads Running text" = "If you quit Vienna now, all downloads will stop.";
-
-/* Title of a menu item */
-"Edit…" = "Edit…";
-
-/* Title of a button on an alert */
-"Empty" = "Empty";
 
 /* No comment provided by engineer. */
 "Empty Trash message" = "Are you sure you want to delete the messages in the Trash folder permanently?";
@@ -244,106 +83,13 @@
 "Enclosure" = "Enclosure URL";
 
 /* No comment provided by engineer. */
-"Enter the URL here" = "Enter the URL here";
-
-/* No comment provided by engineer. */
-"Error" = "Error";
-
-/* No comment provided by engineer. */
 "Error importing subscriptions body" = "Cannot import the specified file. The file contents are not valid OPML XML format.";
 
 /* No comment provided by engineer. */
 "Error importing subscriptions title" = "Import error";
 
-/* No comment provided by engineer. */
-"Error loading script '%@'" = "Error loading script '%@'";
-
-/* No comment provided by engineer. */
-"Error parsing XML data in feed" = "Error parsing XML data in feed";
-
-/* No comment provided by engineer. */
-"Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
-
-/* No comment provided by engineer. */
-"Error retrieving RSS feed:" = "Error retrieving RSS feed:";
-
-/* No comment provided by engineer. */
-"Error: Feed not found!" = "Error: Feed not found!";
-
-/* No comment provided by engineer. */
-"External Browser" = "External Browser";
-
-/* No comment provided by engineer. */
-"Feed URL updated to %@" = "Feed URL updated to %@";
-
-/* No comment provided by engineer. */
-"Fetching Open Reader Subscriptions…" = "Fetching Open Reader Subscriptions…";
-
-/* Notification body */
-"File %@ downloaded" = "File %@ downloaded";
-
-/* Notification body */
-"File %@ failed to download" = "File %@ failed to download";
-
-/* No comment provided by engineer. */
-"Flag" = "Flag";
-
-/* Data field name visible in menu/smart folder definition */
-"Flagged" = "Flagged";
-
-/* Data field name visible in menu/article list/smart folder definition */
-"Folder" = "Folder";
-
-/* No comment provided by engineer. */
-"Folder image retrieved from %@" = "Folder image retrieved from %@";
-
-/* No comment provided by engineer. */
-"Folders" = "Folders";
-
-/* Title of a menu item */
-"Force Refresh Selected Subscriptions From Open Reader" = "Force Refresh Selected Subscriptions From Open Reader";
-
-/* No comment provided by engineer. */
-"Forcing Refresh subscriptions…" = "Forcing Refresh subscriptions…";
-
-/* Toolbar item name for the General preference pane */
-"General" = "General";
-
-/* Title of a menu item */
-"Get Info" = "Get Info";
-
-/* No comment provided by engineer. */
-"Go forward to the next page" = "Go forward to the next page";
-
-/* No comment provided by engineer. */
-"Got HTTP status 304 - No news from last check" = "Got HTTP status 304 - No news from last check";
-
-/* No comment provided by engineer. */
-"HTTP code %d reported from server" = "HTTP code %d reported from server";
-
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "HasEnclosure" = "Enclosure";
-
-/* Pseudo field name visible in article list */
-"Headlines" = "Headlines";
-
-/* No comment provided by engineer. */
-"Hide Filter Bar" = "Hide Filter Bar";
-
-/* Title of a menu item */
-"Hide Status Bar" = "Hide Status Bar";
-
-/* Title of a menu item */
-"Hide Toolbar" = "Hide Toolbar";
-
-/* Title of a button on an alert */
-"Import" = "Import";
-
-/* No comment provided by engineer. */
-"Import subscriptions from OPML file?" = "Import subscriptions from OPML file?";
-
-/* No comment provided by engineer. */
-"Improper infinitely looping URL redirect to %@" = "Improper infinitely looping URL redirect to %@";
 
 /* No comment provided by engineer. */
 "Invalid style body" = "The Default style will be used instead.";
@@ -352,67 +98,10 @@
 "Invalid style title" = "The style %@ appears to be missing or corrupted";
 
 /* No comment provided by engineer. */
-"JavaScript" = "JavaScript";
-
-/* No comment provided by engineer. */
-"Last Week" = "Last Week";
-
-/* Data field name visible in menu/article list */
-"Link" = "Link";
-
-/* No comment provided by engineer. */
-"Loading" = "Loading";
-
-/* No comment provided by engineer. */
-"Loading…" = "Loading…";
-
-/* No comment provided by engineer. */
 "Locate Text" = "A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine.";
 
 /* No comment provided by engineer. */
 "Locate Title" = "Cannot create the Vienna database";
-
-/* Title of a button on an alert */
-"Locate…" = "Locate…";
-
-/* Title of a menu item */
-"Mark All Articles as Read" = "Mark All Articles as Read";
-
-/* No comment provided by engineer. */
-"Mark All Read" = "Mark All Read";
-
-/* Title of a menu item */
-"Mark All Subscriptions as Read" = "Mark All Subscriptions as Read";
-
-/* Title of a menu item */
-"Mark Flagged" = "Mark Flagged";
-
-/* Title of a menu item */
-"Mark Read" = "Mark Read";
-
-/* No comment provided by engineer. */
-"Mark Unflagged" = "Mark Unflagged";
-
-/* Title of a menu item */
-"Mark Unread" = "Mark Unread";
-
-/* No comment provided by engineer. */
-"Marked Articles" = "Marked Articles";
-
-/* No comment provided by engineer. */
-"More Scripts…" = "More Scripts…";
-
-/* No comment provided by engineer. */
-"Move Folders" = "Move Folders";
-
-/* No comment provided by engineer. */
-"Never" = "Never";
-
-/* No comment provided by engineer. */
-"New Tab" = "New Tab";
-
-/* Notification title */
-"New articles retrieved" = "New articles retrieved";
 
 /* No comment provided by engineer. */
 "New style body" = "The style \"%@\" has been installed to your Styles folder and added to the Style menu.";
@@ -424,89 +113,7 @@
 "New unread articles retrieved" = "%d new unread articles retrieved";
 
 /* No comment provided by engineer. */
-"No" = "No";
-
-/* No comment provided by engineer. */
-"No articles in feed" = "No articles in feed";
-
-/* No comment provided by engineer. */
-"No new articles available" = "No new articles available";
-
-/* Title of a button on an alert */
-"OK" = "OK";
-
-/* Title of a popup menu item */
-"Open" = "Open";
-
-/* Title of a menu item */
-"Open Article Page" = "Open Article Page";
-
-/* No comment provided by engineer. */
-"Open Article Page in %@" = "Open Article Page in %@";
-
-/* Title of a menu item */
-"Open Article Page in External Browser" = "Open Article Page in External Browser";
-
-/* No comment provided by engineer. */
-"Open Frame" = "Open Frame";
-
-/* No comment provided by engineer. */
-"Open Image in %@" = "Open Image in %@";
-
-/* No comment provided by engineer. */
-"Open Image in New Tab" = "Open Image in New Tab";
-
-/* No comment provided by engineer. */
-"Open Link in %@" = "Open Link in %@";
-
-/* No comment provided by engineer. */
-"Open Link in New Tab" = "Open Link in New Tab";
-
-/* No comment provided by engineer. */
-"Open Page in %@" = "Open Page in %@";
-
-/* No comment provided by engineer. */
-"Open Reader Authentication Failed" = "Open Reader Authentication Failed";
-
-/* No comment provided by engineer. */
 "Open Reader Authentication Failed text" = "Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences.\nAlso check your network access.";
-
-/* No comment provided by engineer. */
-"Open Scripts Folder" = "Open Scripts Folder";
-
-/* Title of a menu item */
-"Open Subscription Home Page" = "Open Subscription Home Page";
-
-/* No comment provided by engineer. */
-"Open Subscription Home Page in %@" = "Open Subscription Home Page in %@";
-
-/* Title of a menu item */
-"Open Subscription Home Page in External Browser" = "Open Subscription Home Page in External Browser";
-
-/* No comment provided by engineer. */
-"Other" = "Other";
-
-/* No comment provided by engineer. */
-"Play" = "Play";
-
-/* No comment provided by engineer. */
-"Plugin installed" = "Plugin installed";
-
-/* Title of the Preferences window */
-"Preferences" = "Preferences";
-
-/* No comment provided by engineer. */
-"Queue" = "Queue";
-
-/* Title of a button on an alert */
-"Quit" = "Quit";
-
-/* Title of a button on an alert
-   Title of a menu item */
-"Quit Vienna" = "Quit Vienna";
-
-/* No comment provided by engineer. */
-"RSS Icon not found!" = "RSS Icon not found!";
 
 /* No comment provided by engineer. */
 "RSS Subscription Export Title" = "Export Completed";
@@ -514,134 +121,14 @@
 /* No comment provided by engineer. */
 "RSS Subscription Import Title" = "Import Completed";
 
-/* Data field name visible in menu/smart folder definition */
-"Read" = "Read";
-
-/* No comment provided by engineer. */
-"Recent Searches" = "Recent Searches";
-
-/* No comment provided by engineer. */
-"Recents" = "Recents";
-
-/* No comment provided by engineer. */
-"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";
-
-/* Title of a menu item */
-"Refresh All Subscriptions" = "Refresh All Subscriptions";
-
-/* Title of a menu item */
-"Refresh Selected Subscriptions" = "Refresh Selected Subscriptions";
-
-/* No comment provided by engineer. */
-"Refresh completed" = "Refresh completed";
-
-/* No comment provided by engineer. */
-"Refresh the current page" = "Refresh the current page";
-
-/* No comment provided by engineer. */
-"Refreshing folder images…" = "Refreshing folder images…";
-
-/* No comment provided by engineer. */
-"Refreshing subscriptions…" = "Refreshing subscriptions…";
-
-/* Title of a popup menu item */
-"Remove From List" = "Remove From List";
-
-/* Title of a menu item */
-"Rename…" = "Rename…";
-
-/* Title of a menu item */
-"Restore Article" = "Restore Article";
-
 /* No comment provided by engineer. */
 "Resubscribe" = "Resubscribe to Feed";
-
-/* No comment provided by engineer. */
-"Retrieving articles" = "Retrieving articles";
-
-/* No comment provided by engineer. */
-"Retrieving folder image" = "Retrieving folder image";
-
-/* No comment provided by engineer. */
-"Retrieving folder image for Open Reader Feed" = "Retrieving folder image for Open Reader Feed";
-
-/* No comment provided by engineer. */
-"Return to the previous page" = "Return to the previous page";
-
-/* No comment provided by engineer. */
-"Search Results" = "Search Results";
-
-/* Placeholder title of a search field */
-"Search all articles" = "Search all articles";
-
-/* No comment provided by engineer. */
-"Search all articles or the current web page" = "Search all articles or the current web page";
-
-/* Placeholder title of a search field */
-"Search current web page" = "Search current web page";
 
 /* No comment provided by engineer. */
 "Search in %@" = "Filter in %@";
 
 /* No comment provided by engineer. */
-"Select…" = "Select…";
-
-/* No comment provided by engineer. */
-"Send Link" = "Send Link";
-
-/* No comment provided by engineer. */
-"Send Links" = "Send Links";
-
-/* No comment provided by engineer. */
-"Show Filter Bar" = "Show Filter Bar";
-
-/* Title of a menu item */
-"Show Main Window…" = "Show Main Window…";
-
-/* Title of a menu item */
-"Show Status Bar" = "Show Status Bar";
-
-/* Title of a menu item */
-"Show Toolbar" = "Show Toolbar";
-
-/* Title of a popup menu item */
-"Show in Finder" = "Show in Finder";
-
-/* Data field name visible in menu/article list/smart folder definition */
-"Subject" = "Subject";
-
-/* No comment provided by engineer. */
-"Subscribe to the feed for this page" = "Subscribe to the feed for this page";
-
-/* Pseudo field name visible in menu/article list */
-"Summary" = "Summary";
-
-/* Toolbar item name for the Syncing preference pane */
-"Syncing" = "Syncing";
-
-/* Data field name visible in smart folder definition */
-"Text" = "Text";
-
-/* No comment provided by engineer. */
-"This article contains an enclosed file." = "This article contains an enclosed file.";
-
-/* No comment provided by engineer. */
-"Today" = "Today";
-
-/* No comment provided by engineer. */
 "Today's Articles" = "Today’s Articles";
-
-/* No comment provided by engineer. */
-"Trash" = "Trash";
-
-/* URL */
-"URL" = "URL";
-
-/* No comment provided by engineer. */
-"Unread" = "Unread";
-
-/* No comment provided by engineer. */
-"Unread Articles" = "Unread Articles";
 
 /* No comment provided by engineer. */
 "Unrecognised database format text" = "The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.";
@@ -651,9 +138,6 @@
 
 /* No comment provided by engineer. */
 "Unsubscribe" = "Unsubscribe from Feed";
-
-/* Title of a button on an alert */
-"Upgrade Database" = "Upgrade Database";
 
 /* No comment provided by engineer. */
 "Vienna cannot open the file body" = "Vienna cannot open the file \"%@\" because it moved since you downloaded it.";
@@ -669,58 +153,3 @@
 
 /* No comment provided by engineer. */
 "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconveninece." = "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconvenience.";
-
-/* No comment provided by engineer. */
-"Yes" = "Yes";
-
-/* No comment provided by engineer. */
-"Yesterday" = "Yesterday";
-
-/* rule for association of multiple criteria */
-"all" = "all";
-
-/* rule for association of multiple criteria */
-"any" = "any";
-
-/* test for a string */
-"contains" = "contains";
-
-/* test for a string */
-"does not contain" = "does not contain";
-
-/* test for a value */
-"is" = "is";
-
-/* test for a date */
-"is after" = "is after";
-
-/* test for a date */
-"is before" = "is before";
-
-/* test for a numeric value */
-"is greater than" = "is greater than";
-
-/* test for a numeric value */
-"is greater than or equal to" = "is greater than or equal to";
-
-/* test for a numeric value */
-"is less than" = "is less than";
-
-/* test for a numeric value */
-"is less than or equal to" = "is less than or equal to";
-
-/* test for a value */
-"is not" = "is not";
-
-/* test for a date */
-"is on or after" = "is on or after";
-
-/* test for a date */
-"is on or before" = "is on or before";
-
-/* test for a folder (not operational as of Vienna 3.2) */
-"not under" = "not under";
-
-/* test for a folder (not operational as of Vienna 3.2) */
-"under" = "under";
-

--- a/Interfaces/Base.lproj/Localizable.strings
+++ b/Interfaces/Base.lproj/Localizable.strings
@@ -1,458 +1,726 @@
-"Mark Read" = "Mark Read";
-"Mark Unread" = "Mark Unread";
-"Mark Unflagged" = "Mark Unflagged";
-"Articles" = "Articles";
-"Folders" = "Folders";
-"Loading %@…" = "Loading %@…";
-"Completed" = "Completed";
-"Refresh RSS feeds" = "Refresh subscriptions";
-"Refresh All Subscriptions" = "Refresh All Subscriptions";
-"Already subscribed title" = "Error";
-"Already subscribed body" = "You are already subscribed to that feed";
-"RSS Subscription Import Title" = "Import Completed";
-"%d subscriptions successfully imported" = "%d subscriptions successfully imported";
-"RSS Subscription Export Title" = "Export Completed";
-"%d subscriptions successfully exported" = "%d subscriptions successfully exported";
-"New unread articles retrieved" = "%d new unread articles retrieved";
-"Growl refresh completed" = "New articles retrieved";
-"New articles retrieved" = "New articles retrieved";
-"(Untitled Feed)" = "(Untitled Feed)";
-"Open Link in Browser" = "Open Link in Browser";
-"Copy Link to Clipboard" = "Copy Link to Clipboard";
-"Refresh completed" = "Refresh completed";
-"Retrieving articles" = "Retrieving articles";
-"ClearButton" = "Clear";
-"Read" = "Read";
-"Flagged" = "Flagged";
-"Comments" = "Comments";
-"Parent" = "Parent";
-"Number" = "Number";
-"Subject" = "Subject";
-"Folder" = "Folder";
-"Date" = "Date";
-"Author" = "Author";
-"Text" = "Text";
-"Headlines" = "Headlines";
-"Link" = "Link";
-"Deleted" = "Deleted";
-"GUID" = "GUID";
-"No" = "No";
-"Yes" = "Yes";
-"Version %@" = "Version %@";
-"Refresh All" = "Refresh All";
-"Subscribe" = "Subscribe";
-"Smart Folder" = "Smart Folder";
-"Flag" = "Flag";
-"Next Unread" = "Next Unread";
-"Noon" = "Noon";
-"Midnight" = "Midnight";
-"Today" = "Today";
-"Yesterday" = "Yesterday";
-"Tomorrow" = "Tomorrow";
-"%@ at %@" = "%@ at %@";
-"Quit" = "Quit";
-"Refresh cancelled" = "Refresh cancelled";
-"Additional actions for the selected folder" = "Additional actions for the selected folder";
-"Create a new subscription" = "Create a new subscription";
-"Refresh all your subscriptions" = "Refresh all your subscriptions";
-"New style title" = "Vienna has installed a new style";
-"New style body" = "The style \"%@\" has been installed to your Styles folder and added to the Style menu.";
-"More Styles…" = "More Styles…";
-"Delete selected message" = "Are you sure you want to permanently delete the selected articles?";
-"Delete selected message text" = "This operation cannot be undone.";
-"Cancel" = "Cancel";
-"OK" = "OK";
-"From" = "From";
-"To" = "To";
-"(No title)" = "(No title)";
-"Refreshing folder images…" = "Refreshing folder images…";
-"Refreshing subscriptions…" = "Refreshing subscriptions…";
-"Authenticating with user name '%@'" = "Authenticating with user name \"%@\"";
-"No new articles available" = "No new articles available";
-"%d new articles retrieved" = "%d new articles retrieved";
-"HTTP code %d reported from server" = "HTTP code %d reported from server";
-"Headers:\n" = "Headers:\n";
-"Connection error (%d, %@):\n" = "Connection error (%d, %@):\n";
-"\tDescription: %@\n" = "\tDescription: %@\n";
-"\tSuggestion: %@\n" = "\tSuggestion: %@\n";
-"\tCause: %@\n" = "\tCause: %@\n";
-"Article feed will be compressed" = "Article feed will be compressed";
-"Redirecting to %@" = "Redirecting to %@";
-"Error: %@" = "Error: %@";
-"Error" = "Error";
-"Credentials Prompt" = "The subscription for \"%@\" requires a user name and password for access.";
-"%ld bytes received" = "%ld bytes received";
-"Authentication failed for user '%@'" = "Authentication failed for user \"%@\"";
-"Error parsing XML data in feed" = "Error parsing XML data in feed";
-"Retrieving folder image" = "Retrieving folder image";
-"Folder image retrieved from %@" = "Folder image retrieved from %@";
-"Contacting…" = "Contacting…";
-"Connect Running" = "A connection is in progress";
-"Connect Running text" = "Do you want to stop the connection and close Vienna now?";
-"Delete group folder" = "Delete group folder";
-"Delete group folder text" = "Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone.";
-"Delete smart folder" = "Delete smart folder";
-"Delete smart folder text" = "Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search.";
-"Delete RSS feed text" = "Are you sure you want to unsubscribe from \"%@\"? This operation will delete all cached articles.";
-"Delete RSS feed" = "Delete subscription";
-"Delete multiple folders text" = "Are you sure you want to delete all %d selected folders? This operation cannot be undone.";
-"Delete multiple folders" = "Delete multiple folders";
-"Delete folder status" = "Deleting folder \"%@\"…";
-"An error has occurred" = "An error has occurred.";
-"Your software is up to date" = "Your version of Vienna is up to date.";
-"Please try again later" = "Please try again later.";
-"An update is now available" = "An update is now available";
-"Update available text" = "Version %@ of Vienna is available from:\n\n%@\n\nWould you like to download it now? If you choose not to download it now, you can download it later by choosing Check For Updates again.";
-"any" = "any";
-"all" = "all";
-"Open Scripts Folder" = "Open Scripts Folder";
-"Cannot create database folder title" = "Sorry, but Vienna was unable to create the database folder";
-"Cannot create database folder text" = "Vienna was trying to create the folder \"%@\" but an error occurred. Check the permissions on the folders on the path specified.";
-"Unrecognised database format title" = "The database file format has changed";
-"Unrecognised database format text" = "The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.";
-"Upgrade Title" = "Database Upgrade";
-"Upgrade Text" = "Your existing database needs to be upgraded to work with this build of Vienna. Alternatively you can elect to start with a new, empty database. In either case, your existing database will be backed up to %@. The new or upgraded database will NOT work with earlier versions of Vienna.\n\nNote: for this build, it is suggested that you start with a new database for simplicity.\n";
-"New Database" = "New Database";
-"Upgrade" = "Upgrade";
-"Exit" = "Exit";
-"Search in %@" = "Filter in %@";
-"Marked Articles" = "Marked Articles";
-"Unread Articles" = "Unread Articles";
-"Today's Articles" = "Today’s Articles";
-"Trash" = "Trash";
-"Select…" = "Select…";
-" (%d unread)" = " (%d unread)";
-"is" = "is";
-"is not" = "is not";
-"is after" = "is after";
-"is before" = "is before";
-"is on or after" = "is on or after";
-"is on or before" = "is on or before";
-"contains" = "contains";
-"does not contain" = "does not contain";
-"is less than" = "is less than";
-"is greater than" = "is greater than";
-"is less than or equal to" = "is less than or equal to";
-"is greater than or equal to" = "is greater than or equal to";
-"Cannot open export file message" = "Cannot create export output file";
-"Cannot open export file message text" = "The specified export output file could not be created. Check that it is not locked and no other application is using it.";
-"Source" = "Source";
-"Status" = "Status";
-"Enter LiveJournal User name" = "Enter LiveJournal User name";
-"Enter MSN Spaces User name" = "Enter MSN Spaces User name";
-"Enter Blogspot User name" = "Enter Blogspot User name";
-"Enter Xanga User name" = "Enter Xanga User name";
-"Enter URL of RSS feed" = "Enter URL of news feed";
-"Cannot rename folder" = "Cannot rename folder";
-"A folder with that name already exists" = "A folder with that name already exists";
-"Recent Searches" = "Recent Searches";
-"Recents" = "Recents";
-"Clear" = "Clear Recent Searches";
-"Search web page" = "Search web page";
-"Loading…" = "Loading…";
-"Open Image in New Tab" = "Open Image in New Tab";
-"Open Link in New Tab" = "Open Link in New Tab";
-"Open Link in %@" = "Open Link in %@";
-"Open Page in %@" = "Open Page in %@";
-"Copy Page Link to Clipboard" ="Copy Page Link to Clipboard";
-"%d unread articles" = "%d unread articles";
-"More Scripts…" = "More Scripts…";
-"Install Update" = "Install Update";
-"Do Not Install" = "Do Not Install";
-"Replace smart folder title" = "A smart folder named %@ already exists";
-"Replace smart folder text" = "Do you want to replace the existing smart folder with the criteria you have defined here?";
-"Replace" = "Replace";
-"Never" = "Never";
-"After a Day" = "After a Day";
-"After 2 Days" = "After 2 Days";
-"After a Week" = "After a Week";
-"After 2 Weeks" = "After 2 Weeks";
-"After a Month" = "After a Month";
-"Last Week" = "Last Week";
-"2 Weeks Ago" = "2 Weeks Ago";
-"A month" = "A month";
-"Activity Window" = "Activity Window";
-"Error importing subscriptions body" = "Cannot import the specified file. The file contents are not valid OPML XML format.";
-"Error importing subscriptions title" = "Import error";
-"Rename" = "Rename";
-"Mark All Read" = "Mark All Read";
-"Move Folders" = "Move Folders";
-"Downloads" = "Downloads";
-"Invalid style title" = "The style %@ appears to be missing or corrupted";
-"Invalid style body" = "The Default style will be used instead.";
-"Downloads Running" = "One or more downloads are in progress";
-"Downloads Running text" = "If you quit Vienna now, all downloads will stop.";
-"Mark All Subscriptions as Read" = "Mark All Subscriptions as Read";
-"Preferences" = "Preferences";
-"General" = "General";
-"Appearance" = "Appearance";
-"Locate Title" = "Cannot create the Vienna database";
-"Locate Text" = "A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine.";
-"Empty Trash message" = "Are you sure you want to delete the messages in the Trash folder permanently?";
-"Empty Trash message text" = "You cannot undo this action";
-"Cannot open database title" = "Sorry but Vienna was unable to open the database";
-"Cannot open database text" = "The database file (%@) could not be opened for some reason. It may be corrupted or inaccessible. Please delete or rename the database file and restart Vienna.";
-"Vienna cannot open the file title" = "Vienna cannot open the file.";
-"Vienna cannot open the file body" = "Vienna cannot open the file \"%@\" because it moved since you downloaded it.";
-"Vienna cannot show the file title" = "Vienna cannot show the file.";
-"Vienna cannot show the file body" = "Vienna cannot show the file \"%@\" because it moved since you downloaded it.";
-"Empty" = "Empty";
-"Open" = "Open";
-"Show in Finder" = "Show in Finder";
-"Remove From List" = "Remove from list";
-"%.1f MB" = "%.1f MB";
-"%.1f KB" = "%.1f KB";
-"%.1f bytes" = "%.1f bytes";
-"%.1f of %.1f MB" = "%.1f of %.1f MB";
-"%.1f of %.1f KB" = "%.1f of %.1f KB";
-"%.1f of %.1f bytes" = "%.1f of %.1f bytes";
-"An error occurred when this feed was last refreshed" = "An error occurred when this feed was last refreshed";
-"Connecting to %@" = "Connecting to %@";
-"About Vienna" = "About Vienna";
-"Acknowledgements" = "Acknowledgements";
-"Article" = "Article";
-"Back" = "Back";
-"Bring All to Front" = "Bring All to Front";
-"Check Spelling" = "Check Spelling";
-"Check Spelling as You Type" = "Check Spelling as You Type";
-"Check for Updates" = "Check for Updates";
-"Close All Tabs" = "Close All Tabs";
-"Close Tab" = "Close Tab";
-"Close Window" = "Close Window";
-"Columns" = "Columns";
-"Copy" = "Copy";
-"Cut" = "Cut";
-"Delete" = "Delete";
-"Delete Article" = "Delete Article";
-"Delete…" = "Delete…";
-"Edit" = "Edit";
-"Edit…" = "Edit…";
-"Empty Trash" = "Empty Trash";
-"Export Subscriptions…" = "Export Subscriptions…";
-"File" = "File";
-"Find" = "Find";
-"Find Next" = "Find Next";
-"Find Previous" = "Find Previous";
-"Find…" = "Find…";
-"Forward" = "Forward";
-"Help" = "Help";
-"Hide Others" = "Hide Others";
-"Hide Vienna" = "Hide Vienna";
-"Import Subscriptions…" = "Import Subscriptions…";
-"Jump to Selection" = "Jump to Selection";
-"Main Window" = "Main Window";
-"MainMenu" = "MainMenu";
-"Mark All Articles as Read" = "Mark All Articles as Read";
-"Mark Flagged" = "Mark Flagged";
-"Minimize" = "Minimize";
-"New Group Folder…" = "New Group Folder…";
-"New Smart Folder…" = "New Smart Folder…";
-"New Subscription…" = "New Subscription…";
-"Next Tab" = "Next Tab";
-"Open Article Page" = "Open Article Page";
-"Open Article Page in External Browser" = "Open Article Page in External Browser";
-"Open Subscription Home Page" = "Open Subscription Home Page";
-"Open Subscription Home Page in External Browser" = "Open Subscription Home Page in External Browser";
-"Page Setup…" = "Page Setup…";
-"Paste" = "Paste";
-"Preferences…" = "Preferences…";
-"Previous Tab" = "Previous Tab";
-"Print…" = "Print…";
-"Quit Vienna" = "Quit Vienna";
-"Redo" = "Redo";
-"Refresh Selected Subscriptions" = "Refresh Selected Subscriptions";
-"Reload Page" = "Reload Page";
-"Rename…" = "Rename…";
-"Restore Article" = "Restore Article";
-"Select All" = "Select All";
-"Services" = "Services";
-"Show All" = "Show All";
-"Skip Folder" = "Skip Folder";
-"Sort By" = "Sort By";
-"Spelling" = "Spelling";
-"Spelling…" = "Spelling…";
-"Stop Refreshing" = "Stop Refreshing";
-"Stop Reloading Page" = "Stop Reloading Page";
-"Style" = "Style";
-"Undo" = "Undo";
-"Use Selection for Find" = "Use Selection for Find";
-"Validate Feed" = "Validate Feed";
-"Vienna Help" = "Vienna Help";
-"Vienna Web Site" = "Vienna Web Site";
-"View" = "View";
-"Window" = "Window";
-"Zoom" = "Zoom";
-"Export all subscriptions" = "Export all subscriptions";
-"Export selected subscriptions" = "Export selected subscriptions";
-"Preserve group folders in exported file" = "Preserve group folders in exported file";
-"Open Frame" = "Open Frame";
-"Open Image in %@" = "Open Image in %@";
-"Open Subscription Home Page in %@" = "Open Subscription Home Page in %@";
-"Open Article Page in %@" = "Open Article Page in %@";
-"New Tab" = "New Tab";
-"External Browser" = "External Browser";
-
-/* Added in 2.1.0 */
-"Send Link" = "Send Link";
-"Send Links" = "Send Links";
-"Increase Font Size" = "Increase Font Size";
-"Decrease Font Size" = "Decrease Font Size";
-"Enter the URL here" = "Enter the URL here";
-"Refresh the current page" = "Refresh the current page";
-"Return to the previous page" = "Return to the previous page";
-"Go forward to the next page" = "Go forward to the next page";
-"Layout" = "Layout";
-"Reading Pane on Right" = "Reading Pane on Right";
-"Reading Pane at Bottom" = "Reading Pane at Bottom";
-"Filter By" = "Filter By";
-"Filter by:" = "Filter by:";
-"All" = "All";
-"All Articles" = "All Articles";
-"Unread" = "Unread";
-"Last Refresh" = "Last Refresh";
-"Feed URL updated to %@" = "Feed URL updated to %@";
-"Filter articles" = "Filter articles";
-"Feed has been removed by the server" = "Feed has been removed by the server";
-"Mark all articles read" = "Mark all articles read";
+/* No comment provided by engineer. */
 "%@ Info" = "%@ Info";
-"%u articles" = "%u articles";
-"%u unread" = "%u unread";
-"Keyboard Shortcuts" = "Keyboard Shortcuts";
-"%@ (Filtered: %@)" = "%@ (Filter: %@)";
-"Get Info…" = "Get Info…";
-"Open Web Location…" = "Open Web Location…";
-"Refresh Folder Images" = "Refresh Folder Images";
-"Report" = "Horizontal";
-"Condensed" = "Vertical";
-"Unified" =  "Unified";
-"Summary" = "Summary";
-"Blog With…" = "Blog With…";
-"Blog with %@" = "Blog with %@";
-"Bigger Text" = "Bigger Text";
-"Smaller Text" = "Smaller Text";
 
-/* Added in 2.1.1 */
+/* Progress in bytes, e.g. 1 KB of 1 MB */
+"%@ of %@" = "%1$@ of %2$@";
+
+/* Number of bytes received, e.g. 1 MB received */
+"%@ received" = "%@ received";
+
+/* {existing authors},{new author name} */
+"%@, %@" = "%1$@, %2$@";
+
+/* No comment provided by engineer. */
+"%d new articles retrieved" = "%d new articles retrieved";
+
+/* No comment provided by engineer. */
+"%d subscriptions successfully exported" = "%d subscriptions successfully exported";
+
+/* No comment provided by engineer. */
+"%d subscriptions successfully imported" = "%d subscriptions successfully imported";
+
+/* No comment provided by engineer. */
+"%d unread articles" = "%d unread articles";
+
+/* No comment provided by engineer. */
+"%u articles" = "%u articles";
+
+/* No comment provided by engineer. */
+"%u unread" = "%u unread";
+
+/* No comment provided by engineer. */
+"(No title)" = "(No title)";
+
+/* No comment provided by engineer. */
+"(Untitled Feed)" = "(Untitled Feed)";
+
+/* No comment provided by engineer. */
+"A folder with that name already exists" = "A folder with that name already exists";
+
+/* No comment provided by engineer. */
+"A new plugin has been installed. It is now available from the menu and you can add it to the toolbar." = "A new plugin has been installed. It is now available from the menu and you can add it to the toolbar.";
+
+/* Toolbar item name for the Advanced preference pane */
 "Advanced" = "Advanced";
 
-/* Added in 2.2.0 */
-"Import subscriptions from OPML file?" = "Import subscriptions from OPML file?";
-"Do you really want to import the subscriptions from the specified OPML file?" = "Do you really want to import the subscriptions from the specified OPML file?";
-"Import" = "Import";
-"HasEnclosure" = "Enclosure";
-"Enclosure" = "Enclosure URL";
-"Open New Tab" = "Open New Tab";
-"Subscribe to the feed for this page" = "Subscribe to the feed for this page";
-"Open Vienna" = "Open Vienna";
-"Download Enclosure" = "Download Enclosure";
-"Download Enclosures" = "Download Enclosures";
-"Local File" = "Local File";
-"Hide Status Bar" = "Hide Status Bar";
-"Show Status Bar" = "Show Status Bar";
-"Customize Toolbar…" = "Customize Toolbar…";
-"Search Articles" = "Search Articles";
-"Progress" = "Progress";
-"Delete all articles in the trash" = "Delete all articles in the trash";
-"Unsubscribe" = "Unsubscribe from Feed";
-"Resubscribe" = "Resubscribe to Feed";
-"Download" = "Download";
-"This article contains an enclosed file." = "This article contains an enclosed file.";
-"Growl download completed" = "File download successful";
-"Growl download failed" = "File download failed";
-"Download completed" = "Download completed";
-"File %@ downloaded" = "File %@ downloaded";
-"Download failed" = "Download failed";
-"File %@ failed to download" = "File %@ failed to download";
-"Play" = "Play";
-"Click the Play button to play this enclosure in iTunes." = "Click the Play button to play this enclosure in iTunes.";
-"Click the Open button to open this file." = "Click the Open button to open this file.";
-"Filter displayed articles by matching text" = "Filter displayed articles by matching text";
-"Close the filter bar" = "Close the filter bar";
-"Search all articles" = "Search all articles";
-"Search Results" = "Search Results";
-"Hide Filter Bar" = "Hide Filter Bar";
-"Show Filter Bar" = "Show Filter Bar";
-"Email a link to the current article or website" = "Email a link to the current article or website";
-"Refresh" = "Refresh";
-"Action" = "Action";
-"Get Info" = "Get Info";
-"See information about the selected subscription" = "See information about the selected subscription";
-"Display the list of available styles" = "Display the list of available styles";
+/* No comment provided by engineer. */
+"After 2 Days" = "After 2 Days";
 
-/* Added in 2.3.0 */
-"Order By" = "Order By";
-"Manual" = "Manual";
-"Name" = "Name";
+/* No comment provided by engineer. */
+"After 2 Weeks" = "After 2 Weeks";
 
-/*Added in 2.4*/
-"Show XML Source" = "Show XML Source";
-"Source of folder" = "Source of folder";
-"No feed source to display." = "No feed source to display.";
-"Search current web page" = "Search current web page";
-"Search all articles or the current web page" = "Search all articles or the current web page";
-"Database Upgrade" = "Database Upgrade";
-"Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconveninece." = "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconveninece.";
-"Upgrade Database" = "Upgrade Database";
+/* No comment provided by engineer. */
+"After a Day" = "After a Day";
 
-/* Added in 2.5.0 */
-"Cannot create folder title" = "Cannot create folder";
+/* No comment provided by engineer. */
+"After a Month" = "After a Month";
+
+/* No comment provided by engineer. */
+"After a Week" = "After a Week";
+
+/* Already subscribed body */
+"Already subscribed body" = "You are already subscribed to that feed";
+
+/* Already subscribed title */
+"Already subscribed title" = "Error";
+
+/* No comment provided by engineer. */
+"An error occurred when this feed was last refreshed" = "An error occurred when this feed was last refreshed";
+
+/* Toolbar item name for the Appearance preference pane */
+"Appearance" = "Appearance";
+
+/* No comment provided by engineer. */
+"AppleScript Error in '%@' script" = "AppleScript Error in '%@' script";
+
+/* No comment provided by engineer. */
+"Articles" = "Articles";
+
+/* No comment provided by engineer. */
+"Ascending" = "Ascending";
+
+/* No comment provided by engineer. */
+"Authenticating on Open Reader" = "Authenticating on Open Reader";
+
+/* Data field name visible in menu/article list/smart folder definition */
+"Author" = "Author";
+
+/* Title of a button on an alert
+   Title of a popup menu item */
+"Cancel" = "Cancel";
+
+/* No comment provided by engineer. */
+"Cannot create database folder text" = "Vienna was trying to create the folder \"%@\" but an error occurred. Check the permissions on the folders on the path specified.";
+
+/* No comment provided by engineer. */
+"Cannot create database folder title" = "Sorry, but Vienna was unable to create the database folder";
+
+/* No comment provided by engineer. */
 "Cannot create folder body" = "The \"%@\" folder cannot be created.";
 
-/* Added in 2.6.0 */
-"Article load completed" = "Article load completed";
-"Loading HTML article…" = "Loading HTML article…";
-"Ascending" = "Ascending";
-"Descending" = "Descending";
-"Use Current Style for Articles" = "Use Current Style for Articles";
-"Use Web Page for Articles" = "Use Web Page for Articles";
+/* No comment provided by engineer. */
+"Cannot create folder title" = "Cannot create folder";
 
-/* Added for Open Reader support */
-"Force Refresh Selected Subscriptions From Open Reader" = "Force Refresh Selected Subscriptions From Open Reader";
-"Update Subscriptions From Open Reader" = "Update Subscriptions From Open Reader";
-"Delete Open Reader RSS feed text" = "Unsubscribing from an Open Reader RSS feed will also remove your locally cached articles.";
+/* No comment provided by engineer. */
+"Cannot open database text" = "The database file (%@) could not be opened for some reason. It may be corrupted or inaccessible. Please delete or rename the database file and restart Vienna.";
+
+/* No comment provided by engineer. */
+"Cannot open database title" = "Sorry but Vienna was unable to open the database";
+
+/* No comment provided by engineer. */
+"Cannot open export file message" = "Cannot create export output file";
+
+/* No comment provided by engineer. */
+"Cannot open export file message text" = "The specified export output file could not be created. Check that it is not locked and no other application is using it.";
+
+/* No comment provided by engineer. */
+"Cannot rename folder" = "Cannot rename folder";
+
+/* No comment provided by engineer. */
+"Clear" = "Clear Recent Searches";
+
+/* No comment provided by engineer. */
+"Click the Open button to open this file." = "Click the Open button to open this file.";
+
+/* No comment provided by engineer. */
+"Click the Play button to play this enclosure in iTunes." = "Click the Play button to play this enclosure in iTunes.";
+
+/* No comment provided by engineer. */
+"Connecting to %@" = "Connecting to %@";
+
+/* No comment provided by engineer. */
+"Connecting to Open Reader server to retrieve %@" = "Connecting to Open Reader server to retrieve %@";
+
+/* No comment provided by engineer. */
+"Copy Link to Clipboard" = "Copy Link to Clipboard";
+
+/* No comment provided by engineer. */
+"Copy Page Link to Clipboard" = "Copy Page Link to Clipboard";
+
+/* Copy URL */
+"Copy URL" = "Copy URL";
+
+/* No comment provided by engineer. */
+"Credentials Prompt" = "The subscription for \"%@\" requires a user name and password for access.";
+
+/* No comment provided by engineer. */
+"Database Upgrade" = "Database Upgrade";
+
+/* Data field name visible in menu/article list/smart folder definition */
+"Date" = "Date";
+
+/* Title of a button on an alert
+   Title of a menu item */
+"Delete" = "Delete";
+
+/* Title of a menu item */
+"Delete Article" = "Delete Article";
+
+/* No comment provided by engineer. */
 "Delete Open Reader RSS feed" = "Delete Open Reader RSS feed";
 
-/* Added in 3.0.0 */
-"Last 48 hours" = "Last 48 hours";
-"Unread or flagged" = "Unread or flagged";
-"Syncing" = "Syncing";
-"Reindex Database" = "Reindex Database";
-"Other" = "Other";
-"Authenticating on Open Reader" = "Authenticating on Open Reader";
-"Connecting to Open Reader server to retrieve %@" = "Connecting to Open Reader server to retrieve %@";
-"Retrieving folder image for Open Reader Feed" = "Retrieving folder image for Open Reader Feed";
-"Fetching Open Reader Subscriptions…" = "Fetching Open Reader Subscriptions…";
-"Open Reader Authentication Failed" = "Open Reader Authentication Failed";
-"Open Reader Authentication Failed text" = "Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences.\nAlso check your network access.";
+/* No comment provided by engineer. */
+"Delete Open Reader RSS feed text" = "Unsubscribing from an Open Reader RSS feed will also remove your locally cached articles.";
 
-/* Added in 3.0.1 */
-"Plugin installed" = "Plugin installed";
-"A new plugin has been installed. It is now available from the menu and you can add it to the toolbar." = "A new plugin has been installed. It is now available from the menu and you can add it to the toolbar.";
+/* No comment provided by engineer. */
+"Delete RSS feed" = "Delete subscription";
+
+/* No comment provided by engineer. */
+"Delete RSS feed text" = "Are you sure you want to unsubscribe from \"%@\"? This operation will delete all cached articles.";
+
+/* No comment provided by engineer. */
+"Delete folder status" = "Deleting folder \"%@\"…";
+
+/* No comment provided by engineer. */
+"Delete group folder" = "Delete group folder";
+
+/* No comment provided by engineer. */
+"Delete group folder text" = "Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Delete multiple folders" = "Delete multiple folders";
+
+/* No comment provided by engineer. */
+"Delete multiple folders text" = "Are you sure you want to delete all %d selected folders? This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Delete selected message" = "Are you sure you want to permanently delete the selected articles?";
+
+/* No comment provided by engineer. */
+"Delete selected message text" = "This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Delete smart folder" = "Delete smart folder";
+
+/* No comment provided by engineer. */
+"Delete smart folder text" = "Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search.";
+
+/* Data field name visible in smart folder definition */
+"Deleted" = "Deleted";
+
+/* Title of a menu item */
+"Delete…" = "Delete…";
+
+/* No comment provided by engineer. */
+"Descending" = "Descending";
+
+/* No comment provided by engineer. */
+"Do you really want to import the subscriptions from the specified OPML file?" = "Do you really want to import the subscriptions from the specified OPML file?";
+
+/* No comment provided by engineer. */
+"Download" = "Download";
+
+/* Title of a menu item */
+"Download Enclosure" = "Download Enclosure";
+
+/* Title of a menu item */
+"Download Enclosures" = "Download Enclosures";
+
+/* Notification title */
+"Download completed" = "Download completed";
+
+/* Notification title */
+"Download failed" = "Download failed";
+
+/* No comment provided by engineer. */
+"Downloads Running" = "One or more downloads are in progress";
+
+/* No comment provided by engineer. */
+"Downloads Running text" = "If you quit Vienna now, all downloads will stop.";
+
+/* Title of a menu item */
+"Edit…" = "Edit…";
+
+/* Title of a button on an alert */
+"Empty" = "Empty";
+
+/* No comment provided by engineer. */
+"Empty Trash message" = "Are you sure you want to delete the messages in the Trash folder permanently?";
+
+/* No comment provided by engineer. */
+"Empty Trash message text" = "You cannot undo this action";
+
+/* Data field name (URL) visible in menu/article list */
+"Enclosure" = "Enclosure URL";
+
+/* No comment provided by engineer. */
+"Enter the URL here" = "Enter the URL here";
+
+/* No comment provided by engineer. */
+"Error" = "Error";
+
+/* No comment provided by engineer. */
+"Error importing subscriptions body" = "Cannot import the specified file. The file contents are not valid OPML XML format.";
+
+/* No comment provided by engineer. */
+"Error importing subscriptions title" = "Import error";
+
+/* No comment provided by engineer. */
 "Error loading script '%@'" = "Error loading script '%@'";
-"AppleScript Error in '%@' script" = "AppleScript Error in '%@' script";
-"No thanks" = "No thanks";
-"Include anonymous system profile when checking for updates?" = "Include anonymous system profile when checking for updates?";
-"Include anonymous system profile when checking for updates text" = "This helps Vienna development by letting us know what versions of macOS are most popular amongst our users.";
+
+/* No comment provided by engineer. */
+"Error parsing XML data in feed" = "Error parsing XML data in feed";
+
+/* No comment provided by engineer. */
+"Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
+
+/* No comment provided by engineer. */
+"Error retrieving RSS feed:" = "Error retrieving RSS feed:";
+
+/* No comment provided by engineer. */
 "Error: Feed not found!" = "Error: Feed not found!";
-"Loading" = "Loading";
-"Plugin could not be installed" = "Plugin could not be installed";
-"Vienna failed to install the plugin." = "Vienna failed to install the plugin.";
-"Queue" = "Queue";
+
+/* No comment provided by engineer. */
+"External Browser" = "External Browser";
+
+/* No comment provided by engineer. */
+"Feed URL updated to %@" = "Feed URL updated to %@";
+
+/* No comment provided by engineer. */
+"Fetching Open Reader Subscriptions…" = "Fetching Open Reader Subscriptions…";
+
+/* Notification body */
+"File %@ downloaded" = "File %@ downloaded";
+
+/* Notification body */
+"File %@ failed to download" = "File %@ failed to download";
+
+/* No comment provided by engineer. */
+"Flag" = "Flag";
+
+/* Data field name visible in menu/smart folder definition */
+"Flagged" = "Flagged";
+
+/* Data field name visible in menu/article list/smart folder definition */
+"Folder" = "Folder";
+
+/* No comment provided by engineer. */
+"Folder image retrieved from %@" = "Folder image retrieved from %@";
+
+/* No comment provided by engineer. */
+"Folders" = "Folders";
+
+/* Title of a menu item */
+"Force Refresh Selected Subscriptions From Open Reader" = "Force Refresh Selected Subscriptions From Open Reader";
+
+/* No comment provided by engineer. */
 "Forcing Refresh subscriptions…" = "Forcing Refresh subscriptions…";
+
+/* Toolbar item name for the General preference pane */
+"General" = "General";
+
+/* Title of a menu item */
+"Get Info" = "Get Info";
+
+/* No comment provided by engineer. */
+"Go forward to the next page" = "Go forward to the next page";
+
+/* No comment provided by engineer. */
+"Got HTTP status 304 - No news from last check" = "Got HTTP status 304 - No news from last check";
+
+/* No comment provided by engineer. */
+"HTTP code %d reported from server" = "HTTP code %d reported from server";
+
+/* Data field name (Y/N) visible in menu/smart folder definition */
+"HasEnclosure" = "Enclosure";
+
+/* Pseudo field name visible in article list */
+"Headlines" = "Headlines";
+
+/* No comment provided by engineer. */
+"Hide Filter Bar" = "Hide Filter Bar";
+
+/* Title of a menu item */
+"Hide Status Bar" = "Hide Status Bar";
+
+/* Title of a menu item */
+"Hide Toolbar" = "Hide Toolbar";
+
+/* Title of a button on an alert */
+"Import" = "Import";
+
+/* No comment provided by engineer. */
+"Import subscriptions from OPML file?" = "Import subscriptions from OPML file?";
+
+/* No comment provided by engineer. */
 "Improper infinitely looping URL redirect to %@" = "Improper infinitely looping URL redirect to %@";
 
-/* Added in 3.0.2 */
-"Close" = "Close";
+/* No comment provided by engineer. */
+"Invalid style body" = "The Default style will be used instead.";
+
+/* No comment provided by engineer. */
+"Invalid style title" = "The style %@ appears to be missing or corrupted";
+
+/* No comment provided by engineer. */
+"JavaScript" = "JavaScript";
+
+/* No comment provided by engineer. */
+"Last Week" = "Last Week";
+
+/* Data field name visible in menu/article list */
+"Link" = "Link";
+
+/* No comment provided by engineer. */
+"Loading" = "Loading";
+
+/* No comment provided by engineer. */
+"Loading…" = "Loading…";
+
+/* No comment provided by engineer. */
+"Locate Text" = "A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine.";
+
+/* No comment provided by engineer. */
+"Locate Title" = "Cannot create the Vienna database";
+
+/* Title of a button on an alert */
 "Locate…" = "Locate…";
-"Error retrieving RSS feed:"="Error retrieving RSS feed:";
-"Got HTTP status 304 - No news from last check" = "Got HTTP status 304 - No news from last check";
-"Error retrieving RSS Icon:" = "Error retrieving RSS Icon:";
-"RSS Icon not found!" = "RSS Icon not found!";
 
-/*Added in 3.0.5 */
-"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";
+/* Title of a menu item */
+"Mark All Articles as Read" = "Mark All Articles as Read";
 
-/*Added in 3.0.7 */
+/* No comment provided by engineer. */
+"Mark All Read" = "Mark All Read";
+
+/* Title of a menu item */
+"Mark All Subscriptions as Read" = "Mark All Subscriptions as Read";
+
+/* Title of a menu item */
+"Mark Flagged" = "Mark Flagged";
+
+/* Title of a menu item */
+"Mark Read" = "Mark Read";
+
+/* No comment provided by engineer. */
+"Mark Unflagged" = "Mark Unflagged";
+
+/* Title of a menu item */
+"Mark Unread" = "Mark Unread";
+
+/* No comment provided by engineer. */
+"Marked Articles" = "Marked Articles";
+
+/* No comment provided by engineer. */
+"More Scripts…" = "More Scripts…";
+
+/* No comment provided by engineer. */
+"Move Folders" = "Move Folders";
+
+/* No comment provided by engineer. */
+"Never" = "Never";
+
+/* No comment provided by engineer. */
+"New Tab" = "New Tab";
+
+/* Notification title */
+"New articles retrieved" = "New articles retrieved";
+
+/* No comment provided by engineer. */
+"New style body" = "The style \"%@\" has been installed to your Styles folder and added to the Style menu.";
+
+/* No comment provided by engineer. */
+"New style title" = "Vienna has installed a new style";
+
+/* Notification body */
+"New unread articles retrieved" = "%d new unread articles retrieved";
+
+/* No comment provided by engineer. */
+"No" = "No";
+
+/* No comment provided by engineer. */
 "No articles in feed" = "No articles in feed";
 
-/*Added in 3.1.2 */
-"Filter folders" = "Search for folders";
+/* No comment provided by engineer. */
+"No new articles available" = "No new articles available";
+
+/* Title of a button on an alert */
+"OK" = "OK";
+
+/* Title of a popup menu item */
+"Open" = "Open";
+
+/* Title of a menu item */
+"Open Article Page" = "Open Article Page";
+
+/* No comment provided by engineer. */
+"Open Article Page in %@" = "Open Article Page in %@";
+
+/* Title of a menu item */
+"Open Article Page in External Browser" = "Open Article Page in External Browser";
+
+/* No comment provided by engineer. */
+"Open Frame" = "Open Frame";
+
+/* No comment provided by engineer. */
+"Open Image in %@" = "Open Image in %@";
+
+/* No comment provided by engineer. */
+"Open Image in New Tab" = "Open Image in New Tab";
+
+/* No comment provided by engineer. */
+"Open Link in %@" = "Open Link in %@";
+
+/* No comment provided by engineer. */
+"Open Link in New Tab" = "Open Link in New Tab";
+
+/* No comment provided by engineer. */
+"Open Page in %@" = "Open Page in %@";
+
+/* No comment provided by engineer. */
+"Open Reader Authentication Failed" = "Open Reader Authentication Failed";
+
+/* No comment provided by engineer. */
+"Open Reader Authentication Failed text" = "Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences.\nAlso check your network access.";
+
+/* No comment provided by engineer. */
+"Open Scripts Folder" = "Open Scripts Folder";
+
+/* Title of a menu item */
+"Open Subscription Home Page" = "Open Subscription Home Page";
+
+/* No comment provided by engineer. */
+"Open Subscription Home Page in %@" = "Open Subscription Home Page in %@";
+
+/* Title of a menu item */
+"Open Subscription Home Page in External Browser" = "Open Subscription Home Page in External Browser";
+
+/* No comment provided by engineer. */
+"Other" = "Other";
+
+/* No comment provided by engineer. */
+"Play" = "Play";
+
+/* No comment provided by engineer. */
+"Plugin installed" = "Plugin installed";
+
+/* Title of the Preferences window */
+"Preferences" = "Preferences";
+
+/* No comment provided by engineer. */
+"Queue" = "Queue";
+
+/* Title of a button on an alert */
+"Quit" = "Quit";
+
+/* Title of a button on an alert
+   Title of a menu item */
+"Quit Vienna" = "Quit Vienna";
+
+/* No comment provided by engineer. */
+"RSS Icon not found!" = "RSS Icon not found!";
+
+/* No comment provided by engineer. */
+"RSS Subscription Export Title" = "Export Completed";
+
+/* No comment provided by engineer. */
+"RSS Subscription Import Title" = "Import Completed";
+
+/* Data field name visible in menu/smart folder definition */
+"Read" = "Read";
+
+/* No comment provided by engineer. */
+"Recent Searches" = "Recent Searches";
+
+/* No comment provided by engineer. */
+"Recents" = "Recents";
+
+/* No comment provided by engineer. */
+"Redirection attempt treated as temporary for safety concern" = "Redirection attempt treated as temporary for safety concern";
+
+/* Title of a menu item */
+"Refresh All Subscriptions" = "Refresh All Subscriptions";
+
+/* Title of a menu item */
+"Refresh Selected Subscriptions" = "Refresh Selected Subscriptions";
+
+/* No comment provided by engineer. */
+"Refresh completed" = "Refresh completed";
+
+/* No comment provided by engineer. */
+"Refresh the current page" = "Refresh the current page";
+
+/* No comment provided by engineer. */
+"Refreshing folder images…" = "Refreshing folder images…";
+
+/* No comment provided by engineer. */
+"Refreshing subscriptions…" = "Refreshing subscriptions…";
+
+/* Title of a popup menu item */
+"Remove From List" = "Remove From List";
+
+/* Title of a menu item */
+"Rename…" = "Rename…";
+
+/* Title of a menu item */
+"Restore Article" = "Restore Article";
+
+/* No comment provided by engineer. */
+"Resubscribe" = "Resubscribe to Feed";
+
+/* No comment provided by engineer. */
+"Retrieving articles" = "Retrieving articles";
+
+/* No comment provided by engineer. */
+"Retrieving folder image" = "Retrieving folder image";
+
+/* No comment provided by engineer. */
+"Retrieving folder image for Open Reader Feed" = "Retrieving folder image for Open Reader Feed";
+
+/* No comment provided by engineer. */
+"Return to the previous page" = "Return to the previous page";
+
+/* No comment provided by engineer. */
+"Search Results" = "Search Results";
+
+/* Placeholder title of a search field */
+"Search all articles" = "Search all articles";
+
+/* No comment provided by engineer. */
+"Search all articles or the current web page" = "Search all articles or the current web page";
+
+/* Placeholder title of a search field */
+"Search current web page" = "Search current web page";
+
+/* No comment provided by engineer. */
+"Search in %@" = "Filter in %@";
+
+/* No comment provided by engineer. */
+"Select…" = "Select…";
+
+/* No comment provided by engineer. */
+"Send Link" = "Send Link";
+
+/* No comment provided by engineer. */
+"Send Links" = "Send Links";
+
+/* No comment provided by engineer. */
+"Show Filter Bar" = "Show Filter Bar";
+
+/* Title of a menu item */
+"Show Main Window…" = "Show Main Window…";
+
+/* Title of a menu item */
+"Show Status Bar" = "Show Status Bar";
+
+/* Title of a menu item */
+"Show Toolbar" = "Show Toolbar";
+
+/* Title of a popup menu item */
+"Show in Finder" = "Show in Finder";
+
+/* Data field name visible in menu/article list/smart folder definition */
+"Subject" = "Subject";
+
+/* No comment provided by engineer. */
+"Subscribe to the feed for this page" = "Subscribe to the feed for this page";
+
+/* Pseudo field name visible in menu/article list */
+"Summary" = "Summary";
+
+/* Toolbar item name for the Syncing preference pane */
+"Syncing" = "Syncing";
+
+/* Data field name visible in smart folder definition */
+"Text" = "Text";
+
+/* No comment provided by engineer. */
+"This article contains an enclosed file." = "This article contains an enclosed file.";
+
+/* No comment provided by engineer. */
+"Today" = "Today";
+
+/* No comment provided by engineer. */
+"Today's Articles" = "Today’s Articles";
+
+/* No comment provided by engineer. */
+"Trash" = "Trash";
+
+/* URL */
+"URL" = "URL";
+
+/* No comment provided by engineer. */
+"Unread" = "Unread";
+
+/* No comment provided by engineer. */
+"Unread Articles" = "Unread Articles";
+
+/* No comment provided by engineer. */
+"Unrecognised database format text" = "The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.";
+
+/* No comment provided by engineer. */
+"Unrecognised database format title" = "The database file format has changed";
+
+/* No comment provided by engineer. */
+"Unsubscribe" = "Unsubscribe from Feed";
+
+/* Title of a button on an alert */
+"Upgrade Database" = "Upgrade Database";
+
+/* No comment provided by engineer. */
+"Vienna cannot open the file body" = "Vienna cannot open the file \"%@\" because it moved since you downloaded it.";
+
+/* No comment provided by engineer. */
+"Vienna cannot open the file title" = "Vienna cannot open the file.";
+
+/* No comment provided by engineer. */
+"Vienna cannot show the file body" = "Vienna cannot show the file \"%@\" because it moved since you downloaded it.";
+
+/* No comment provided by engineer. */
+"Vienna cannot show the file title" = "Vienna cannot show the file.";
+
+/* No comment provided by engineer. */
+"Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconveninece." = "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconvenience.";
+
+/* No comment provided by engineer. */
+"Yes" = "Yes";
+
+/* No comment provided by engineer. */
+"Yesterday" = "Yesterday";
+
+/* rule for association of multiple criteria */
+"all" = "all";
+
+/* rule for association of multiple criteria */
+"any" = "any";
+
+/* test for a string */
+"contains" = "contains";
+
+/* test for a string */
+"does not contain" = "does not contain";
+
+/* test for a value */
+"is" = "is";
+
+/* test for a date */
+"is after" = "is after";
+
+/* test for a date */
+"is before" = "is before";
+
+/* test for a numeric value */
+"is greater than" = "is greater than";
+
+/* test for a numeric value */
+"is greater than or equal to" = "is greater than or equal to";
+
+/* test for a numeric value */
+"is less than" = "is less than";
+
+/* test for a numeric value */
+"is less than or equal to" = "is less than or equal to";
+
+/* test for a value */
+"is not" = "is not";
+
+/* test for a date */
+"is on or after" = "is on or after";
+
+/* test for a date */
+"is on or before" = "is on or before";
+
+/* test for a folder (not operational as of Vienna 3.2) */
+"not under" = "not under";
+
+/* test for a folder (not operational as of Vienna 3.2) */
+"under" = "under";
+


### PR DESCRIPTION
While English has always been the development language of Vienna, the English version of Vienna displays a few texts differently than what string keys are present in the Objective-C/Swift code. Three main reasons can be identified; some are historical and others are practical : 
- the discovery of a typo in an English expression __after__ the translation effort has begun. In these situations, it is much more convenient to fix what the english version displays by adding an item in the English/Base Localizable.strings file than to require __all__ translators to modify the string key they use;
- the adequate English text might sometimes be very long and it has been decided that it would be better to use a shorthand in the source code to prevent potential typos;
- in many experienced teams, it is [a rule that the string key should stress the context of the idiom than needs to be translated](https://www.objc.io/issues/9-strings/string-localization/ "Best Practices on string localization at objc.io"), rather than let the programmer use whatever he is used to use in English.

A good example illustrating all these three reasons can be seen is this item which had to be added in Vienna's Base Localizable.strings (note the initial typo on "inconvenience")

```
/* No comment provided by engineer. */
"Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconveninece." = "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconvenience.";
```

In the case of Vienna, only a few strings really need to be in the Base Localizable.strings. For the ease of future maintenance, I submit a reorganization and a cleanup of this file.
The reorganization adopts the sort order that genstrings and Crowdin use.
The cleanup removes obsolete (unused) and superfluous items.