### PR TITLE
Fix typo on the word ‘inconvenience’

### DIFF
--- a/Interfaces/Base.lproj/Localizable.strings
+++ b/Interfaces/Base.lproj/Localizable.strings
@@ -1,50 +1,149 @@
-"Already subscribed title" = "Error";
+/* Already subscribed body */
 "Already subscribed body" = "You are already subscribed to that feed";
-"RSS Subscription Import Title" = "Import Completed";
-"RSS Subscription Export Title" = "Export Completed";
-"New unread articles retrieved" = "%d new unread articles retrieved";
-"New style title" = "Vienna has installed a new style";
-"New style body" = "The style \"%@\" has been installed to your Styles folder and added to the Style menu.";
-"Delete selected message" = "Are you sure you want to permanently delete the selected articles?";
-"Delete selected message text" = "This operation cannot be undone.";
-"Credentials Prompt" = "The subscription for \"%@\" requires a user name and password for access.";
-"Delete group folder text" = "Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone.";
-"Delete smart folder text" = "Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search.";
-"Delete RSS feed text" = "Are you sure you want to unsubscribe from \"%@\"? This operation will delete all cached articles.";
-"Delete RSS feed" = "Delete subscription";
-"Delete multiple folders text" = "Are you sure you want to delete all %d selected folders? This operation cannot be undone.";
-"Delete folder status" = "Deleting folder \"%@\"…";
-"Cannot create database folder title" = "Sorry, but Vienna was unable to create the database folder";
+
+/* Already subscribed title */
+"Already subscribed title" = "Error";
+
+/* No comment provided by engineer. */
 "Cannot create database folder text" = "Vienna was trying to create the folder \"%@\" but an error occurred. Check the permissions on the folders on the path specified.";
-"Unrecognised database format title" = "The database file format has changed";
-"Unrecognised database format text" = "The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.";
-"Search in %@" = "Filter in %@";
-"Today's Articles" = "Today’s Articles";
-"Cannot open export file message" = "Cannot create export output file";
-"Cannot open export file message text" = "The specified export output file could not be created. Check that it is not locked and no other application is using it.";
-"Clear" = "Clear Recent Searches";
-"Copy Page Link to Clipboard" ="Copy Page Link to Clipboard";
-"Error importing subscriptions body" = "Cannot import the specified file. The file contents are not valid OPML XML format.";
-"Error importing subscriptions title" = "Import error";
-"Invalid style title" = "The style %@ appears to be missing or corrupted";
-"Invalid style body" = "The Default style will be used instead.";
-"Downloads Running" = "One or more downloads are in progress";
-"Downloads Running text" = "If you quit Vienna now, all downloads will stop.";
-"Locate Title" = "Cannot create the Vienna database";
-"Locate Text" = "A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine.";
-"Empty Trash message" = "Are you sure you want to delete the messages in the Trash folder permanently?";
-"Empty Trash message text" = "You cannot undo this action";
-"Cannot open database title" = "Sorry but Vienna was unable to open the database";
-"Cannot open database text" = "The database file (%@) could not be opened for some reason. It may be corrupted or inaccessible. Please delete or rename the database file and restart Vienna.";
-"Vienna cannot open the file title" = "Vienna cannot open the file.";
-"Vienna cannot open the file body" = "Vienna cannot open the file \"%@\" because it moved since you downloaded it.";
-"Vienna cannot show the file title" = "Vienna cannot show the file.";
-"Vienna cannot show the file body" = "Vienna cannot show the file \"%@\" because it moved since you downloaded it.";
-"HasEnclosure" = "Enclosure";
-"Enclosure" = "Enclosure URL";
-"Unsubscribe" = "Unsubscribe from Feed";
-"Resubscribe" = "Resubscribe to Feed";
-"Cannot create folder title" = "Cannot create folder";
+
+/* No comment provided by engineer. */
+"Cannot create database folder title" = "Sorry, but Vienna was unable to create the database folder";
+
+/* No comment provided by engineer. */
 "Cannot create folder body" = "The \"%@\" folder cannot be created.";
+
+/* No comment provided by engineer. */
+"Cannot create folder title" = "Cannot create folder";
+
+/* No comment provided by engineer. */
+"Cannot open database text" = "The database file (%@) could not be opened for some reason. It may be corrupted or inaccessible. Please delete or rename the database file and restart Vienna.";
+
+/* No comment provided by engineer. */
+"Cannot open database title" = "Sorry but Vienna was unable to open the database";
+
+/* No comment provided by engineer. */
+"Cannot open export file message" = "Cannot create export output file";
+
+/* No comment provided by engineer. */
+"Cannot open export file message text" = "The specified export output file could not be created. Check that it is not locked and no other application is using it.";
+
+/* No comment provided by engineer. */
+"Clear" = "Clear Recent Searches";
+
+/* No comment provided by engineer. */
+"Credentials Prompt" = "The subscription for \"%@\" requires a user name and password for access.";
+
+/* No comment provided by engineer. */
 "Delete Open Reader RSS feed text" = "Unsubscribing from an Open Reader RSS feed will also remove your locally cached articles.";
+
+/* No comment provided by engineer. */
+"Delete RSS feed" = "Delete subscription";
+
+/* No comment provided by engineer. */
+"Delete RSS feed text" = "Are you sure you want to unsubscribe from \"%@\"? This operation will delete all cached articles.";
+
+/* No comment provided by engineer. */
+"Delete folder status" = "Deleting folder \"%@\"…";
+
+/* No comment provided by engineer. */
+"Delete group folder text" = "Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Delete multiple folders text" = "Are you sure you want to delete all %d selected folders? This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Delete selected message" = "Are you sure you want to permanently delete the selected articles?";
+
+/* No comment provided by engineer. */
+"Delete selected message text" = "This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Delete smart folder text" = "Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search.";
+
+/* No comment provided by engineer. */
+"Downloads Running" = "One or more downloads are in progress";
+
+/* No comment provided by engineer. */
+"Downloads Running text" = "If you quit Vienna now, all downloads will stop.";
+
+/* No comment provided by engineer. */
+"Empty Trash message" = "Are you sure you want to delete the messages in the Trash folder permanently?";
+
+/* No comment provided by engineer. */
+"Empty Trash message text" = "You cannot undo this action";
+
+/* Data field name (URL) visible in menu/article list */
+"Enclosure" = "Enclosure URL";
+
+/* No comment provided by engineer. */
+"Error importing subscriptions body" = "Cannot import the specified file. The file contents are not valid OPML XML format.";
+
+/* No comment provided by engineer. */
+"Error importing subscriptions title" = "Import error";
+
+/* Data field name (Y/N) visible in menu/smart folder definition */
+"HasEnclosure" = "Enclosure";
+
+/* No comment provided by engineer. */
+"Invalid style body" = "The Default style will be used instead.";
+
+/* No comment provided by engineer. */
+"Invalid style title" = "The style %@ appears to be missing or corrupted";
+
+/* No comment provided by engineer. */
+"Locate Text" = "A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine.";
+
+/* No comment provided by engineer. */
+"Locate Title" = "Cannot create the Vienna database";
+
+/* No comment provided by engineer. */
+"New style body" = "The style \"%@\" has been installed to your Styles folder and added to the Style menu.";
+
+/* No comment provided by engineer. */
+"New style title" = "Vienna has installed a new style";
+
+/* Notification body */
+"New unread articles retrieved" = "%d new unread articles retrieved";
+
+/* No comment provided by engineer. */
 "Open Reader Authentication Failed text" = "Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences.\nAlso check your network access.";
+
+/* No comment provided by engineer. */
+"RSS Subscription Export Title" = "Export Completed";
+
+/* No comment provided by engineer. */
+"RSS Subscription Import Title" = "Import Completed";
+
+/* No comment provided by engineer. */
+"Resubscribe" = "Resubscribe to Feed";
+
+/* No comment provided by engineer. */
+"Search in %@" = "Filter in %@";
+
+/* No comment provided by engineer. */
+"Today's Articles" = "Today’s Articles";
+
+/* No comment provided by engineer. */
+"Unrecognised database format text" = "The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.";
+
+/* No comment provided by engineer. */
+"Unrecognised database format title" = "The database file format has changed";
+
+/* No comment provided by engineer. */
+"Unsubscribe" = "Unsubscribe from Feed";
+
+/* No comment provided by engineer. */
+"Vienna cannot open the file body" = "Vienna cannot open the file \"%@\" because it moved since you downloaded it.";
+
+/* No comment provided by engineer. */
+"Vienna cannot open the file title" = "Vienna cannot open the file.";
+
+/* No comment provided by engineer. */
+"Vienna cannot show the file body" = "Vienna cannot show the file \"%@\" because it moved since you downloaded it.";
+
+/* No comment provided by engineer. */
+"Vienna cannot show the file title" = "Vienna cannot show the file.";
+
+/* No comment provided by engineer. */
+"Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconveninece." = "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconvenience.";


### PR DESCRIPTION
Almost the same thing than pull request #959 did:
- Sort Base Localizable.strings to reflect imports from Crowdin 
- Comment it like `genstrings` does
- Add the last (‘Vienna must upgrade…’) item to work around the typo

but the main purpose here is to fix the typo 😀 !