### PR TITLE
Use AppController singleton in TabbedWebView

### DIFF
--- a/src/ArticleCellView.m
+++ b/src/ArticleCellView.m
@@ -40,7 +40,6 @@
 		SEL loadFinishedSelector = NSSelectorFromString(@"webViewLoadFinished:");
 		[[NSNotificationCenter defaultCenter] addObserver:[controller.browserView primaryTabItemView] selector:loadFinishedSelector name:WebViewProgressFinishedNotification object:articleView];
 		[articleView setOpenLinksInNewBrowser:YES];
-		[articleView setController:controller];
 		[articleView.mainFrame.frameView setAllowsScrolling:NO];
 
 		// Make web preferences 16pt Arial to match Safari

--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -105,8 +105,7 @@
 	articleText.UIDelegate = self;
 	articleText.frameLoadDelegate = self;
 	[articleText setOpenLinksInNewBrowser:YES];
-	[articleText setController:self.controller];
-	
+
 	// Make web preferences 16pt Arial to match Safari
 	articleText.preferences.standardFontFamily = @"Arial";
 	articleText.preferences.defaultFontSize = 16;

--- a/src/ArticleView.m
+++ b/src/ArticleView.m
@@ -320,9 +320,9 @@ static NSMutableDictionary * stylePathMappings = nil;
 		if (deltaX != 0)
 		{
 			if (deltaX > 0)
-				[controller goBack:self];
+				[APPCONTROLLER goBack:self];
 			else 
-				[controller viewNextUnread:self];
+				[APPCONTROLLER viewNextUnread:self];
 		}
 	}		
 }

--- a/src/BrowserPane.m
+++ b/src/BrowserPane.m
@@ -178,7 +178,6 @@
 -(void)setController:(AppController *)theController
 {
 	controller = theController;
-	[self.webPane setController:controller];
 }
 
 /* viewLink

--- a/src/TabbedWebView.h
+++ b/src/TabbedWebView.h
@@ -24,7 +24,6 @@
 @class AppController;
 
 @interface TabbedWebView : WebView <WebPolicyDelegate> {
-	AppController * controller;
 	WebPreferences * defaultWebPrefs;
 	BOOL openLinksInNewBrowser;
 	BOOL isFeedRedirect;
@@ -34,7 +33,6 @@
 // Public functions
 +(NSString *)userAgent;
 -(void)initTabbedWebView;
--(void)setController:(AppController *)theController;
 -(void)setOpenLinksInNewBrowser:(BOOL)flag;
 -(void)keyDown:(NSEvent *)theEvent;
 -(void)printDocument:(id)sender;

--- a/src/TabbedWebView.m
+++ b/src/TabbedWebView.m
@@ -93,7 +93,6 @@ static NSString * _userAgent ;
 -(void)initTabbedWebView
 {
 	// Init our vars
-	controller = nil;
 	openLinksInNewBrowser = NO;
 	isFeedRedirect = NO;
 	isDownload = NO;
@@ -126,15 +125,6 @@ static NSString * _userAgent ;
 	[self loadMinimumFontSize];
 	[self loadUseJavaScript];
     [self loadUseWebPlugins];
-}
-
-/* setController
- * Set the associated controller for this view
- */
--(void)setController:(AppController *)theController
-{
-	controller = theController;
-	self.policyDelegate = self;
 }
 
 /* setOpenLinksInNewBrowser
@@ -209,7 +199,7 @@ static NSString * _userAgent ;
 		// Indicate a redirect for a feed
 		[self setIsFeedRedirect:YES];
 
-		[controller openURLInDefaultBrowser:[NSURL URLWithString:[NSString stringWithFormat:@"feed://%@", linkPath]]];
+        [APPCONTROLLER openURLInDefaultBrowser:[NSURL URLWithString:[NSString stringWithFormat:@"feed://%@", linkPath]]];
 		[listener ignore];
 		return;
 	}
@@ -254,7 +244,7 @@ static NSString * _userAgent ;
 		NSUInteger  modifierFlag = [[actionInformation valueForKey:WebActionModifierFlagsKey] unsignedIntegerValue];
 		BOOL useAlternateBrowser = (modifierFlag & NSAlternateKeyMask) ? YES : NO; // This is to avoid problems in casting the value into BOOL
 		[listener ignore];
-		[controller openURL:request.URL inPreferredBrowser:!useAlternateBrowser];
+		[APPCONTROLLER openURL:request.URL inPreferredBrowser:!useAlternateBrowser];
 		return;
 	}
 	[listener use];
@@ -282,7 +272,7 @@ static NSString * _userAgent ;
 		if (openLinksInNewBrowser || (modifierFlags & NSCommandKeyMask))
 		{
 			[listener ignore];
-			[controller openURL:request.URL inPreferredBrowser:!useAlternateBrowser];
+			[APPCONTROLLER openURL:request.URL inPreferredBrowser:!useAlternateBrowser];
 			return;
 		}
 		else
@@ -291,7 +281,7 @@ static NSString * _userAgent ;
 			if (prefs.openLinksInVienna == useAlternateBrowser)
 			{
 				[listener ignore];
-				[controller openURLInDefaultBrowser:request.URL];
+				[APPCONTROLLER openURLInDefaultBrowser:request.URL];
 				return;
 			}
 		}


### PR DESCRIPTION
Resolves #972.

ArticleListView is currently responsible for setting the `controller` property of its ArticleView child. This was done in `-awakeFromNib`, which was too early. The singleton is a more robust solution until the web view has its own controller.