### PR TITLE
Enable File Quarantine

### DIFF
--- a/Resources/Vienna-Info.plist
+++ b/Resources/Vienna-Info.plist
@@ -53,6 +53,8 @@
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>Vienna</string>
+	<key>LSFileQuarantineEnabled</key>
+	<true/>
 	<key>CFBundleHelpBookFolder</key>
 	<string>Vienna.help</string>
 	<key>CFBundleHelpBookName</key>


### PR DESCRIPTION
This will add a quarantine flag to any file that Vienna saves, causing Gatekeeper to verify the file before allowing the user to open it. See [`LSFileQuarantineEnabled`](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW10). This should alleviate some of the concerns in #975.

There might be a performance penalty for files that are saved for internal use. We should test this and if need be exclude certain paths using the [`LSFileQuarantineExcludedPathPatterns`](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW6) key (e.g. `~/Library/*`).

Alternatively, we can add the file attribute ourselves using the Launch Services APIs, though this will require more work.

