### PR TITLE
Fix crash on macOS 10.13 High Sierra.

### DIFF
--- a/src/ActivityViewer.m
+++ b/src/ActivityViewer.m
@@ -191,8 +191,16 @@
  */
 -(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSUInteger)rowIndex
 {
-	ActivityItem * item = allItems[rowIndex];
-	return (aTableColumn.identifier) ? [item valueForKey:aTableColumn.identifier] : @"";
+	NSString * identifier = aTableColumn.identifier;
+	if (identifier != nil && identifier.length > 0 )
+	{
+		ActivityItem * item = allItems[rowIndex];
+		return [item valueForKey:identifier];
+	}
+	else
+	{
+		return @"";
+	}
 }
 
 /* dealloc


### PR DESCRIPTION
On High Sierra, -[NSTableColumn identifier] returns an empty string instead of nil. This has been filed as rdar://problem/34057984

The exception and crash occurs because ActivityItem is not key value coding compliant for the empty string. The previous code assumed nil and did not check for the empty string.