### PR TITLE
Restore truncation that was removed in a6926eeee797b323b46e971d364f29f1de42bc52

### DIFF
--- a/src/ArticleListView.m
+++ b/src/ArticleListView.m
@@ -137,7 +137,8 @@ static const CGFloat MA_Minimum_Article_Pane_Dimension = 80;
 	
 	// Create report and condensed view attribute dictionaries
 	NSMutableParagraphStyle * style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-	style.lineBreakMode = NSLineBreakByClipping;
+	style.lineBreakMode = NSLineBreakByTruncatingTail;
+	style.tighteningFactorForTruncation = 0.0;
 	
 	reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];
 	unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];

--- a/src/FoldersTree.m
+++ b/src/FoldersTree.m
@@ -912,7 +912,8 @@
 	if (info == nil)
 	{
 		NSMutableParagraphStyle * style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-		style.lineBreakMode = NSLineBreakByClipping;
+		style.lineBreakMode = NSLineBreakByTruncatingTail;
+		style.tighteningFactorForTruncation = 0.0;
 		info = @{NSParagraphStyleAttributeName: style};
 	}
 


### PR DESCRIPTION
Setting tighteningFactorForTruncation to 0.0 stops the text from being squeezed.