### PR TITLE
Fix for https://github.com/ViennaRSS/vienna-rss/issues/877

### DIFF
--- a/src/Database.m
+++ b/src/Database.m
@@ -1751,6 +1751,8 @@ const NSInteger MA_Current_DB_Version = 19;
                 NSInteger newItemId = [results stringForColumnIndex:0].integerValue;
                 NSInteger newParentId = [results stringForColumnIndex:1].integerValue;
                 NSString * name = [results stringForColumnIndex:2];
+				if (name == nil) // Paranoid check because of https://github.com/ViennaRSS/vienna-rss/issues/877
+					name = [Database untitledFeedFolderName];
                 NSInteger unreadCount = [results stringForColumnIndex:3].integerValue;
                 NSDate * lastUpdate = [NSDate dateWithTimeIntervalSince1970:[results stringForColumnIndex:4].doubleValue];
                 NSInteger type = [results stringForColumnIndex:5].integerValue;

--- a/src/RefreshManager.m
+++ b/src/RefreshManager.m
@@ -971,7 +971,7 @@
 			
             
 			// A notify is only needed if we added any new articles.
-			if ([folder.name hasPrefix:[Database untitledFeedFolderName]] && !feedTitle.blank)
+			if (feedTitle != nil  && !feedTitle.blank && [folder.name hasPrefix:[Database untitledFeedFolderName]])
 			{
 				// If there's an existing feed with this title, make ours unique
 				// BUGBUG: This duplicates logic in database.m so consider moving it there.


### PR DESCRIPTION
Fixes a bug introduced in 67d181764be6d9f242392e689ad38aea6d533796

-[RichXMLParser init] called [self setTitle:@""]. When the -init method was deleted, the title was no longer guaranteed to be non-nil.