### PR TITLE
Fix for https://github.com/ViennaRSS/vienna-rss/issues/768

### DIFF
--- a/src/DownloadManager.m
+++ b/src/DownloadManager.m
@@ -355,14 +355,13 @@
 +(NSString *)fullDownloadPath:(NSString *)filename
 {
 	NSString * downloadPath = [Preferences standardPreferences].downloadFolder;
-    NSString * decodedFilename = [filename stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	NSFileManager * fileManager = [NSFileManager defaultManager];
 	BOOL isDir = YES;
 
 	if (![fileManager fileExistsAtPath:downloadPath isDirectory:&isDir] || !isDir)
 		downloadPath = @"~/Desktop";
 	
-	return [downloadPath.stringByExpandingTildeInPath stringByAppendingPathComponent:decodedFilename];
+	return [downloadPath.stringByExpandingTildeInPath stringByAppendingPathComponent:filename];
 }
 
 /* isFileDownloaded
@@ -371,17 +370,16 @@
  */
 +(BOOL)isFileDownloaded:(NSString *)filename
 {
-    NSString * decodedFilename = [filename stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	DownloadManager * downloadManager = [DownloadManager sharedInstance];
 	NSInteger count = downloadManager.downloadsList.count;
 	NSInteger index;
 
-	NSString * firstFile = decodedFilename.stringByStandardizingPath;
+	NSString * firstFile = filename.stringByStandardizingPath;
 
 	for (index = 0; index < count; ++index)
 	{
 		DownloadItem * item = downloadManager.downloadsList[index];
-		NSString * secondFile = decodedFilename.stringByStandardizingPath;
+		NSString * secondFile = filename.stringByStandardizingPath;
 		
 		if ([firstFile compare:secondFile options:NSCaseInsensitiveSearch] == NSOrderedSame)
 		{

--- a/src/StdEnclosureView.m
+++ b/src/StdEnclosureView.m
@@ -79,17 +79,16 @@
 	enclosureURLString = [cleanedUpAndEscapedUrlFromString(newFilename) absoluteString];
 
 	NSString * basename = [NSURL URLWithString:enclosureURLString].lastPathComponent;
-    NSString * decodedname = [basename stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    NSString * ext = decodedname.pathExtension;
-
 	if (basename==nil)
 	{
 		return;
 	}
+	
+	NSString * ext = basename.pathExtension;
 
 	// Find the file's likely location in Finder and see if it is already there.
 	// We'll set the options in the pane based on whether the file is there or not.
-	NSString * destPath = [DownloadManager fullDownloadPath:decodedname];
+	NSString * destPath = [DownloadManager fullDownloadPath:basename];
 	if (![DownloadManager isFileDownloaded:destPath])
 	{
 		[downloadButton setTitle:NSLocalizedString(@"Download", nil)];
@@ -135,7 +134,7 @@
 									 NSForegroundColorAttributeName: [NSColor colorWithCalibratedHue:240.0f/360.0f saturation:1.0f brightness:0.75f alpha:1.0f],
 									 NSUnderlineStyleAttributeName: @YES,
 									 };
-	NSAttributedString * link = [[NSAttributedString alloc] initWithString:decodedname attributes:linkAttributes];
+	NSAttributedString * link = [[NSAttributedString alloc] initWithString:basename attributes:linkAttributes];
 	filenameField.attributedStringValue = link;
 }
 
@@ -153,8 +152,7 @@
 -(IBAction)openFile:(id)sender
 {
 	NSString * basename = [NSURL URLWithString:enclosureURLString].lastPathComponent;
-    NSString * decodedname = [basename stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-	NSString * destPath = [DownloadManager fullDownloadPath:decodedname];
+	NSString * destPath = [DownloadManager fullDownloadPath:basename];
 
 	[[NSWorkspace sharedWorkspace] openFile:destPath];
 }


### PR DESCRIPTION
-[NSURL lastPathComponent] is documented as calling stringByReplacingPercentEscapesUsingEncoding. Thus, Vienna was calling it twice, redundantly.

The filename was http://static.giantbomb.com/uploads/screen_medium/0/31/2912034-1467281594-bb2%255.jpg
The last path component was 2912034-1467281594-bb2%5.jpg
When Vienna called stringByReplacingPercentEscapesUsingEncoding on the last path component, it was returning nil. This caused the crash.