### PR TITLE
Fix bug where NO was returned from method with NSString return type.

### DIFF
--- a/src/Database.m
+++ b/src/Database.m
@@ -2594,11 +2594,7 @@ const NSInteger MA_Current_DB_Version = 19;
         NSError *error;
         if (![fileManager createDirectoryAtPath:databaseFolder withIntermediateDirectories:YES attributes:NULL error:&error])
         {
-            NSRunAlertPanel(NSLocalizedString(@"Cannot create database folder", nil),
-                            [NSString stringWithFormat:NSLocalizedString(@"Cannot create database folder text: %@", nil), error],
-                            NSLocalizedString(@"Close", nil), @"", @"",
-                            databaseFolder);
-            return NO;
+			NSLog(@"Cannot create database folder: %@", error);
         }
     }
     


### PR DESCRIPTION
We don't need to show the alert either, because it would be shown twice, and then a third alert appears from -[Database relocateLockedDatabase:]. Just allow the relocate alert to be shown.

This bug was introduced in f433a8e8eca0f22a3c873ec3fb9a43b4cfc176f3