### PR TITLE
Fix build warning in InfoPanelController.m

### DIFF
--- a/src/InfoPanelController.m
+++ b/src/InfoPanelController.m
@@ -78,8 +78,7 @@
 
     // Check if the source file exists. If not, disable the button.
     NSFileManager *fileManager = NSFileManager.defaultManager;
-    self.openCachedFileButton.enabled = [fileManager fileExistsAtPath:self.cachedFile
-                                                          isDirectory:NO];
+    self.openCachedFileButton.enabled = [fileManager fileExistsAtPath:self.cachedFile];
 }
 
 /* updateFolder


### PR DESCRIPTION
The `isDirectory` parameter does not affect the return value of the method, but only returns a pointer that is not used.