### PR TITLE
Reduce synchronization work on folder refresh

### DIFF
--- a/src/Folder.m
+++ b/src/Folder.m
@@ -522,10 +522,8 @@ static NSArray * iconArray = nil;
  */
 -(void)setUnreadCount:(NSInteger)count
 {
-	@synchronized(self) {
-		NSAssert1(count >= 0, @"Attempting to set a negative unread count on folder %@", [self name]);
-		unreadCount = count;
-	}
+    NSAssert1(count >= 0, @"Attempting to set a negative unread count on folder %@", [self name]);
+    unreadCount = count;
 }
 
 /* setChildUnreadCount
@@ -534,10 +532,8 @@ static NSArray * iconArray = nil;
  */
 -(void)setChildUnreadCount:(NSInteger)count
 {
-	@synchronized(self) {
-		NSAssert1(count >= 0, @"Attempting to set a negative unread count on folder %@", [self name]);
-		childUnreadCount = count;
-	}
+    NSAssert1(count >= 0, @"Attempting to set a negative unread count on folder %@", [self name]);
+    childUnreadCount = count;
 }
 
 /* clearCache


### PR DESCRIPTION
No need to manually synchronize anymore, because since commit
d7f50f0144a180b4cee0db1ba3dde29c91ef0328, count properties are atomic.