### PR TITLE
Change user-agent to allow some forbes.com pages to load

### DIFF
--- a/src/Constants.m
+++ b/src/Constants.m
@@ -21,7 +21,7 @@
 @import Foundation;
 
 NSString * MA_DefaultUserAgentString = @"Mozilla/5.0 Vienna/%@";
-NSString * MA_BrowserUserAgentString = @"Vienna/%@ Version/%@ Safari/%@";
+NSString * MA_BrowserUserAgentString = @"(Macintosh; Intel Mac OS X %@) AppleWebKit/%@ (KHTML, like Gecko) Version/%@ Safari/604.1.38 Vienna/%@";
 
 NSString * MAPref_ArticleListFont = @"MessageListFont";
 NSString * MAPref_AutoSortFoldersTree = @"AutomaticallySortFoldersTree";

--- a/src/TabbedWebView.m
+++ b/src/TabbedWebView.m
@@ -48,15 +48,15 @@ static NSString * _userAgent ;
 {
 	if(!_userAgent)
 	{
+	    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+        NSString * osVersion = [NSString stringWithFormat:@"%ld_%ld_%ld", version.majorVersion, version.minorVersion, version.patchVersion];
         NSString * webkitVersion = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"].infoDictionary[@"CFBundleVersion"];
-        if (webkitVersion)
-            webkitVersion = [webkitVersion substringFromIndex:2];
-        else
+        if (!webkitVersion)
             webkitVersion = @"536.30";
         NSString * shortSafariVersion = [NSBundle bundleWithPath:@"/Applications/Safari.app"].infoDictionary[@"CFBundleShortVersionString"];
         if (!shortSafariVersion)
             shortSafariVersion = @"6.0";
-        _userAgent = [NSString stringWithFormat:MA_BrowserUserAgentString, ((ViennaApp *)NSApp).applicationVersion.firstWord, shortSafariVersion, webkitVersion];
+        _userAgent = [NSString stringWithFormat:MA_BrowserUserAgentString, osVersion, webkitVersion, shortSafariVersion, ((ViennaApp *)NSApp).applicationVersion.firstWord];
 	}
 	return _userAgent;
 }
@@ -121,7 +121,7 @@ static NSString * _userAgent ;
 	[defaultWebPrefs setJavaScriptEnabled:NO];
     [defaultWebPrefs setPlugInsEnabled:NO];
     // handle UserAgent
-    self.applicationNameForUserAgent = [TabbedWebView userAgent];
+    self.customUserAgent = [TabbedWebView userAgent];
 	[self loadMinimumFontSize];
 	[self loadUseJavaScript];
     [self loadUseWebPlugins];


### PR DESCRIPTION
Workaround for issue #1040

The new user agent looks something like :
````
(Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/13604.3.5 (KHTML, like Gecko) Version/11.0.1 Safari/604.1.38 Vienna/3.2.0
````
I have used this user agent for a few weeks now without noticeable inconveniences.
I have checked in particular that BBC videos load without requiring Adobe Flash.