### PR TITLE
Notes for next beta version (3.2.0_beta1)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,79 @@ most recent build should be at the top of this file.
 
 Thanks!
 
+3.2.0 Beta 1
+------------
+### ! For OS X 10.9 or later only !
+- New toolbar icons
+- Use default external application to view content of cached XML files
+- Show acknowledgements in "About" panel
+- Technical updates :
+	- Converted NIBs to XIBs and to Auto Layout
+	- Moved translation system to Base localization and Crowdin
+	- Refactored some UI elements to separate XIB files
+	- Refactorings (to KVO or delegate patterns, and conversion of various elements to properties)
+	- Change OpenReader to use asynchronous requests
+	- Update to Xcode 9
+	- Conversion of code for some UI elements to Swift4
+	- Replace CDEvents with Swift-based FSEvents implementation
+	- Update autorevision to 1.20
+	- Update Sparkle to 1.18.1
+	- Update MASPreferences to 1.3.0
+	- plus various housekeeping changes…
+
+3.1.16
+------
+- Fix article selection after an article is deleted from within the 'Unread Articles' folder
+- Fix bugs related to multithreading
+- Fix handling of impossibility of creating the database
+
+3.1.15
+------
+- Fix article list not scrolling to top when selecting a folder
+- Fix 'Skip Folder' not selecting the first unread article in the next folder with unread articles
+
+3.1.14
+------
+- Fix article pane not updating on article deletion from the 'Unread Articles' folder
+
+3.1.13
+------
+- Fixes related to searching and smart folders
+- Fix for selection of first article when jumping on next feed
+- Better fix for unwanted reload of the article currently being read during sync
+
+3.1.12
+------
+- Fix crashes induced by some URLs
+- Fix crash on macOS 10.13 High Sierra related to Activity window
+- Fix unwanted reload of the article currently being read during sync
+- Fix selection of current article on change of sort criterion/order
+- Fix bug where Vienna doesn't quit when you press ‘Quit Vienna’ in the Database Upgrade window
+- Truncate long text items with an ellipsis
+
+3.1.11
+------
+- Fix deleting article from smart folder or filtered folder
+- Fix selection of last unread article with Next Unread command
+- Update FMDB to 2.7.2
+
+3.1.10
+------
+- Fix access to Get Info window
+- Fix CoreAnimation related problems
+
+3.1.9
+-----
+- Change the website to vienna-rss.com as the old domain name (vienna-rss.org) could not be renewed. Perform a minor database evolution to update this.
+- Add a plug-in supporting wallabag.it
+- Show acknowledgements in "About" dialog box
+- Fix del.icio.us URL
+- Fix an issue with icon
+- Change status bar icons to scalable pdfs
+- Remove textures in some windows, change some .nib to .xib
+- Refactor things (window preferences code, delegates, organization of help files …)
+- Modernize build architecture (Xcode 8.2, update pods)
+
 3.1.8
 -----
 - Fixed an External XML Entity (XXE) vulnerability which allowed servers to steal the content of files on the machine running Vienna

--- a/notes.html
+++ b/notes.html
@@ -108,14 +108,30 @@ sup {
 
 <h1 id="toc_0">Version Notes</h1>
 
-<h2 id="toc_1">3.1.8</h2>
+<h2 id="toc_1">3.2.0 Beta 1</h2>
+
+<h3 id="toc_2">! For OS X 10.9 or later only !</h3>
 
 <ul>
-<li>Fixed an External XML Entity (XXE) vulnerability which allowed servers to steal the content of files on the machine running Vienna</li>
-<li>Fix incorrect escaping of OPML export</li>
-<li>Fix font preferences not working</li>
-<li>Fix error on unread articles count with OpenReader feeds</li>
-<li>Fix articles&#39; list during feed refreshes when the current selection is a smart or group folder </li>
+<li>New toolbar icons</li>
+<li>Use default external application to view content of cached XML files</li>
+<li>Show acknowledgements in &quot;About&quot; panel</li>
+<li>Technical updates :
+
+<ul>
+<li>Converted NIBs to XIBs and to Auto Layout</li>
+<li>Moved translation system to Base localization and Crowdin</li>
+<li>Refactored some UI elements to separate XIB files</li>
+<li>Refactorings (to KVO or delegate patterns, and conversion of various elements to properties)</li>
+<li>Change OpenReader to use asynchronous requests</li>
+<li>Update to Xcode 9</li>
+<li>Conversion of code for some UI elements to Swift4</li>
+<li>Replace CDEvents with Swift-based FSEvents implementation</li>
+<li>Update autorevision to 1.20</li>
+<li>Update Sparkle to 1.18.1</li>
+<li>Update MASPreferences to 1.3.0</li>
+<li>plus various housekeeping changes…</li>
+</ul></li>
 </ul>
 
 


### PR DESCRIPTION
My intention is to release 3.2.0_beta1 this week, and publish 3.2.0 on January 28th.

Cf. cycle described [here](https://github.com/ViennaRSS/vienna-rss/wiki/Vienna-Development-Cycle-(WIP)).

