### PR TITLE
Protect against NSXMLParserTagNameMismatchError

### DIFF
--- a/src/RichXMLParser.m
+++ b/src/RichXMLParser.m
@@ -65,8 +65,11 @@
                 switch (error.code) {
                     case NSXMLParserGTRequiredError:
                         return NO;
+                    case NSXMLParserTagNameMismatchError:
+                        return NO;
                 }
             }
+
             // recover some cases like text encoding errors, non standard tags...
             xmlDocument = [[NSXMLDocument alloc] initWithData:xmlData
                                                       options:NSXMLDocumentTidyXML|NSXMLNodeLoadExternalEntitiesNever


### PR DESCRIPTION
When adding a new feed with NSXMLDocumentTidyXML, some types of errors cause
an unhandled exception. I added NSXMLParserTagNameMismatchError as another case
which we should fail on when parsing a feed.

Closes #1073