### PR TITLE
Articles shortcut

### DIFF
--- a/Interfaces/Base.lproj/MainMenu.xib
+++ b/Interfaces/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13122.19" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13122.19"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ViennaApp">
@@ -447,6 +447,11 @@ CA
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="390">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Article List" keyEquivalent="y" id="Rs9-r3-soc">
+                                <connections>
+                                    <action selector="viewArticlesTab:" target="-1" id="p4V-jV-gaL"/>
+                                </connections>
                             </menuItem>
                             <menuItem title="Next Unread" keyEquivalent="u" id="344">
                                 <connections>

--- a/Vienna/Vienna Help/Resources/cs.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/cs.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/da.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/da.lproj/keyboard.html
@@ -241,6 +241,10 @@
         <p>Hopper til den næste ulæste artikel.</p>
       </td>
     </tr>
+	<tr>
+		<td>Command-Y</td>
+		<td>Opens the article list tab.</td>
+	</tr>
     <tr>
       <td>
         <p>Skift-Command-M</p>

--- a/Vienna/Vienna Help/Resources/de.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/de.lproj/keyboard.html
@@ -62,6 +62,10 @@ menus. To see a contextual menu, press the Steuerung key and click the item.</p>
     <td>Springt zum nächsten ungelesen Artikel.</td>
   </tr>
   <tr>
+	  <td>Befehl-Y</td>
+	  <td>Öffnet die Artikelliste.</td>
+  </tr>
+  <tr>
     <td>Enter</td>
     <td>Öffnet die permanente Webadresse des momentanen Artikels.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/en.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/en.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/es.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/es.lproj/keyboard.html
@@ -151,6 +151,10 @@
       <td>Shift-Comando-U</td>
       <td>Marca como leídos los artículos seleccionados.</td>
     </tr>
+	<tr>
+		<td>Command-Y</td>
+		<td>Opens the article list tab.</td>
+	</tr>
     <tr>
       <td>Shift-Comando-S</td>
       <td>Marca como leída la carpeta seleccionada y se desplaza a

--- a/Vienna/Vienna Help/Resources/eu.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/eu.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/fr.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/fr.lproj/keyboard.html
@@ -260,6 +260,10 @@
       <td>Shift-⌘-U</td>
       <td>Marque les articles sélectionnés comme étant lus.</td>
     </tr>
+	<tr>
+		<td>Command-Y</td>
+		<td>Opens the article list tab.</td>
+	</tr>
     <tr>
       <td>Alt-⌘-S</td>
       <td>Ouvre l'application de messagerie par défaut et crée un

--- a/Vienna/Vienna Help/Resources/gl.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/gl.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/it.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/it.lproj/keyboard.html
@@ -76,6 +76,10 @@
       <td>Comando-U</td>
       <td>Va all'articolo successivo non letto.</td>
     </tr>
+	<tr>
+		<td>Command-Y</td>
+		<td>Opens the article list tab.</td>
+	</tr>
     <tr>
       <td>Enter/Return</td>
       <td>Apre l'articolo selezionato nella pagina web

--- a/Vienna/Vienna Help/Resources/ja.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/ja.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/ko.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/ko.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/pt-BR.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/pt-BR.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/pt.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/pt.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/ru.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/ru.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/sv.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/sv.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/tr.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/tr.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/uk.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/uk.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/zh-Hans.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/zh-Hans.lproj/keyboard.html
@@ -175,6 +175,10 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
     <td>Moves to the next unread article.</td>
   </tr>
   <tr>
+	  <td>Command-Y</td>
+	  <td>Opens the article list tab.</td>
+  </tr>
+  <tr>
     <td>Command-Z</td>
     <td>Undoes the last action, if it can be undone.</td>
   </tr>

--- a/Vienna/Vienna Help/Resources/zh-Hant.lproj/keyboard.html
+++ b/Vienna/Vienna Help/Resources/zh-Hant.lproj/keyboard.html
@@ -60,6 +60,10 @@
       <td>Command-U</td>
       <td>移動到下一篇未讀的文章</td>
     </tr>
+	<tr>
+		<td>Command-Y</td>
+		<td>Opens the article list tab.</td>
+	</tr>
     <tr>
       <td>Enter/Return</td>
       <td>開啟所選擇的文章的原始網頁。</td>

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -92,6 +92,7 @@
 -(IBAction)markFlagged:(id)sender;
 -(IBAction)renameFolder:(id)sender;
 -(IBAction)viewFirstUnread:(id)sender;
+-(IBAction)viewArticlesTab:(id)sender;
 -(IBAction)viewNextUnread:(id)sender;
 -(IBAction)printDocument:(id)sender;
 -(IBAction)goBack:(id)sender;

--- a/src/AppController.m
+++ b/src/AppController.m
@@ -2284,6 +2284,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		case 'N':
 			[self viewNextUnread:self];
 			return YES;
+
+		case 'y':
+		case 'Y':
+			[self viewArticlesTab:self];
 			
 		case 'u':
 		case 'U':
@@ -2941,6 +2945,14 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 }
 
 #pragma mark Tabs
+
+/* articlesTab
+ * Go straight back to the articles tab
+ */
+-(void)viewArticlesTab:(id)sender
+{
+	[self.browserView showArticlesTab];
+}
 
 /* previousTab
  * Display the previous tab, if there is one.

--- a/src/BrowserView.h
+++ b/src/BrowserView.h
@@ -48,6 +48,7 @@
 @property (nonatomic, readonly) NSInteger countOfTabs;
 -(void)createNewTabWithView:(NSView<BaseView> *)newTabView makeKey:(BOOL)keyIt;
 -(void)showTabItemView:(NSView *)theTabView;
+-(void)showArticlesTab;
 -(void)showPreviousTab;
 -(void)showNextTab;
 -(void)saveOpenTabs;

--- a/src/BrowserView.m
+++ b/src/BrowserView.m
@@ -256,6 +256,14 @@
 	}
 }
 
+/* articlesTab
+ * Go straight back to the articles tab
+ */
+-(void)showArticlesTab
+{
+	[self showTabItemView:primaryTabItemView];
+}
+
 /* showPreviousTab
  * Switch to the previous tab in the view order. Wrap round to the end
  * if we're at the beginning.


### PR DESCRIPTION
Command-Y or Command-y lets you jump straight to the articles. Solves #1071 and partly solves #430 . The other part of #430 is solved when we install the preference pane for the tab closing behavior changes. I am preparing it at the moment.