### PR TITLE
Fix a warning when user adds subscription

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -854,7 +854,9 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
     // If this folder also requires an image refresh, do that
     if ((folder.flags & VNAFolderFlagCheckForImage)) {
-        [self refreshFavIconForFolder:folder];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self refreshFavIconForFolder:folder];
+        });
     }
 }
 


### PR DESCRIPTION
Warning about ‘UI API called on a background thread’ was caused by icon
fetching.