### PR TITLE
Use system text colour for horizontal layout text

### DIFF
--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -127,8 +127,8 @@
 	style.tighteningFactorForTruncation = 0.0;
 	
     if (@available(macOS 10.10, *)) {
-        reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor labelColor], NSForegroundColorAttributeName, nil];
-        unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor labelColor], NSForegroundColorAttributeName, nil];
+        reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor textColor], NSForegroundColorAttributeName, nil];
+        unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor textColor], NSForegroundColorAttributeName, nil];
     } else {
         reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];
         unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -126,9 +126,14 @@
 	style.lineBreakMode = NSLineBreakByTruncatingTail;
 	style.tighteningFactorForTruncation = 0.0;
 	
-	reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];
-	unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];
-		
+    if (@available(macOS 10.10, *)) {
+        reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor labelColor], NSForegroundColorAttributeName, nil];
+        unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor labelColor], NSForegroundColorAttributeName, nil];
+    } else {
+        reportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];
+        unreadReportCellDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, nil];
+    }
+    		
 	selectionDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor whiteColor], NSForegroundColorAttributeName, nil];
 	unreadTopLineDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor textColor], NSForegroundColorAttributeName, nil];
 	topLineDict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:style, NSParagraphStyleAttributeName, [NSColor textColor], NSForegroundColorAttributeName, nil];


### PR DESCRIPTION
Use the system text colour for macOS >= 10.10 to improve legibility of horizontal layout when using dark mode.

Partially solves #1184.

Not sure if this is the best way to fix this as I've been out of touch with dark mode stuff. @barijaona please provide your input :)

## Dark mode example on 10.14
![screen shot 2018-10-14 at 18 05 54](https://user-images.githubusercontent.com/799345/46915355-039ad180-cfdd-11e8-867b-8c1c058d0a5c.png)

## Light mode example on 10.14
![image](https://user-images.githubusercontent.com/799345/46915359-2cbb6200-cfdd-11e8-856b-d7f599f4449a.png)

## Dark mode regression example for vertical layout on 10.14
![screen shot 2018-10-14 at 18 07 08](https://user-images.githubusercontent.com/799345/46915345-e108b880-cfdc-11e8-8e4c-65a1ac2215dd.png)


