### PR TITLE
use mojave style

### DIFF
--- a/Vienna/Sources/Main window/BrowserView.m
+++ b/Vienna/Sources/Main window/BrowserView.m
@@ -72,7 +72,7 @@
 
 -(void)configureTabBar
 {
-    if (@available(macOS 10.10,*)) {
+    if (@available(macOS 10.14, *)) {
         [self.tabBarControl setStyleNamed:@"Mojave"];
     } else {
         [self.tabBarControl setStyleNamed:@"Sierra"];

--- a/Vienna/Sources/Main window/BrowserView.m
+++ b/Vienna/Sources/Main window/BrowserView.m
@@ -72,7 +72,11 @@
 
 -(void)configureTabBar
 {
-	[self.tabBarControl setStyleNamed:@"Sierra"];
+    if (@available(macOS 10.10,*)) {
+        [self.tabBarControl setStyleNamed:@"Mojave"];
+    } else {
+        [self.tabBarControl setStyleNamed:@"Sierra"];
+    }
 	//TODO: settings
 	[self.tabBarControl setOnlyShowCloseOnHover:YES];
 	[self.tabBarControl setCanCloseOnlyTab:NO];


### PR DESCRIPTION
needs https://github.com/ViennaRSS/MMTabBarView/pull/7
for the style to be available in MMTabBar

According to https://github.com/MiMo42/MMTabBarView/pull/62 , this version should provide automatic dark mode capabilities to the browser tab bar.
Related issues are #1164 (dark mode generally) and #1184 (tab titles specifically)