### PR TITLE
Align folder names on left in subscriptions panel

### DIFF
--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -947,6 +947,7 @@
 		NSMutableParagraphStyle * style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
 		style.lineBreakMode = NSLineBreakByTruncatingTail;
 		style.tighteningFactorForTruncation = 0.0;
+		style.alignment = NSTextAlignmentLeft;
 		info = @{NSParagraphStyleAttributeName: style};
 	}
 


### PR DESCRIPTION
Feed titles / folder names should be aligned on left end, even when they
are in right-to-left (RTL) languages, like Arabic.
Issue #1193