### PR TITLE
Update travis CI config to use Xcode 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode10
 
 cache: carthage
 


### PR DESCRIPTION
It still uses macOS 10.13 for now but hopefully it will move to macOS 10.14 once they update their images.