### PR TITLE
Fixes and clarifications for OpenReader

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2457,7 +2457,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		[myGoogle subscribeToFeed:urlString];
 		NSString * folderName = [db folderFromID:parentId].name;
 		if (folderName != nil)
-			[myGoogle setFolderName:folderName forFeed:urlString set:TRUE];
+			[myGoogle setFolderLabel:folderName forFeed:urlString set:TRUE];
 		[myGoogle loadSubscriptions];
 
 	}

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -29,7 +29,7 @@
 -(void)unsubscribeFromFeed:(NSString *)feedURL;
 -(void)markRead:(Article *)article readFlag:(BOOL)flag;
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag;
--(void)setFolderName:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
+-(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
 -(void)refreshFeed:(Folder*)thisFolder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:(BOOL)ignoreLimit;
 @property (nonatomic, readonly) NSUInteger countOfNewArticles;
 

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -30,6 +30,7 @@
 -(void)markRead:(Article *)article readFlag:(BOOL)flag;
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag;
 -(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
+-(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedURL;
 -(void)refreshFeed:(Folder*)thisFolder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:(BOOL)ignoreLimit;
 @property (nonatomic, readonly) NSUInteger countOfNewArticles;
 

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -958,7 +958,13 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     NSURL *unsubscribeURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/edit", APIBaseURL]];
     NSMutableURLRequest *myRequest = [self authentifiedFormRequestFromURL:unsubscribeURL];
     [myRequest setPostValue:@"unsubscribe" forKey:@"ac"];
-    [myRequest setPostValue:[NSString stringWithFormat:@"feed/%@", feedURL] forKey:@"s"];
+    NSString *feedIdentifier;
+    if (hostRequiresHexaForFeedId) {
+        feedIdentifier = feedURL.lastPathComponent;
+    } else {
+        feedIdentifier = feedURL;
+    }
+    [myRequest setPostValue:[NSString stringWithFormat:@"feed/%@", percentEscape(feedIdentifier)] forKey:@"s"];
     __weak typeof(self) weakSelf = self;
     [[RefreshManager sharedManager] addConnection:myRequest
         completionHandler :^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -971,17 +977,23 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     ];
 }
 
-/* setFolderName
- * set or remove a folder name to a newsfeed
+/* setFolderLabel:forFeed:set:
+ * add or remove a label (folder name) to a newsfeed
  * set parameter : TRUE => add ; FALSE => remove
  */
--(void)setFolderName:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag
+-(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag
 {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/edit?client=%@", APIBaseURL, ClientName]];
 
     NSMutableURLRequest *request = [self authentifiedFormRequestFromURL:url];
     [request setPostValue:@"edit" forKey:@"ac"];
-    [request setPostValue:[NSString stringWithFormat:@"feed/%@", feedURL] forKey:@"s"];
+    NSString *feedIdentifier;
+    if (hostRequiresHexaForFeedId) {
+        feedIdentifier = feedURL.lastPathComponent;
+    } else {
+        feedIdentifier = feedURL;
+    }
+    [request setPostValue:[NSString stringWithFormat:@"feed/%@", percentEscape(feedIdentifier)] forKey:@"s"];
     [request setPostValue:[NSString stringWithFormat:@"user/-/label/%@", folderName] forKey:flag ? @"a" : @"r"];
     __weak typeof(self) weakSelf = self;
     [[RefreshManager sharedManager] addConnection:request

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -903,7 +903,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 
 
-    if (subscriptionsDict[@"subscription"] != nil) { // detect probable authentication error
+    if (subscriptionsDict[@"subscriptions"] != nil) { // detect probable authentication error
         //check if we have a folder which is not registered as a Open Reader feed
         for (Folder *f in APPCONTROLLER.folders) {
             if (f.type == VNAFolderTypeOpenReader && ![googleFeeds containsObject:f.feedURL]) {

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -41,9 +41,9 @@ NSString *openReaderHost;
 NSString *username;
 NSString *password;
 NSString *APIBaseURL;
-BOOL hostSupportsLongId;
+BOOL hostSendsHexaItemId;
 BOOL hostRequiresSParameter;
-BOOL hostRequiresLastPathOnly;
+BOOL hostRequiresHexaForFeedId;
 BOOL hostRequiresInoreaderAdditionalHeaders;
 BOOL hostRequiresBackcrawling;
 NSDictionary *inoreaderAdditionalHeaders;
@@ -251,16 +251,16 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     username = prefs.syncingUser;
     openReaderHost = prefs.syncServer;
     // default settings
-    hostSupportsLongId = NO;
+    hostSendsHexaItemId = NO;
     hostRequiresSParameter = NO;
-    hostRequiresLastPathOnly = NO;
+    hostRequiresHexaForFeedId = NO;
     hostRequiresInoreaderAdditionalHeaders = NO;
     hostRequiresBackcrawling = YES;
     // settings for specific kind of servers
     if ([openReaderHost isEqualToString:@"theoldreader.com"]) {
-        hostSupportsLongId = YES;
+        hostSendsHexaItemId = YES;
         hostRequiresSParameter = YES;
-        hostRequiresLastPathOnly = YES;
+        hostRequiresHexaForFeedId = YES;
         hostRequiresBackcrawling = NO;
     }
     if ([openReaderHost rangeOfString:@"inoreader.com"].length != 0) {
@@ -442,7 +442,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 
     NSString *feedIdentifier;
-    if (hostRequiresLastPathOnly) {
+    if (hostRequiresHexaForFeedId) {
         feedIdentifier = thisFolder.feedURL.lastPathComponent;
     } else {
         feedIdentifier =  thisFolder.feedURL;
@@ -731,7 +731,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                 NSMutableArray *guidArray = [NSMutableArray arrayWithCapacity:itemRefsArray.count];
                 for (NSDictionary *itemRef in itemRefsArray) {
                     NSString *guid;
-                    if (hostSupportsLongId) {
+                    if (hostSendsHexaItemId) {
                         guid = [NSString stringWithFormat:@"tag:google.com,2005:reader/item/%@", itemRef[@"id"]];
                     } else {
                         // as described in http://code.google.com/p/google-reader-api/wiki/ItemId
@@ -793,7 +793,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                 NSMutableArray *guidArray = [NSMutableArray arrayWithCapacity:itemRefsArray.count];
                 for (NSDictionary *itemRef in itemRefsArray) {
                     NSString *guid;
-                    if (hostSupportsLongId) {
+                    if (hostSendsHexaItemId) {
                         guid = [NSString stringWithFormat:@"tag:google.com,2005:reader/item/%@", itemRef[@"id"]];
                     } else {
                         // as described in http://code.google.com/p/google-reader-api/wiki/ItemId

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -843,7 +843,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     NSArray *localFolders = APPCONTROLLER.folders;
 
     for (Folder *f in localFolders) {
-        if (f.feedURL) {
+        if (f.feedURL && f.type == VNAFolderTypeOpenReader) {
             [localFeeds addObject:f.feedURL];
         }
     }
@@ -853,9 +853,14 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         if (feedID == nil) {
             break;
         }
-        NSString *feedURL = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
-        if (![feedURL hasPrefix:@"http:"] && ![feedURL hasPrefix:@"https:"]) {
-            feedURL = [NSString stringWithFormat:@"https://%@/reader/public/atom/%@", openReaderHost, feedURL];
+        NSString *feedURL = feed[@"url"];
+        if (feedURL == nil || hostRequiresHexaForFeedId) { // TheOldReader requires BSON identifier in stream Ids instead of URL (ex: feed/0125ef...)
+            NSString * feedIdentifier = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
+            if (hostRequiresHexaForFeedId) { // TheOldReader
+                feedURL = [NSString stringWithFormat:@"https://%@/reader/public/atom/%@", openReaderHost, feedIdentifier];
+            } else { // most services use feed URL as identifier (like GoogleReader did)
+                feedURL = feedIdentifier;
+            }
         }
 
         NSString *folderName = nil;

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1335,10 +1335,10 @@
 					OpenReader * myGoogle = [OpenReader sharedManager];
 					// remove old label
 					NSString * folderName = [dbManager folderFromID:oldParentId].name;
-					[myGoogle setFolderName:folderName forFeed:folder.feedURL set:FALSE];
+					[myGoogle setFolderLabel:folderName forFeed:folder.feedURL set:FALSE];
 					// add new label
 					folderName = [dbManager folderFromID:newParentId].name;
-					[myGoogle setFolderName:folderName forFeed:folder.feedURL set:TRUE];
+					[myGoogle setFolderLabel:folderName forFeed:folder.feedURL set:TRUE];
 				}
 			}
 			else

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1140,6 +1140,9 @@
 		else
         {
             [dbManager setName:newName forFolder:folder.itemId];
+            if (folder.type == VNAFolderTypeOpenReader) {
+                [[OpenReader sharedManager] setFolderTitle:newName forFeed:folder.feedURL];
+            }
         }
 	}
 }


### PR DESCRIPTION
- Fix a typo which prevents feeds unsubscribed at the server level to be removed from Vienna
- Prevent a crash occurring on non standard responses to ClientLogin requests
- Fix feed unsubscribes and moves for TheOldReader
- Sync feed titles between Vienna and the server
- Clarification of names of configuration variables

Discussion : FreshRSS/FreshRSS#2091 and ViennaRSS/vienna-rss#1197