### PR TITLE
Fix crash when displaying some article summary

### DIFF
--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -260,79 +260,77 @@ static NSMutableDictionary * entityMap = nil;
  */
 +(NSString *)stringByRemovingHTML:(NSString *)theString
 {
-	NSMutableString * aString = [NSMutableString stringWithString:theString];
-	NSInteger maxChrs = theString.length;
-	NSInteger cutOff = 600;
-	NSInteger indexOfChr = 0;
-	NSInteger tagLength = 0;
-	NSInteger tagStartIndex = 0;
-	BOOL isInQuote = NO;
-	BOOL isInTag = NO;
+    NSMutableString *aString = [NSMutableString stringWithString:theString];
+    NSInteger maxChrs = theString.length;
+    NSInteger cutOff = 600;
+    NSInteger indexOfChr = 0;
+    NSInteger tagLength = 0;
+    NSInteger tagStartIndex = 0;
+    BOOL isInQuote = NO;
+    BOOL isInTag = NO;
 
-	// Rudimentary HTML tag parsing. This could be done by initWithHTML on an attributed string
-	// and extracting the raw string but initWithHTML cannot be invoked within an NSURLConnection
-	// callback which is where this is probably liable to be used.
-	while (indexOfChr < maxChrs)
-	{
-		unichar ch = [aString characterAtIndex:indexOfChr];
-		if (isInTag)
-			++tagLength;
-		else if (indexOfChr >= cutOff)
-			break;
-		
-		if (ch == '"')
-			isInQuote = !isInQuote;
-		else if (ch == '<' && !isInQuote)
-		{
-			isInTag = YES;
-			tagStartIndex = indexOfChr;
-			tagLength = 0;
-		}
-		else if (ch == '>' && isInTag)
-		{
-			if (tagLength > 1)
-			{
-				++tagLength; // Include the start tag
-				NSRange tagRange = NSMakeRange(tagStartIndex, tagLength);
-				NSString * tag = [aString substringWithRange:tagRange].lowercaseString;
-				NSInteger indexOfTagName = 1;
+    // Rudimentary HTML tag parsing. This could be done by initWithHTML on an attributed string
+    // and extracting the raw string but initWithHTML cannot be invoked within an NSURLConnection
+    // callback which is where this is probably liable to be used.
+    while (indexOfChr < maxChrs) {
+        unichar ch = [aString characterAtIndex:indexOfChr];
+        if (isInTag) {
+            ++tagLength;
+        } else if (indexOfChr >= cutOff) {
+            break;
+        }
 
-				// Extract the tag name
-				if ([tag characterAtIndex:indexOfTagName] == '/')
-					++indexOfTagName;
-				
-				NSInteger chIndex = indexOfTagName;
-				unichar ch = [tag characterAtIndex:chIndex];
-				while (chIndex < tagLength && [[NSCharacterSet lowercaseLetterCharacterSet] characterIsMember:ch])
-					ch = [tag characterAtIndex:++chIndex];
-	
-				NSString * tagName = [tag substringWithRange:NSMakeRange(indexOfTagName, chIndex - indexOfTagName)];
-				[aString deleteCharactersInRange:tagRange];
+        if (ch == '"') {
+            isInQuote = !isInQuote;
+        } else if (ch == '<' && !isInQuote) {
+            isInTag = YES;
+            tagStartIndex = indexOfChr;
+            tagLength = 0;
+        } else if (ch == '>' && isInTag) {
+            if (tagLength > 1) {
+                ++tagLength;                 // Include the start tag
+                NSRange tagRange = NSMakeRange(tagStartIndex, tagLength);
+                NSString *tag = [aString substringWithRange:tagRange].lowercaseString;
+                NSInteger indexOfTagName = 1;
 
-				// Replace <br> and </p> with newlines
-				if ([tagName isEqualToString:@"br"] || [tag isEqualToString:@"<p>"] || [tag isEqualToString:@"<div>"])
-					[aString insertString:@"\n" atIndex:tagRange.location];
+                // Extract the tag name
+                if ([tag characterAtIndex:indexOfTagName] == '/') {
+                    ++indexOfTagName;
+                }
 
-				// Reset scan to the point where the tag started minus one because
-				// we bump up indexOfChr at the end of the loop.
-				indexOfChr = tagStartIndex - 1;
-				maxChrs = aString.length;
-				isInTag = NO;
-				isInQuote = NO;	// Fix problem with Tribe.net feeds that have bogus quotes in HTML tags
-			}
-			else if (!isInQuote)
-			{
-				isInTag = NO;
-			}
-		}
-		++indexOfChr;
-	}
-	
-	if (maxChrs > cutOff)
-		[aString deleteCharactersInRange:NSMakeRange(cutOff, maxChrs - cutOff)];
-	
-	return aString.stringByUnescapingExtendedCharacters;
-}
+                NSInteger chIndex = indexOfTagName;
+                unichar ch = [tag characterAtIndex:chIndex];
+                while (chIndex < tagLength && [[NSCharacterSet lowercaseLetterCharacterSet] characterIsMember:ch]) {
+                    ch = [tag characterAtIndex:++chIndex];
+                }
+
+                NSString *tagName = [tag substringWithRange:NSMakeRange(indexOfTagName, chIndex - indexOfTagName)];
+                [aString deleteCharactersInRange:tagRange];
+
+                // Replace <br> and </p> with newlines
+                if ([tagName isEqualToString:@"br"] || [tag isEqualToString:@"<p>"] || [tag isEqualToString:@"<div>"]) {
+                    [aString insertString:@"\n" atIndex:tagRange.location];
+                }
+
+                // Reset scan to the point where the tag started minus one because
+                // we bump up indexOfChr at the end of the loop.
+                indexOfChr = tagStartIndex - 1;
+                maxChrs = aString.length;
+                isInTag = NO;
+                isInQuote = NO;                 // Fix problem with Tribe.net feeds that have bogus quotes in HTML tags
+            } else if (!isInQuote) {
+                isInTag = NO;
+            }
+        }
+        ++indexOfChr;
+    }
+
+    if (maxChrs > cutOff) {
+        [aString deleteCharactersInRange:NSMakeRange(cutOff, maxChrs - cutOff)];
+    }
+
+    return aString.stringByUnescapingExtendedCharacters;
+} // stringByRemovingHTML
 
 /* normalised
  * Returns the current string normalised. Newlines are removed and replaced with spaces and multiple

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -290,8 +290,9 @@ static NSMutableDictionary * entityMap = nil;
 		}
 		else if (ch == '>' && isInTag)
 		{
-			if (++tagLength > 2)
+			if (tagLength > 1)
 			{
+				++tagLength; // Include the start tag
 				NSRange tagRange = NSMakeRange(tagStartIndex, tagLength);
 				NSString * tag = [aString substringWithRange:tagRange].lowercaseString;
 				NSInteger indexOfTagName = 1;
@@ -318,6 +319,10 @@ static NSMutableDictionary * entityMap = nil;
 				maxChrs = aString.length;
 				isInTag = NO;
 				isInQuote = NO;	// Fix problem with Tribe.net feeds that have bogus quotes in HTML tags
+			}
+			else if (!isInQuote)
+			{
+				isInTag = NO;
 			}
 		}
 		++indexOfChr;


### PR DESCRIPTION
Issue #1211: problematic feed:
https://www.channel3000.com/feeds/rssFeed?obfType=DOAPP_STORIES&siteId=400001&categoryId=10001
An article description had a series of <><><><><> that our parser
wasn't expecting.