### PR TITLE
Add support for dark mode to Credits.rtf

### DIFF
--- a/Credits.rtf
+++ b/Credits.rtf
@@ -1,17 +1,16 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1671
+{\rtf1\ansi\ansicpg1252\cocoartf1671\cocoasubrtf200
 {\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 Helvetica-Bold;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0\cname textColor;}
 {\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
 {\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
-\paperw12240\paperh15840\vieww18240\viewh8480\viewkind0
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+\paperw12240\paperh15840\vieww10800\viewh7900\viewkind0
+\pard\tx185\tx427\pardirnatural\partightenfactor0
 
-\f0\fs22 \cf0 Portions of this software may utilize the following copyrighted material, the use of which is hereby acknowledged.\
+\f0\fs22 \cf2 Portions of this software may utilize the following copyrighted material, the use of which is hereby acknowledged.\
 \
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
-\f1\b \cf0 Vienna development team
+\f1\b Vienna development team
 \f0\b0 \
 \
 	\'95	Steve Palmer\
@@ -51,115 +50,75 @@
 \f1\b Graphics
 \f0\b0 \
 \
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li425\fi-426\pardirnatural\partightenfactor0
-\cf0 	\'95	Nick Daz\'e9, for the Vienna 3 icon and many visual improvements.\
+	\'95	Nick Daz\'e9, for the Vienna 3 icon and many visual improvements.\
 	\'95	Brandon Booth, for the General and Appearance preference icons.\
 	\'95	Philipp Antoni, for the UI improvements in 2.2.\
 	\'95	"Add to Safari reading list" icon originally authored from {\field{\*\fldinst{HYPERLINK "https://emey87.deviantart.com"}}{\fldrslt Emey87}}, used under a Creative Commons Attribution-No Derivative Works 3.0 Unported license.\
 	\'95	Monochrome status bar icon: Font Awesome by {\field{\*\fldinst{HYPERLINK "https://fontawesome.io"}}{\fldrslt Dave Gand}}, used under a SIL Open Font License (OFL) 1.1 license.\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+\
 
-\f1\b \cf0 Localizations
+\f1\b Localizations
 \f0\b0 \
 \
 Basque\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Aitor Zubizarreta\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Aitor Zubizarreta\
+\
 Simplified Chinese\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Arsen Liang\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Arsen Liang\
+\
 Traditional Chinese\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Weizhong Yang and Jack M.H. Lin\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Weizhong Yang and Jack M.H. Lin\
+\
 Czech\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Jakub Formanek and Boris Du\'9aek\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Jakub Formanek and Boris Du\'9aek\
+\
 Danish\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	David Munch\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		David Munch\
+\
 Dutch\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Martijn van Exel, Peter van Peursem and Konstruktionist\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Martijn van Exel, Peter van Peursem and Konstruktionist\
+\
 French\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Cyril Gautrias\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Cyril Gautrias\
+\
 German\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Jan Kampling, Michael Str\'f6ck and biphuhn\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Jan Kampling, Michael Str\'f6ck and biphuhn\
+\
 Italian\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Marcello Teodori\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Marcello Teodori\
+\
 Japanese\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Daisuke Okada\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Daisuke Okada\
+\
 Korean\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Lee Seung Koo\
+		Lee Seung Koo\
 \
 Lithuanian\
-	Andrius Dru\'9einis-Vitkus\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Andrius Dru\'9einis-Vitkus\
+\
 Portuguese\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Rui Carlos A. Gon\'e7alves\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Rui Carlos A. Gon\'e7alves\
+\
 Brazilian Portuguese\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Helv\'e9cio Mafra and Adriano Marcondes Machado\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Helv\'e9cio Mafra and Adriano Marcondes Machado\
+\
 Spanish\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Carlos Morales and Juan Pablo Atienza Martinez\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Carlos Morales and Juan Pablo Atienza Martinez\
+\
 Swedish\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Christoffer Larsson and Peter Vendleg\'e5rd\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Christoffer Larsson and Peter Vendleg\'e5rd\
+\
 Turkish\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Emrah Omuris\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Emrah Omuris\
+\
 Russian\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Taras "sacrat" Brizitsky\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+		Taras "sacrat" Brizitsky\
+\
 Ukrainian\
-\pard\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li424\fi-425\pardirnatural\partightenfactor0
-\cf0 	Andriy Kachalo\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+		Andriy Kachalo\
+\
 
-\f1\b \cf0 FMDatabase Library
+\f1\b FMDatabase Library
 \f0\b0 \
 Copyright (c) 2008-2014 Flying Meat Inc.\
 \
@@ -181,16 +140,15 @@ Copyright (c) 2016 Vadim Shpakovski. All rights reserved.\
 \
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\
 \
-\pard\tx189\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li427\fi-428\pardirnatural\partightenfactor0
-\ls1\ilvl0\cf0 {\listtext	1.	}Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\
+\pard\tx185\tx427\pardirnatural\partightenfactor0
+\ls1\ilvl0 {\listtext	1.	}Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\
 {\listtext	2.	}Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0 \
+\pard\tx185\tx427\pardirnatural\partightenfactor0
+\
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\
 \
-\pard\tx185\tx427\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
-\f1\b \cf0 MMTabViewControl
+\f1\b MMTabViewControl
 \f0\b0 \
 Copyright \'a9 2005, Positive Spin Media. All rights reserved.\
 Copyright \'a9 2018, Michael Monscheuer. All rights reserved.\
@@ -231,5 +189,4 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\
 }


### PR DESCRIPTION
As suggested in the [10.14 AppKit release notes](https://developer.apple.com/documentation/macos_release_notes/macos_mojave_10_14_release_notes/appkit_release_notes_for_macos_10_14). I haven’t tested this on anything below 10.14 yet.

Supplements #1208