### PR TITLE
Update Swift support to version 4.2

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1967,12 +1967,12 @@
 				TargetAttributes = {
 					035B703419E0E4AE00197334 = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 8D15AC270486D014006FF6A4;
 					};
 					8D15AC270486D014006FF6A4 = {
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 					};
 					F64D8AC01F22BAAF0077D27C = {
 						CreatedOnToolsVersion = 9.0;
@@ -3239,7 +3239,7 @@
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna Tests/Vienna Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Vienna.app/Contents/MacOS/Vienna";
 			};
 			name = Development;
@@ -3296,7 +3296,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna Tests/Vienna Tests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Vienna.app/Contents/MacOS/Vienna";
 			};
 			name = Deployment;
@@ -3372,6 +3372,7 @@
 				PRODUCT_NAME = Vienna;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna/Sources/Vienna-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				WARNING_CFLAGS = "-Wall";
 			};
 			name = Development;
@@ -3406,6 +3407,7 @@
 				PRODUCT_NAME = Vienna;
 				SEPARATE_STRIP = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Vienna/Sources/Vienna-Bridging-Header.h";
+				SWIFT_VERSION = 4.2;
 				WARNING_CFLAGS = "-Wall";
 			};
 			name = Deployment;

--- a/Vienna/Sources/Main window/ButtonToolbarItem.swift
+++ b/Vienna/Sources/Main window/ButtonToolbarItem.swift
@@ -55,20 +55,12 @@ class ButtonToolbarItem: NSToolbarItem {
     // will allow any responder object to validate the toolbar item. This method
     // is also invoked in text-only mode.
     override func validate() {
-        guard let action = action else {
+        guard let action = action, let responder = NSApp.target(forAction: action, to: target, from: self) else {
             return
         }
 
-        guard let responder = NSApp.target(forAction: action, to: target, from: self) else {
-            if #available(macOS 10.12, *) {
-                os_log("Toolbar item with identifier '%@' has no responder", type: .debug, itemIdentifier as CVarArg)
-            }
-
-            return
-        }
-
-        if (responder as AnyObject).responds(to: #selector(validateToolbarItem(_:))) {
-            isEnabled = (responder as AnyObject).validateToolbarItem(self)
+        if let responder = responder as? NSToolbarItemValidation {
+            isEnabled = responder.validateToolbarItem(self)
         }
     }
 

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -104,28 +104,33 @@ final class MainWindowController: NSWindowController {
         statusBarState(disclosed: !statusBar.isDisclosed)
     }
 
-    // MARK: Validation
+    // MARK: Observation
 
-    override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        if menuItem.action == #selector(changeFiltering(_:)) {
-            menuItem.state = menuItem.tag == Preferences.standard().filterMode ? .on     : .off
-        } else if menuItem.action == #selector(toggleStatusBar(_:)) {
+    private var observationTokens: [NSKeyValueObservation] = []
+
+}
+
+// MARK: - Menu-item validation
+
+extension MainWindowController: NSMenuItemValidation {
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.action {
+        case #selector(changeFiltering(_:)):
+            menuItem.state = menuItem.tag == Preferences.standard().filterMode ? .on : .off
+        case #selector(toggleStatusBar(_:)):
             if statusBar.isDisclosed {
                 menuItem.title = NSLocalizedString("Hide Status Bar", comment: "Title of a menu item")
             } else {
                 menuItem.title = NSLocalizedString("Show Status Bar", comment: "Title of a menu item")
             }
-        } else {
-            return super.validateMenuItem(menuItem)
+        default:
+            return responds(to: menuItem.action)
         }
 
         // At this point, assume that the menu item is enabled.
         return true
     }
-
-    // MARK: Observation
-
-    private var observationTokens: [NSKeyValueObservation] = []
 
 }
 


### PR DESCRIPTION
Apple removed the NSResponder validator methods. NSWindowController no longer inherits these, so they must be implemented by conforming to a protocol ([see also](https://forums.developer.apple.com/thread/107328)).

This ought to be the last update until Swift 5, which promises ABI stability.