### PR TITLE
Replace a few RSS link templates in zh-Hant

### DIFF
--- a/Vienna/Resources/zh-Hant.lproj/RSSSources.plist
+++ b/Vienna/Resources/zh-Hant.lproj/RSSSources.plist
@@ -70,5 +70,41 @@
 		<key>SiteHomePage</key>
 		<string>https://logdown.com/</string>
 	</dict>
+	<key>字媒體</key>
+	<dict>
+		<key>LinkName</key>
+		<string>請輸入字媒體使用者名稱</string>
+		<key>LinkTemplate</key>
+		<string>https://zi.media/rss/authors/%@</string>
+		<key>SiteHomePage</key>
+		<string>https://zi.media/</string>
+	</dict>
+	<key>隨意窩</key>
+	<dict>
+		<key>LinkName</key>
+		<string>請輸入隨意窩使用者名稱</string>
+		<key>LinkTemplate</key>
+		<string>https://blog.xuite.net/%@/blog/rss.xml</string>
+		<key>SiteHomePage</key>
+		<string>https://blog.xuite.net/</string>
+	</dict>
+	<key>HatenaBlog</key>
+	<dict>
+		<key>LinkName</key>
+		<string>請輸入 HatenaBlog 使用者名稱</string>
+		<key>LinkTemplate</key>
+		<string>https://%@.hatenablog.com/feed</string>
+		<key>SiteHomePage</key>
+		<string>https://hatenablog.com/</string>
+	</dict>
+	<key>PChome 個人新聞台</key>
+	<dict>
+		<key>LinkName</key>
+		<string>請輸入 PChome 個人新聞台使用者名稱</string>
+		<key>LinkTemplate</key>
+		<string>http://mypaper.pchome.com.tw/%@/rss</string>
+		<key>SiteHomePage</key>
+		<string>http://mypaper.pchome.com.tw/</string>
+	</dict>
 </dict>
 </plist>

--- a/Vienna/Resources/zh-Hant.lproj/RSSSources.plist
+++ b/Vienna/Resources/zh-Hant.lproj/RSSSources.plist
@@ -27,15 +27,6 @@
 		<key>SiteHomePage</key>
 		<string>http://www.livejournal.com</string>
 	</dict>
-	<key>MSN Spaces</key>
-	<dict>
-		<key>LinkName</key>
-		<string>請輸入 MSN Spaces 使用者名稱</string>
-		<key>LinkTemplate</key>
-		<string>http://spaces.msn.com/members/%@/feed.rss</string>
-		<key>SiteHomePage</key>
-		<string>http://spaces.msn.com</string>
-	</dict>
 	<key>URL</key>
 	<dict>
 		<key>LinkName</key>
@@ -61,42 +52,23 @@
 		<key>SiteHomePage</key>
 		<string>http://wordpress.com</string>
 	</dict>
-	<key>Yam Blog</key>
+	<key>痞客邦部落格</key>
 	<dict>
 		<key>LinkName</key>
-		<string>請輸入 Yam Blog 樂多日誌使用者名稱</string>
+		<string>請輸入痞客邦部落格使用者名稱</string>
 		<key>LinkTemplate</key>
-		<string>http://blog.yam.com/%@/atom.xml</string>
+		<string>https://feed.pixnet.net/blog/posts/atom/%@</string>
 		<key>SiteHomePage</key>
-		<string>http://blog.yam.com</string>
+		<string>https://www.pixnet.net/blog</string>
 	</dict>
-	<key>無名小站</key>
+	<key>Logdown</key>
 	<dict>
 		<key>LinkName</key>
-		<string>請輸入無名小站使用者名稱</string>
+		<string>請輸入 Logdown 使用者名稱</string>
 		<key>LinkTemplate</key>
-		<string>feed://www.wretch.cc/blog/%@&amp;rss20=1</string>
+		<string>https://%@.logdown.com/posts.atom</string>
 		<key>SiteHomePage</key>
-		<string>http://www.wretch.cc/blog/</string>
-	</dict>
-	<key>部落格鄉村台灣站</key>
-	<dict>
-		<key>LinkName</key>
-		<string>請輸入部落格鄉村台灣站使用者名稱</string>
-		<key>LinkTemplate</key>
-		<string>http://www.blogtw.com/rss.php?user=%@</string>
-		<key>SiteHomePage</key>
-		<string>http://www.blogtw.com/</string>
-	</dict>
-    <key>部落格鄉村香港站</key>
-	<dict>
-		<key>LinkName</key>
-		<string>請輸入部落格鄉村香港站使用者名稱</string>
-		<key>LinkTemplate</key>
-		<string>http://www.bloghk.com/rss.php?user=%@</string>
-		<key>SiteHomePage</key>
-		<string>http://www.bloghk.com/</string>
+		<string>https://logdown.com/</string>
 	</dict>
 </dict>
 </plist>
-


### PR DESCRIPTION
The dropdown shows a few BSPs that were shutdown and no longer available. They are replaced with a few new ones.
