### PR TITLE
Fix selection of next unread article through spacebar

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2341,7 +2341,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 				}
 				else
 				{
-					if (visibleRect.origin.y + visibleRect.size.height >= theView.frame.size.height - 2)
+					if (visibleRect.size.height == 0
+                        || visibleRect.origin.y + visibleRect.size.height >= theView.frame.size.height - 2)
 						[self viewNextUnread:self];
 					else
 						[view scrollPageDown:self];


### PR DESCRIPTION
Fix issue #1239 : hitting the spacebar to select the next unread article
does not work when the article view is empty, as reported at
https://forums.cocoaforge.com/viewtopic.php?t=27124&p=140537