### PR TITLE
Upgrade database for new Vienna Developer feed URL

### DIFF
--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, VNAQueryScope) {
 
 // The current database version number
 const NSInteger MA_Min_Supported_DB_Version = 12;
-const NSInteger MA_Current_DB_Version = 19;
+const NSInteger MA_Current_DB_Version = 20;
 
 @implementation Database
 

--- a/Vienna/Sources/Database/VNADatabaseMigration.m
+++ b/Vienna/Sources/Database/VNADatabaseMigration.m
@@ -127,6 +127,22 @@
             db.userVersion = (uint32_t)19;
             NSLog(@"Updated database schema to version 19.");
         }
+        case 20: {
+            // Upgrade to rev 20.
+            // Update the Vienna Developer's blog RSS URL after moved to github pages
+            
+            FMResultSet *results = [db executeQuery:@"SELECT folder_id FROM rss_folders WHERE feed_url LIKE ?", @"%%www.vienna-rss.com/?feed=rss2%%"];
+            
+            if([results next]) {
+                int viennaFolderId = [results intForColumn:@"folder_id"];
+                [db executeUpdate:@"UPDATE rss_folders SET feed_url=? WHERE folder_id=?",
+                 @"https://www.vienna-rss.com/feed.xml",
+                 @(viennaFolderId)];
+            }
+            [results close];
+            db.userVersion = (uint32_t)20;
+            NSLog(@"Updated database schema to version 20.");
+        }
     }
     
 }


### PR DESCRIPTION
Closes #1251.
After moving to GitHub pages our RSS feed URL changed.
The only way to really redirect is through changing the URL in the DB.