### PR TITLE
Remove Unsplash from DemoFeeds.plist

### DIFF
--- a/Vienna/Resources/DemoFeeds.plist
+++ b/Vienna/Resources/DemoFeeds.plist
@@ -32,11 +32,6 @@
 		<key>URL</key>
 		<string>http://www.nomadicmatt.com/feed/</string>
 	</dict>
-	<key>Unsplash</key>
-	<dict>
-		<key>URL</key>
-		<string>https://unsplash.com/rss</string>
-	</dict>
 	<key>Kottke</key>
 	<dict>
 		<key>URL</key>


### PR DESCRIPTION
Remove non-working/missing Unsplash feed from default feeds.

See https://github.com/ViennaRSS/vienna-rss/issues/1260