### PR TITLE
Add file template macros for Xcode

### DIFF
--- a/Vienna.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Vienna.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>COPYRIGHT</key>
+	<string>Copyright ___YEAR___ ___FULLUSERNAME___</string>
+	<key>FILEHEADER</key>
+	<string>
+//  ___FILENAME___
+//  ___PACKAGENAME___
+//
+//  ___COPYRIGHT___
+//
+//  Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
This will create source-code files with the proper Apache license header by default.