### PR TITLE
Trim feed author strings in RichXMLParser

### DIFF
--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, VNAQueryScope) {
 
 // The current database version number
 const NSInteger MA_Min_Supported_DB_Version = 12;
-const NSInteger MA_Current_DB_Version = 20;
+const NSInteger MA_Current_DB_Version = 21;
 
 @implementation Database
 

--- a/Vienna/Sources/Parsing/RichXMLParser.m
+++ b/Vienna/Sources/Parsing/RichXMLParser.m
@@ -394,17 +394,17 @@
                 // Parse item author
                 if ( (isRSSElement && [articleItemTag isEqualToString:@"author"])
                      || ([itemChildElement.prefix isEqualToString:dcPrefix] && [articleItemTag isEqualToString:@"creator"]) ) {
-                    NSString * authorName = itemChildElement.stringValue;
+                    NSString *authorName = [itemChildElement.stringValue trim];
 
                     // the author is in the feed's entry
-                    if (authorName != nil) {
+                    if (authorName) {
                         // if we currently have a string set as the author then append the new author name
-                        if (newFeedItem.author.length > 0) {
-                            newFeedItem.author = [NSString stringWithFormat:
-                                                  NSLocalizedString(@"%@, %@", @"{existing authors},{new author name}"), newFeedItem.author, authorName];
-                        }
                         // else we currently don't have an author set, so set it to the first author
-                        else {
+                        if (newFeedItem.author.length > 0
+                            && [newFeedItem.author rangeOfString:authorName
+                                                         options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)].location != NSNotFound) {
+                            newFeedItem.author = [NSString stringWithFormat:NSLocalizedString(@"%@, %@", @"{existing authors}, {new author name}"), newFeedItem.author, authorName];
+                        } else {
                             newFeedItem.author = authorName;
                         }
                     }
@@ -548,7 +548,7 @@
         if (isAtomElement && [elementTag isEqualToString:@"author"]) {
             NSXMLElement * nameElement = [atomChildElement elementsForName:@"name"].firstObject;
             if (nameElement != nil) {
-                defaultAuthor = nameElement.stringValue;
+                defaultAuthor = [nameElement.stringValue trim];
             }
             success = YES;
             continue;
@@ -633,18 +633,20 @@
 
                 // Parse item author
                 if (isArticleElementAtomType && [articleItemTag isEqualToString:@"author"]) {
-                    NSString * authorName = ([itemChildElement elementsForName:@"name"].firstObject).stringValue;
-                    if (authorName == nil) {
+                    NSString *authorName = ([itemChildElement elementsForName:@"name"].firstObject).stringValue;
+                    authorName = [authorName trim];
+                    if (!authorName) {
                         authorName = ([itemChildElement elementsForName:@"email"].firstObject).stringValue;
                     }
                     // the author is in the feed's entry
-                    if (authorName != nil) {
+                    if (authorName) {
                         // if we currently have a string set as the author then append the new author name
-                        if (newFeedItem.author.length > 0) {
-                            newFeedItem.author = [NSString stringWithFormat:NSLocalizedString(@"%@, %@", @"{existing authors},{new author name}"), newFeedItem.author, authorName];
-                        }
                         // else we currently don't have an author set, so set it to the first author
-                        else {
+                        if (newFeedItem.author.length > 0
+                            && [newFeedItem.author rangeOfString:authorName
+                                                         options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)].location != NSNotFound) {
+                            newFeedItem.author = [NSString stringWithFormat:NSLocalizedString(@"%@, %@", @"{existing authors}, {new author name}"), newFeedItem.author, authorName];
+                        } else {
                             newFeedItem.author = authorName;
                         }
                     }


### PR DESCRIPTION
Partially addresses #1253 

This trims whitespace off the parsed author strings of feeds. It also adds a string comparison to avoid combining two identical author strings, e.g. if the feed has both `author` and `dc:creator` elements.