### PR TITLE
Improve OpenReader

### DIFF
--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -162,7 +162,6 @@
 -(void)handleRSSLink:(NSString *)linkPath;
 -(void)selectFolder:(NSInteger)folderId;
 -(void)createNewSubscription:(NSString *)urlString underFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId;
--(void)createNewGoogleReaderSubscription:(NSString *)url underFolder:(NSInteger)parentId withTitle:(NSString*)title afterChild:(NSInteger)predecessorId;
 -(void)markSelectedFoldersRead:(NSArray *)arrayOfFolders;
 -(void)doSafeInitialisation;
 -(void)clearUndoStack;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3250,18 +3250,17 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)refreshAllSubscriptions:(id)sender
 {
-    // Reset the refresh timer
-    [self handleCheckFrequencyChange:nil];
-
-    // Kick off the refresh
     if (!self.connecting) {
         if ([Preferences standardPreferences].syncGoogleReader){
             [[OpenReader sharedManager] loadSubscriptions];
         }
+
+        // Reset the refresh timer
+        [self handleCheckFrequencyChange:nil];
+        // Kick off the refresh
         [[RefreshManager sharedManager] refreshSubscriptions:[self.foldersTree folders:0]
           ignoringSubscriptionStatus:NO];
     }
-
 }
 
 -(IBAction)forceRefreshSelectedSubscriptions:(id)sender {

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2388,43 +2388,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     }
 }
 
-/* createNewGoogleReaderSubscription
- * Create a new Open Reader subscription for the specified URL under the given parent folder.
- */
-
--(void)createNewGoogleReaderSubscription:(NSString *)url underFolder:(NSInteger)parentId withTitle:(NSString*)title afterChild:(NSInteger)predecessorId
-{
-	NSLog(@"Adding Open Reader Feed: %@ with Title: %@",url,title);
-	// Replace feed:// with http:// if necessary
-	if ([url hasPrefix:@"feed://"])
-		url = [NSString stringWithFormat:@"http://%@", [url substringFromIndex:7]];
-	
-	// If the folder already exists, just select it.
-	Folder * folder = [db folderFromFeedURL:url];
-	if (folder != nil)
-	{
-		//[self.browser setActiveTabToPrimaryTab];
-		//[self.foldersTree selectFolder:[folder itemId]];
-		return;
-	}
-	
-	// Create then select the new folder.
-	NSInteger folderId = [db addGoogleReaderFolder:title
-                                       underParent:parentId
-                                        afterChild:predecessorId
-                                   subscriptionURL:url];
-		
-	if (folderId != -1)
-	{
-		//		[self.foldersTree selectFolder:folderId];
-		//		if (isAccessible(url))
-		//{
-			Folder * folder = [db folderFromID:folderId];
-			[[RefreshManager sharedManager] refreshSubscriptions:@[folder] ignoringSubscriptionStatus:NO];
-		//}
-	}
-}
-
 /* createNewSubscription
  * Create a new subscription for the specified URL under the given parent folder.
  */
@@ -2447,14 +2410,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	// Create the new folder.
 	if ([Preferences standardPreferences].syncGoogleReader && [Preferences standardPreferences].prefersGoogleNewSubscription)
-	{	//creates in Google
-		OpenReader * myGoogle = [OpenReader sharedManager];
-		[myGoogle subscribeToFeed:urlString];
+	{	//creates in OpenReader
 		NSString * folderName = [db folderFromID:parentId].name;
-		if (folderName != nil)
-			[myGoogle setFolderLabel:folderName forFeed:urlString set:TRUE];
-		[myGoogle loadSubscriptions];
-
+		[[OpenReader sharedManager] subscribeToFeed:urlString withLabel:folderName];
 	}
 	else
 	{ //creates locally
@@ -2813,7 +2771,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
             
 			if (folder.type == VNAFolderTypeOpenReader) {
 				NSLog(@"Unsubscribe Open Reader folder");
-				[[OpenReader sharedManager] unsubscribeFromFeed:folder.feedURL];
+				[[OpenReader sharedManager] unsubscribeFromFeed:folder.remoteId];
 			}
 		}
 	}

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -60,6 +60,7 @@ extern NSNotificationName const databaseDidDeleteFolderNotification;
 -(NSArray *)arrayOfFolders:(NSInteger)parentId;
 -(Folder *)folderFromID:(NSInteger)wantedId;
 -(Folder *)folderFromFeedURL:(NSString *)wantedFeedURL;
+-(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId;
 -(Folder *)folderFromName:(NSString *)wantedName;
 -(NSInteger)addFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId folderName:(NSString *)name type:(NSInteger)type canAppendIndex:(BOOL)canAppendIndex;
 -(BOOL)deleteFolder:(NSInteger)folderId;
@@ -67,6 +68,7 @@ extern NSNotificationName const databaseDidDeleteFolderNotification;
 -(BOOL)setDescription:(NSString *)newDescription forFolder:(NSInteger)folderId;
 -(BOOL)setHomePage:(NSString *)homePageURL forFolder:(NSInteger)folderId;
 -(BOOL)setFeedURL:(NSString *)feed_url forFolder:(NSInteger)folderId;
+-(BOOL)setRemoteId:(NSString *)remoteId forFolder:(NSInteger)folderId;
 -(BOOL)setFolderUsername:(NSInteger)folderId newUsername:(NSString *)name;
 -(void)purgeDeletedArticles;
 -(void)purgeArticlesOlderThanDays:(NSUInteger)daysToKeep;
@@ -87,7 +89,8 @@ extern NSNotificationName const databaseDidDeleteFolderNotification;
 -(NSInteger)addRSSFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId subscriptionURL:(NSString *)url;
 
 // Open Reader folder functions
--(NSInteger)addGoogleReaderFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId subscriptionURL:(NSString *)url;
+-(NSInteger)addOpenReaderFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId
+        subscriptionURL:(NSString *)url remoteId:(NSString *)remoteId;
 
 // Smart folder functions
 -(void)initSmartfoldersDict;

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -935,10 +935,11 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
 	// Adjust unread counts on parents
 	folder = [self folderFromID:folderId];
 	NSInteger adjustment = -folder.unreadCount;
-	while (folder.parentId != VNAFolderTypeRoot)
+	folder = [self folderFromID:folder.parentId];
+	while (folder != nil)
 	{
-		folder = [self folderFromID:folder.parentId];
 		folder.childUnreadCount = folder.childUnreadCount + adjustment;
+		folder = [self folderFromID:folder.parentId];
 	}
 
 	// Delete all articles in this folder then delete ourselves.
@@ -2521,13 +2522,12 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
         [db executeUpdate:@"UPDATE folders set unread_count=? where folder_id=?", @(newCount), @(folder.itemId)];
     }];
 
-	// Update childUnreadCount for our parent. Since we're just working
-	// on one article, we do this the faster way.
-	Folder * tmpFolder = folder;
-	while (tmpFolder.parentId != VNAFolderTypeRoot)
+	// Update childUnreadCount for parents.
+	Folder * tmpFolder = [self folderFromID:folder.parentId];
+	while (tmpFolder != nil)
 	{
-		tmpFolder = [self folderFromID:tmpFolder.parentId];
 		tmpFolder.childUnreadCount = tmpFolder.childUnreadCount + adjustment;
+		tmpFolder = [self folderFromID:tmpFolder.parentId];
 	}
 }
 

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -29,6 +29,7 @@
 -(void)unsubscribeFromFeed:(NSString *)feedURL;
 -(void)markRead:(Article *)article readFlag:(BOOL)flag;
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag;
+-(void)markAllRead:(Folder *)folder;
 -(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
 -(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedURL;
 -(void)refreshFeed:(Folder*)thisFolder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:(BOOL)ignoreLimit;

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -20,6 +20,7 @@
 
 // Check if an accessToken is available
 @property (nonatomic, getter=isReady, readonly) BOOL ready;
+@property (nonatomic) NSOperation * unreadCountOperation;
 
 -(void)loadSubscriptions;
 -(void)clearAuthentication;

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -26,13 +26,13 @@
 -(void)clearAuthentication;
 -(void)resetAuthentication;
 
--(void)subscribeToFeed:(NSString *)feedURL;
--(void)unsubscribeFromFeed:(NSString *)feedURL;
+-(void)subscribeToFeed:(NSString *)feedURL withLabel:(NSString *)label;
+-(void)unsubscribeFromFeed:(NSString *)feedIdentifier;
 -(void)markRead:(Article *)article readFlag:(BOOL)flag;
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag;
 -(void)markAllRead:(Folder *)folder;
--(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
--(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedURL;
+-(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedIdentifier set:(BOOL)flag;
+-(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedIdentifier;
 -(void)refreshFeed:(Folder*)thisFolder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:(BOOL)ignoreLimit;
 @property (nonatomic, readonly) NSUInteger countOfNewArticles;
 

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -137,8 +137,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 -(void)specificHeadersPrepare:(NSMutableURLRequest *)request
 {
     if (hostRequiresInoreaderHeaders) {
-        [request setValue:@"1000001359" forHTTPHeaderField:@"AppID"];
-        [request setValue:@"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn" forHTTPHeaderField:@"AppKey"];
+        [request setValue:[Preferences standardPreferences].syncingAppId forHTTPHeaderField:@"AppID"];
+        [request setValue:[Preferences standardPreferences].syncingAppKey forHTTPHeaderField:@"AppKey"];
         [request setValue:@"Mozilla/5.0 (compatible)" forHTTPHeaderField:@"User-Agent"];
     }
 }

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -509,6 +509,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     [aItem setStatus:NSLocalizedString(@"Error", nil)];
     [refreshedFolder clearNonPersistedFlag:VNAFolderFlagUpdating];
     [refreshedFolder setNonPersistedFlag:VNAFolderFlagError];
+    [refreshedFolder clearNonPersistedFlag:VNAFolderFlagSyncedOK]; // get ready for next request
 }
 
 // callback
@@ -686,6 +687,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             });
             [refreshedFolder clearNonPersistedFlag:VNAFolderFlagUpdating];
             [refreshedFolder setNonPersistedFlag:VNAFolderFlagError];
+            [refreshedFolder clearNonPersistedFlag:VNAFolderFlagSyncedOK];
         }
     });     //block for dispatch_async
 } // feedRequestDone
@@ -810,21 +812,37 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 
 -(void)loadSubscriptions
 {
+    [[RefreshManager sharedManager] suspendConnectionsQueue];
     NSMutableURLRequest *subscriptionRequest =
         [self requestFromURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/list?client=%@&output=json", APIBaseURL,
                                                    ClientName]]];
     __weak typeof(self) weakSelf = self;
-    [[RefreshManager sharedManager] addConnection:subscriptionRequest
-        completionHandler :^(NSData *data, NSURLResponse *response, NSError *error) {
+    NSOperation * subscriptionOperation = [[RefreshManager sharedManager] addConnection:subscriptionRequest
+        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             if (error) {
                 [weakSelf requestFailed:subscriptionRequest response:response error:error];
             } else {
                 [weakSelf subscriptionsRequestDone:subscriptionRequest response:response data:data];
             }
-            weakSelf.statusMessage = @"";
         }
     ];
 
+    NSMutableURLRequest *unreadCountRequest =
+        [self requestFromURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@unread-count?client=%@&output=json&allcomments=false",
+                                                   APIBaseURL,
+                                                   ClientName]]];
+    self.unreadCountOperation = [[RefreshManager sharedManager] addConnection:unreadCountRequest
+        completionHandler:^(NSData *data1, NSURLResponse *response, NSError *error) {
+            if (error) {
+                [weakSelf requestFailed:unreadCountRequest response:response error:error];
+            } else {
+                [weakSelf unreadCountDone:unreadCountRequest response:response data:data1];
+            }
+            weakSelf.statusMessage = @"";
+        }
+    ];
+    [self.unreadCountOperation addDependency:subscriptionOperation];
+	[[RefreshManager sharedManager] resumeConnectionsQueue];
     self.statusMessage = NSLocalizedString(@"Fetching Open Reader Subscriptions…", nil);
 }
 
@@ -891,7 +909,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             NSString *homePageURL = feed[@"htmlUrl"];
             if (homePageURL) {
                 for (Folder *localFolder in localFolders) {
-                    if (localFolder.type == VNAFolderTypeOpenReader && [localFolder.feedURL isEqualToString:feedURL]) {
+                    if (localFolder.isOpenReaderFolder && [localFolder.feedURL isEqualToString:feedURL]) {
                         Database * db = [Database sharedManager];
                         [db setHomePage:homePageURL forFolder:localFolder.itemId];
                         if ([db folderFromName:rssTitle] == nil) { // no conflict
@@ -909,12 +927,52 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     if (subscriptionsDict[@"subscriptions"] != nil) { // detect probable authentication error
         //check if we have a folder which is not registered as a Open Reader feed
         for (Folder *f in APPCONTROLLER.folders) {
-            if (f.type == VNAFolderTypeOpenReader && ![remoteFeeds containsObject:f.feedURL]) {
-                [[Database sharedManager] deleteFolder:f.itemId];
+            if (f.isOpenReaderFolder) {
+             	if ([remoteFeeds containsObject:f.feedURL]) {
+             		[f setNonPersistedFlag:VNAFolderFlagSyncedOK];
+            	} else {
+                	[[Database sharedManager] deleteFolder:f.itemId];
+            	}
             }
         }
     }
 } // subscriptionsRequestDone
+
+// callback 2 to loadSubscriptions
+-(void)unreadCountDone:(NSMutableURLRequest *)request response:(NSURLResponse *)response data:(NSData *)data
+{
+    NSDictionary *unreadDict;
+    NSError *jsonError;
+    unreadDict = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&jsonError];
+    for (NSDictionary *feed in unreadDict[@"unreadcounts"]) {
+        NSString *feedID = feed[@"id"];
+        NSString *feedURL;
+        if ([feedID hasPrefix:@"feed/"]) {
+            NSString *feedIdentifier =
+                [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
+            if (hostRequiresHexaForFeedId) { // TheOldReader
+                feedURL = [NSString stringWithFormat:@"https://%@/reader/public/atom/%@", openReaderHost, feedIdentifier];
+            } else { // most services use feed URL as identifier (like GoogleReader did)
+                feedURL = feedIdentifier;
+            }
+            Folder *folder = [[Database sharedManager] folderFromFeedURL:feedURL];
+            NSInteger remoteCount = ((NSString *)feed[@"count"]).intValue;
+            NSInteger localCount = folder.unreadCount;
+            NSInteger remoteTimestamp = ((NSString *)feed[@"newestItemTimestampUsec"]).longLongValue / 1000000; // convert in truncated seconds
+            NSString *folderLastUpdateString = folder.lastUpdateString;
+            if (folderLastUpdateString == nil || [folderLastUpdateString isEqualToString:@""] ||
+                [folderLastUpdateString isEqualToString:@"(null)"])
+            {
+                folderLastUpdateString = @"0";
+            }
+            NSInteger localTimestamp = folderLastUpdateString.longLongValue;
+            if (remoteTimestamp > localTimestamp || remoteCount != localCount) {
+                // discrepancy between local feed and remote OpenReader server
+                [folder clearNonPersistedFlag:VNAFolderFlagSyncedOK];
+            }
+        }
+    }
+} // unreadCountDone
 
 -(void)subscribeToFeed:(NSString *)feedURL
 {

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -743,7 +743,9 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         } else { //response status other than OK (200)
             [aItem appendDetail:[NSString stringWithFormat:@"%@ %@", NSLocalizedString(@"Error", nil),
                                     [NSHTTPURLResponse localizedStringForStatusCode:((NSHTTPURLResponse *)response).statusCode]]];
-            [aItem setStatus:NSLocalizedString(@"Error", nil)];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [aItem setStatus:NSLocalizedString(@"Error", nil)];
+            });
             [refreshedFolder clearNonPersistedFlag:VNAFolderFlagUpdating];
             [refreshedFolder setNonPersistedFlag:VNAFolderFlagError];
         }

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -44,9 +44,8 @@ NSString *APIBaseURL;
 BOOL hostSendsHexaItemId;
 BOOL hostRequiresSParameter;
 BOOL hostRequiresHexaForFeedId;
-BOOL hostRequiresInoreaderAdditionalHeaders;
+BOOL hostRequiresInoreaderHeaders;
 BOOL hostRequiresBackcrawling;
-NSDictionary *inoreaderAdditionalHeaders;
 
 typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     notAuthenticated = 0,
@@ -87,10 +86,6 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         username = nil;
         password = nil;
         APIBaseURL = nil;
-        inoreaderAdditionalHeaders = @{
-            @"AppID": @"1000001359",
-            @"AppKey": @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn"
-        };
         _asyncQueue = dispatch_queue_create("uk.co.opencommunity.vienna2.openReaderTasks", DISPATCH_QUEUE_SERIAL);
     }
 
@@ -123,7 +118,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 -(NSMutableURLRequest *)requestFromURL:(NSURL *)url
 {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [self commonRequestPrepare:request];
+    [self addClientTokenToRequest:request];
+    [self specificHeadersPrepare:request];
     return request;
 }
 
@@ -138,13 +134,12 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     return request;
 }
 
--(void)commonRequestPrepare:(NSMutableURLRequest *)request
+-(void)specificHeadersPrepare:(NSMutableURLRequest *)request
 {
-    [self addClientTokenToRequest:request];
-    if (hostRequiresInoreaderAdditionalHeaders) {
-        NSMutableDictionary *theHeaders = [request.allHTTPHeaderFields mutableCopy] ? : [[NSMutableDictionary alloc] init];
-        [theHeaders addEntriesFromDictionary:inoreaderAdditionalHeaders];
-        request.allHTTPHeaderFields = theHeaders;
+    if (hostRequiresInoreaderHeaders) {
+        [request setValue:@"1000001359" forHTTPHeaderField:@"AppID"];
+        [request setValue:@"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn" forHTTPHeaderField:@"AppKey"];
+        [request setValue:@"Mozilla/5.0 (compatible)" forHTTPHeaderField:@"User-Agent"];
     }
 }
 
@@ -177,12 +172,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:LoginBaseURL, openReaderHost]];
         NSMutableURLRequest *myRequest = [NSMutableURLRequest requestWithURL:url];
         myRequest.HTTPMethod = @"POST";
-
-        if (hostRequiresInoreaderAdditionalHeaders) {
-            NSMutableDictionary *theHeaders = [myRequest.allHTTPHeaderFields mutableCopy];
-            [theHeaders addEntriesFromDictionary:inoreaderAdditionalHeaders];
-            myRequest.allHTTPHeaderFields = theHeaders;
-        }
+        [myRequest setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+        [self specificHeadersPrepare:myRequest];
         [myRequest setPostValue:username forKey:@"Email"];
         [myRequest setPostValue:password forKey:@"Passwd"];
 
@@ -251,7 +242,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     hostSendsHexaItemId = NO;
     hostRequiresSParameter = NO;
     hostRequiresHexaForFeedId = NO;
-    hostRequiresInoreaderAdditionalHeaders = NO;
+    hostRequiresInoreaderHeaders = NO;
     hostRequiresBackcrawling = YES;
     // settings for specific kind of servers
     if ([openReaderHost isEqualToString:@"theoldreader.com"]) {
@@ -261,7 +252,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         hostRequiresBackcrawling = NO;
     }
     if ([openReaderHost rangeOfString:@"inoreader.com"].length != 0) {
-        hostRequiresInoreaderAdditionalHeaders = YES;
+        hostRequiresInoreaderHeaders = YES;
         hostRequiresBackcrawling = NO;
     }
     if ([openReaderHost rangeOfString:@"bazqux.com"].length != 0) {

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -91,7 +91,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             @"AppID": @"1000001359",
             @"AppKey": @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn"
         };
-        _asyncQueue = dispatch_queue_create("uk.co.opencommunity.vienna2.openReaderTasks", NULL);
+        _asyncQueue = dispatch_queue_create("uk.co.opencommunity.vienna2.openReaderTasks", DISPATCH_QUEUE_SERIAL);
     }
 
     return self;

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -23,7 +23,6 @@
 #import "HelperFunctions.h"
 #import "Folder.h"
 #import "Database.h"
-#import "AppController.h"
 #import "RefreshManager.h"
 #import "Preferences.h"
 #import "StringExtensions.h"
@@ -65,7 +64,6 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 @property (nonatomic) NSTimer *clientAuthTimer;
 @property (nonatomic) dispatch_queue_t asyncQueue;
 @property (nonatomic) OpenReaderStatus openReaderStatus;
-@property (readonly, class, nonatomic) NSString *currentTimestamp;
 
 @end
 
@@ -417,18 +415,16 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         }
     }
 
-    NSString *feedIdentifier;
-    if (hostRequiresHexaForFeedId) {
-        feedIdentifier = thisFolder.feedURL.lastPathComponent;
-    } else {
-        feedIdentifier =  thisFolder.feedURL;
+    NSString *feedIdentifier = thisFolder.remoteId;
+    if (feedIdentifier == nil || ![feedIdentifier hasPrefix:@"feed/"]) {
+            return;
     }
 
     NSURL *refreshFeedUrl =
         [NSURL URLWithString:[NSString stringWithFormat:
-                              @"%@stream/contents/feed/%@?client=%@&comments=false&likes=false%@&ck=%@&output=json",
+                              @"%@stream/contents/%@?client=%@&comments=false&likes=false%@&output=json",
                               APIBaseURL,
-                              percentEscape(feedIdentifier), ClientName, itemsLimitation, OpenReader.currentTimestamp]];
+                              [OpenReader escapeFeedId:feedIdentifier], ClientName, itemsLimitation]];
 
     NSMutableURLRequest *request = [self requestFromURL:refreshFeedUrl];
     [request setUserInfo:
@@ -436,8 +432,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 
     // Request id's of unread items
     NSString *args =
-        [NSString stringWithFormat:@"?client=%@&s=feed/%@&xt=user/-/state/com.google/read&n=1000&output=json", ClientName,
-         percentEscape(feedIdentifier)];
+        [NSString stringWithFormat:@"?client=%@&s=%@&xt=user/-/state/com.google/read&n=1000&output=json", ClientName,
+         [OpenReader escapeFeedId:feedIdentifier]];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@", APIBaseURL, @"stream/items/ids", args]];
     NSMutableURLRequest *request2 = [self requestFromURL:url];
     [request2 setUserInfo:@{ @"folder": thisFolder, @"log": aItem }];
@@ -452,8 +448,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 
     NSString *args3 =
-        [NSString stringWithFormat:@"?client=%@&s=feed/%@&%@&n=1000&output=json", ClientName,
-         percentEscape(feedIdentifier), starredSelector];
+        [NSString stringWithFormat:@"?client=%@&s=%@&%@&n=1000&output=json", ClientName,
+         [OpenReader escapeFeedId:feedIdentifier], starredSelector];
     NSURL *url3 = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@", APIBaseURL, @"stream/items/ids", args3]];
     NSMutableURLRequest *request3 = [self requestFromURL:url3];
     [request3 setUserInfo:@{ @"folder": thisFolder, @"log": aItem }];
@@ -842,9 +838,9 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         }
     ];
     [self.unreadCountOperation addDependency:subscriptionOperation];
-	[[RefreshManager sharedManager] resumeConnectionsQueue];
+    [[RefreshManager sharedManager] resumeConnectionsQueue];
     self.statusMessage = NSLocalizedString(@"Fetching Open Reader Subscriptions…", nil);
-}
+} // loadSubscriptions
 
 // callback 1  to loadSubscriptions
 -(void)subscriptionsRequestDone:(NSMutableURLRequest *)request response:(NSURLResponse *)response data:(NSData *)data
@@ -856,27 +852,23 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                                                           error:&jsonError];
     NSMutableArray *localFeeds = [NSMutableArray array];
     NSMutableArray *remoteFeeds = [NSMutableArray array];
-    NSArray *localFolders = APPCONTROLLER.folders;
+    Database * db = [Database sharedManager];
+    NSArray *localFolders = db.arrayOfAllFolders;
 
     for (Folder *f in localFolders) {
-        if (f.feedURL && f.type == VNAFolderTypeOpenReader) {
-            [localFeeds addObject:f.feedURL];
+        if (f.isOpenReaderFolder && ![f.remoteId isEqualToString:@"0"]) {
+            [localFeeds addObject:f.remoteId];
         }
     }
 
     for (NSDictionary *feed in subscriptionsDict[@"subscriptions"]) {
         NSString *feedID = feed[@"id"];
-        if (feedID == nil) {
+        if (feedID == nil || ![feedID hasPrefix:@"feed/"]) {
             break;
         }
         NSString *feedURL = feed[@"url"];
-        if (feedURL == nil || hostRequiresHexaForFeedId) { // TheOldReader requires BSON identifier in stream Ids instead of URL (ex: feed/0125ef...)
-            NSString * feedIdentifier = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
-            if (hostRequiresHexaForFeedId) { // TheOldReader
-                feedURL = [NSString stringWithFormat:@"https://%@/reader/public/atom/%@", openReaderHost, feedIdentifier];
-            } else { // most services use feed URL as identifier (like GoogleReader did)
-                feedURL = feedIdentifier;
-            }
+        if (!feedURL) {
+            feedURL = [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
         }
 
         NSString *folderName = nil;
@@ -899,19 +891,35 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         if (feed[@"title"]) {
             rssTitle = feed[@"title"];
         }
-        if (![localFeeds containsObject:feedURL]) {
-            // folderName could be nil
-            NSArray *params = folderName ? @[feedURL, rssTitle, folderName] : @[feedURL, rssTitle];
-            [self createNewSubscription:params];
+        if (![localFeeds containsObject:feedID]) {
+        // legacy search in stored URLs
+            NSString *legacyKey;
+            if (hostRequiresHexaForFeedId) {                     // TheOldReader
+                NSString *identifier =
+                  [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
+                legacyKey = [NSString stringWithFormat:@"https://%@/reader/public/atom/%@", openReaderHost, identifier];
+            } else {
+                legacyKey = feedURL;
+            }
+            Folder *f = [db folderFromFeedURL:legacyKey];
+            if (f && f.isOpenReaderFolder) {         // exists already, but we didn't store the remoteId
+                [db setRemoteId:feedID forFolder:f.itemId];
+                [db setFeedURL:feedURL forFolder:f.itemId];
+            } else {
+                // we need to create
+                // folderName could be nil
+                NSArray *params = folderName ? @[feedID, feedURL, rssTitle, folderName] : @[feedID, feedURL, rssTitle];
+                [self createNewSubscription:params];
+            }
         } else {
             // the feed is already known
             // set HomePage if the info is available
             NSString *homePageURL = feed[@"htmlUrl"];
             if (homePageURL) {
                 for (Folder *localFolder in localFolders) {
-                    if (localFolder.isOpenReaderFolder && [localFolder.feedURL isEqualToString:feedURL]) {
-                        Database * db = [Database sharedManager];
+                    if (localFolder.isOpenReaderFolder && [localFolder.remoteId isEqualToString:feedID]) {
                         [db setHomePage:homePageURL forFolder:localFolder.itemId];
+                        [db setFeedURL:feedURL forFolder:localFolder.itemId];
                         if ([db folderFromName:rssTitle] == nil) { // no conflict
                             [db setName:rssTitle forFolder:localFolder.itemId];
                         };
@@ -921,14 +929,14 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             }
         }
 
-        [remoteFeeds addObject:feedURL];
+        [remoteFeeds addObject:feedID];
     }
 
     if (subscriptionsDict[@"subscriptions"] != nil) { // detect probable authentication error
         //check if we have a folder which is not registered as a Open Reader feed
-        for (Folder *f in APPCONTROLLER.folders) {
+        for (Folder *f in localFolders) {
             if (f.isOpenReaderFolder) {
-             	if ([remoteFeeds containsObject:f.feedURL]) {
+             	if ([remoteFeeds containsObject:f.remoteId]  && [f.remoteId hasPrefix:@"feed/"]) {
              		[f setNonPersistedFlag:VNAFolderFlagSyncedOK];
             	} else {
                 	[[Database sharedManager] deleteFolder:f.itemId];
@@ -946,64 +954,68 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     unreadDict = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&jsonError];
     for (NSDictionary *feed in unreadDict[@"unreadcounts"]) {
         NSString *feedID = feed[@"id"];
-        NSString *feedURL;
         if ([feedID hasPrefix:@"feed/"]) {
-            NSString *feedIdentifier =
-                [feedID stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)];
-            if (hostRequiresHexaForFeedId) { // TheOldReader
-                feedURL = [NSString stringWithFormat:@"https://%@/reader/public/atom/%@", openReaderHost, feedIdentifier];
-            } else { // most services use feed URL as identifier (like GoogleReader did)
-                feedURL = feedIdentifier;
-            }
-            Folder *folder = [[Database sharedManager] folderFromFeedURL:feedURL];
-            NSInteger remoteCount = ((NSString *)feed[@"count"]).intValue;
-            NSInteger localCount = folder.unreadCount;
-            NSInteger remoteTimestamp = ((NSString *)feed[@"newestItemTimestampUsec"]).longLongValue / 1000000; // convert in truncated seconds
-            NSString *folderLastUpdateString = folder.lastUpdateString;
-            if (folderLastUpdateString == nil || [folderLastUpdateString isEqualToString:@""] ||
-                [folderLastUpdateString isEqualToString:@"(null)"])
-            {
-                folderLastUpdateString = @"0";
-            }
-            NSInteger localTimestamp = folderLastUpdateString.longLongValue;
-            if (remoteTimestamp > localTimestamp || remoteCount != localCount) {
-                // discrepancy between local feed and remote OpenReader server
-                [folder clearNonPersistedFlag:VNAFolderFlagSyncedOK];
+            Folder *folder = [[Database sharedManager] folderFromRemoteId:feedID];
+            if (folder) {
+                NSInteger remoteCount = ((NSString *)feed[@"count"]).intValue;
+                NSInteger localCount = folder.unreadCount;
+                NSInteger remoteTimestamp = ((NSString *)feed[@"newestItemTimestampUsec"]).longLongValue / 1000000; // convert in truncated seconds
+                NSString *folderLastUpdateString = folder.lastUpdateString;
+                if (folderLastUpdateString == nil || [folderLastUpdateString isEqualToString:@""] ||
+                    [folderLastUpdateString isEqualToString:@"(null)"])
+                {
+                    folderLastUpdateString = @"0";
+                }
+                NSInteger localTimestamp = folderLastUpdateString.longLongValue;
+                if (remoteTimestamp > localTimestamp || remoteCount != localCount) {
+                    // discrepancy between local feed and remote OpenReader server
+                    [folder clearNonPersistedFlag:VNAFolderFlagSyncedOK];
+                }
             }
         }
     }
 } // unreadCountDone
 
--(void)subscribeToFeed:(NSString *)feedURL
+-(void)subscribeToFeed:(NSString *)feedURL withLabel:(NSString *)label
 {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/quickadd?client=%@", APIBaseURL, ClientName]];
 
     NSMutableURLRequest *request = [self authentifiedFormRequestFromURL:url];
     [request setPostValue:feedURL forKey:@"quickadd"];
+    [request setInUserInfo:label  forKey:@"label"];
     __weak typeof(self) weakSelf = self;
     [[RefreshManager sharedManager] addConnection:request
         completionHandler :^(NSData *data, NSURLResponse *response, NSError *error) {
             if (error) {
                 [weakSelf requestFailed:request response:response error:error];
             } else {
-                [weakSelf requestFinished:request response:response data:data];
+                [weakSelf subscribeToFeedDone:request response:response data:data];
             }
         }
     ];
 }
 
--(void)unsubscribeFromFeed:(NSString *)feedURL
+-(void)subscribeToFeedDone:(NSMutableURLRequest *)request response:(NSURLResponse *)response data:(NSData *)data
+{
+    NSDictionary *responseDict;
+    NSError *jsonError;
+    responseDict = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&jsonError];
+    NSString *label = ((NSDictionary *)[request userInfo])[@"label"];
+    NSString * feedIdentifier = responseDict[@"streamId"];
+    if (feedIdentifier) {
+        if (label) {
+            [self setFolderLabel:label forFeed:feedIdentifier set:TRUE];
+        }
+	    [self loadSubscriptions];
+    }
+}
+
+-(void)unsubscribeFromFeed:(NSString *)feedIdentifier
 {
     NSURL *unsubscribeURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/edit", APIBaseURL]];
     NSMutableURLRequest *myRequest = [self authentifiedFormRequestFromURL:unsubscribeURL];
     [myRequest setPostValue:@"unsubscribe" forKey:@"ac"];
-    NSString *feedIdentifier;
-    if (hostRequiresHexaForFeedId) {
-        feedIdentifier = feedURL.lastPathComponent;
-    } else {
-        feedIdentifier = feedURL;
-    }
-    [myRequest setPostValue:[NSString stringWithFormat:@"feed/%@", feedIdentifier] forKey:@"s"];
+    [myRequest setPostValue:feedIdentifier forKey:@"s"];
     __weak typeof(self) weakSelf = self;
     [[RefreshManager sharedManager] addConnection:myRequest
         completionHandler :^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -1020,19 +1032,13 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
  * add or remove a label (folder name) to a newsfeed
  * set parameter : TRUE => add ; FALSE => remove
  */
--(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag
+-(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedIdentifier set:(BOOL)flag
 {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/edit?client=%@", APIBaseURL, ClientName]];
 
     NSMutableURLRequest *request = [self authentifiedFormRequestFromURL:url];
     [request setPostValue:@"edit" forKey:@"ac"];
-    NSString *feedIdentifier;
-    if (hostRequiresHexaForFeedId) {
-        feedIdentifier = feedURL.lastPathComponent;
-    } else {
-        feedIdentifier = feedURL;
-    }
-    [request setPostValue:[NSString stringWithFormat:@"feed/%@", feedIdentifier] forKey:@"s"];
+    [request setPostValue:feedIdentifier forKey:@"s"];
     [request setPostValue:[NSString stringWithFormat:@"user/-/label/%@", folderName] forKey:flag ? @"a" : @"r"];
     __weak typeof(self) weakSelf = self;
     [[RefreshManager sharedManager] addConnection:request
@@ -1049,19 +1055,13 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 /* setFolderTitle:forFeed:
  * set title of a newsfeed
  */
--(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedURL
+-(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedIdentifier
 {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/edit?client=%@", APIBaseURL, ClientName]];
 
     NSMutableURLRequest *request = [self authentifiedFormRequestFromURL:url];
     [request setPostValue:@"edit" forKey:@"ac"];
-    NSString *feedIdentifier;
-    if (hostRequiresHexaForFeedId) {
-        feedIdentifier = feedURL.lastPathComponent;
-    } else {
-        feedIdentifier = feedURL;
-    }
-    [request setPostValue:[NSString stringWithFormat:@"feed/%@", feedIdentifier] forKey:@"s"];
+    [request setPostValue:feedIdentifier forKey:@"s"];
     [request setPostValue:folderName forKey:@"t"];
     __weak typeof(self) weakSelf = self;
     [[RefreshManager sharedManager] addConnection:request
@@ -1119,13 +1119,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     NSURL *markReadURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@mark-all-as-read", APIBaseURL]];
     NSMutableURLRequest *request = [self authentifiedFormRequestFromURL:markReadURL];
     [request setUserInfo: @{ @"folder": folder}];
-    NSString *feedIdentifier;
-    if (hostRequiresHexaForFeedId) {
-        feedIdentifier = folder.feedURL.lastPathComponent;
-    } else {
-        feedIdentifier = folder.feedURL;
-    }
-    [request setPostValue:[NSString stringWithFormat:@"feed/%@", feedIdentifier] forKey:@"s"];
+    NSString *feedIdentifier = folder.remoteId;
+    [request setPostValue:feedIdentifier forKey:@"s"];
     NSString *folderLastUpdateString = folder.lastUpdateString;
     //This is a workaround throw a BAD folderupdate value on DB
     if (folderLastUpdateString == nil || [folderLastUpdateString isEqualToString:@""] ||
@@ -1188,20 +1183,21 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 -(void)createNewSubscription:(NSArray *)params
 {
     NSInteger underFolder = VNAFolderTypeRoot;
-    NSString *feedURL = params[0];
+    NSString *feedID = params[0];
+    NSString *feedURL = params[1];
     NSString *rssTitle = [NSString stringWithFormat:@""];
+    Database *db = [Database sharedManager];
 
-    if (params.count > 1) {
-        if (params.count > 2) {
-            NSString *folderName = params[2];
-            Database *db = [Database sharedManager];
+    if (params.count > 2) {
+        rssTitle = params[2];
+        if (params.count > 3) {
+            NSString *folderName = params[3];
             Folder *folder = [db folderFromName:folderName];
             underFolder = folder.itemId;
         }
-        rssTitle = params[1];
     }
 
-    [APPCONTROLLER createNewGoogleReaderSubscription:feedURL underFolder:underFolder withTitle:rssTitle afterChild:-1];
+    [db addOpenReaderFolder:rssTitle underParent:underFolder afterChild:-1 subscriptionURL:feedURL remoteId:feedID];
 }
 
 -(void)createFolders:(NSMutableArray *)params
@@ -1235,13 +1231,12 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 
 
 /**
- * Get the current timestamp
+ * Percent escape the part after "feed/"
  *
- * @return current timestamp as a string
  */
-+(NSString *)currentTimestamp
++(NSString *)escapeFeedId:(NSString *)identifier
 {
-    return [NSString stringWithFormat:@"%0.0f", NSDate.date.timeIntervalSince1970];
+    return [NSString stringWithFormat:@"feed/%@", percentEscape([identifier stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)])];
 }
 
 @end

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -463,8 +463,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 
     // Request id's of unread items
     NSString *args =
-        [NSString stringWithFormat:@"?ck=%@&client=%@&s=feed/%@&xt=user/-/state/com.google/read&n=1000&output=json",
-         OpenReader.currentTimestamp, ClientName,
+        [NSString stringWithFormat:@"?client=%@&s=feed/%@&xt=user/-/state/com.google/read&n=1000&output=json", ClientName,
          percentEscape(feedIdentifier)];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@", APIBaseURL, @"stream/items/ids", args]];
     NSMutableURLRequest *request2 = [self requestFromURL:url];
@@ -480,7 +479,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 
     NSString *args3 =
-        [NSString stringWithFormat:@"?ck=%@&client=%@&s=feed/%@&%@&n=1000&output=json", OpenReader.currentTimestamp, ClientName,
+        [NSString stringWithFormat:@"?client=%@&s=feed/%@&%@&n=1000&output=json", ClientName,
          percentEscape(feedIdentifier), starredSelector];
     NSURL *url3 = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@", APIBaseURL, @"stream/items/ids", args3]];
     NSMutableURLRequest *request3 = [self requestFromURL:url3];

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -808,6 +808,27 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     });     //block for dispatch_async
 } // starredRequestDone
 
+-(void)loadSubscriptions
+{
+    NSMutableURLRequest *subscriptionRequest =
+        [self requestFromURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/list?client=%@&output=json", APIBaseURL,
+                                                   ClientName]]];
+    __weak typeof(self) weakSelf = self;
+    [[RefreshManager sharedManager] addConnection:subscriptionRequest
+        completionHandler :^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (error) {
+                [weakSelf requestFailed:subscriptionRequest response:response error:error];
+            } else {
+                [weakSelf subscriptionsRequestDone:subscriptionRequest response:response data:data];
+            }
+            weakSelf.statusMessage = @"";
+        }
+    ];
+
+    self.statusMessage = NSLocalizedString(@"Fetching Open Reader Subscriptions…", nil);
+}
+
+// callback 1  to loadSubscriptions
 -(void)subscriptionsRequestDone:(NSMutableURLRequest *)request response:(NSURLResponse *)response data:(NSData *)data
 {
     NSDictionary *subscriptionsDict;
@@ -885,7 +906,6 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         [remoteFeeds addObject:feedURL];
     }
 
-
     if (subscriptionsDict[@"subscriptions"] != nil) { // detect probable authentication error
         //check if we have a folder which is not registered as a Open Reader feed
         for (Folder *f in APPCONTROLLER.folders) {
@@ -895,26 +915,6 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         }
     }
 } // subscriptionsRequestDone
-
--(void)loadSubscriptions
-{
-    NSMutableURLRequest *subscriptionRequest =
-        [self requestFromURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@subscription/list?client=%@&output=json", APIBaseURL,
-                                                   ClientName]]];
-    __weak typeof(self) weakSelf = self;
-    [[RefreshManager sharedManager] addConnection:subscriptionRequest
-        completionHandler :^(NSData *data, NSURLResponse *response, NSError *error) {
-            if (error) {
-                [weakSelf requestFailed:subscriptionRequest response:response error:error];
-            } else {
-                [weakSelf subscriptionsRequestDone:subscriptionRequest response:response data:data];
-            }
-            weakSelf.statusMessage = @"";
-        }
-    ];
-
-    self.statusMessage = NSLocalizedString(@"Fetching Open Reader Subscriptions…", nil);
-}
 
 -(void)subscribeToFeed:(NSString *)feedURL
 {

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -915,18 +915,26 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             }
         } else {
             // the feed is already known
-            // set HomePage if the info is available
+            // set HomePage and other infos if they are available
             NSString *homePageURL = feed[@"htmlUrl"];
-            if (homePageURL) {
-                for (Folder *localFolder in localFolders) {
-                    if (localFolder.isOpenReaderFolder && [localFolder.remoteId isEqualToString:feedID]) {
-                        [db setHomePage:homePageURL forFolder:localFolder.itemId];
-                        [db setFeedURL:feedURL forFolder:localFolder.itemId];
-                        if ([db folderFromName:rssTitle] == nil) { // no conflict
-                            [db setName:rssTitle forFolder:localFolder.itemId];
-                        };
-                        break;
+            for (Folder *localFolder in localFolders) {
+                if (localFolder.isOpenReaderFolder && [localFolder.remoteId isEqualToString:feedID]) {
+                    NSInteger nativeId = localFolder.itemId;
+                    [db setFeedURL:feedURL forFolder:nativeId];
+                    if (homePageURL) {
+                        [db setHomePage:homePageURL forFolder:nativeId];
                     }
+                    if ([db folderFromName:rssTitle] == nil) { // no conflict
+                        [db setName:rssTitle forFolder:nativeId];
+                    }
+                    NSInteger neededParentId = [db folderFromName:folderName].itemId;
+                    if (localFolder.parentId != neededParentId) {
+                        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_OpenReaderFolderChange"
+                                                              object:@[ [NSNumber numberWithInteger:nativeId],
+                                                                        [NSNumber numberWithInteger:neededParentId],
+                                                                        [NSNumber numberWithInteger:0]]];
+                    }
+                    break;
                 }
             }
         }

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -1121,13 +1121,6 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
     [completionOperation addDependency:op];
     [[NSOperationQueue mainQueue] addOperation:completionOperation];
 
-    NSOperation *requiredOperation = ((NSDictionary *)[urlRequest userInfo])[@"dependency"];
-    if (requiredOperation != nil) {
-        op.queuePriority = NSOperationQueuePriorityLow;
-        [op addDependency:requiredOperation];
-        [urlRequest setInUserInfo:nil forKey:@"dependency"];
-    }
-
     [networkQueue addOperation:op];
     if (networkQueue.operationCount == 1) {       // networkQueue is NOT YET started
         [self updateStatus];

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -95,6 +95,8 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         config.timeoutIntervalForRequest = 180;
         config.URLCache = nil;
         config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent};
+        config.HTTPMaximumConnectionsPerHost = 6;
+        config.HTTPShouldUsePipelining = YES;
         _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:[NSOperationQueue mainQueue]];
 
         NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -995,7 +995,7 @@
 		{
 			NSArray * articleArray = [folder arrayOfUnreadArticlesRefs];
 			[refArray addObjectsFromArray:articleArray];
-			[self innerMarkReadByRefsArray:articleArray readFlag:YES];
+			[[OpenReader sharedManager] markAllRead:folder];
 		}
 		else
 		{

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1142,7 +1142,7 @@
         {
             [dbManager setName:newName forFolder:folder.itemId];
             if (folder.type == VNAFolderTypeOpenReader) {
-                [[OpenReader sharedManager] setFolderTitle:newName forFeed:folder.feedURL];
+                [[OpenReader sharedManager] setFolderTitle:newName forFeed:folder.remoteId];
             }
         }
 	}
@@ -1336,13 +1336,13 @@
 			{
 				if (folder.type == VNAFolderTypeOpenReader)
 				{
-					OpenReader * myGoogle = [OpenReader sharedManager];
+					OpenReader * myReader = [OpenReader sharedManager];
 					// remove old label
 					NSString * folderName = [dbManager folderFromID:oldParentId].name;
-					[myGoogle setFolderLabel:folderName forFeed:folder.feedURL set:FALSE];
+					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:FALSE];
 					// add new label
 					folderName = [dbManager folderFromID:newParentId].name;
-					[myGoogle setFolderLabel:folderName forFeed:folder.feedURL set:TRUE];
+					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
 				}
 			}
 			else

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -147,7 +147,7 @@
 	[nc addObserver:self selector:@selector(handleFolderFontChange:) name:@"MA_Notify_FolderFontChange" object:nil];
 	[nc addObserver:self selector:@selector(handleShowFolderImagesChange:) name:@"MA_Notify_ShowFolderImages" object:nil];
 	[nc addObserver:self selector:@selector(handleAutoSortFoldersTreeChange:) name:@"MA_Notify_AutoSortFoldersTreeChange" object:nil];
-    [nc addObserver:self selector:@selector(handleGRSFolderChange:) name:@"MA_Notify_GRSFolderChange" object:nil];
+    [nc addObserver:self selector:@selector(handleOpenReaderFolderChange:) name:@"MA_Notify_OpenReaderFolderChange" object:nil];
 }
 
 -(NSMenu *)folderMenu
@@ -192,10 +192,10 @@
     return folderMenu;
 }
 
--(void)handleGRSFolderChange:(NSNotification *)nc
+-(void)handleOpenReaderFolderChange:(NSNotification *)nc
 {
-    // No need to sync with Google because this is triggered when Open Reader
-    // folder layout has changed. Making a sync call would be redundant.
+    // No need to sync with OpenReader server because this is triggered when
+    // folder layout has changed at server level. Making a sync call would be redundant.
     [self moveFolders:nc.object withGoogleSync:NO];
 }
 
@@ -1334,7 +1334,7 @@
 				[newParent setCanHaveChildren:YES];
 			if ([dbManager setParent:newParentId forFolder:folderId])
 			{
-				if (folder.type == VNAFolderTypeOpenReader)
+				if (sync && folder.type == VNAFolderTypeOpenReader)
 				{
 					OpenReader * myReader = [OpenReader sharedManager];
 					// remove old label
@@ -1342,7 +1342,9 @@
 					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:FALSE];
 					// add new label
 					folderName = [dbManager folderFromID:newParentId].name;
-					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
+					if (folderName) {
+					    [myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
+					}
 				}
 			}
 			else

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -85,6 +85,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, readonly, copy) NSArray<Article *> *articles;
 -(NSArray<Article *> *)articlesWithFilter:(NSString *)filterString;
 @property (nonatomic, readonly) NSInteger itemId;
+@property (nonatomic, copy) NSString *remoteId;
 @property (nonatomic) NSInteger parentId;
 @property (nonatomic) NSInteger nextSiblingId;
 @property (nonatomic) NSInteger firstChildId;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -98,6 +98,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, getter=isGroupFolder, readonly) BOOL groupFolder;
 @property (nonatomic, getter=isSmartFolder, readonly) BOOL smartFolder;
 @property (nonatomic, getter=isRSSFolder, readonly) BOOL RSSFolder;
+@property (nonatomic, getter=isOpenReaderFolder, readonly) BOOL OpenReaderFolder;
 @property (nonatomic, readonly) BOOL loadsFullHTML;
 @property (nonatomic, getter=isUnsubscribed, readonly) BOOL unsubscribed;
 @property (nonatomic, getter=isUpdating, readonly) BOOL updating;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -47,11 +47,13 @@ typedef NS_ENUM(NSInteger, VNAFolderType) {
  Folder flags
  
  - VNAFolderFlagCheckForImage: asks the refresh code to update the folder image
- - VNAFolderFlagNeedCredentials: VNAFolderFlagNeedCredentials description
- - VNAFolderFlagError: VNAFolderFlagError description
- - VNAFolderFlagUnsubscribed: VNAFolderFlagUnsubscribed description
- - VNAFolderFlagUpdating: VNAFolderFlagUpdating description
- - VNAFolderFlagLoadFullHTML: VNAFolderFlagLoadFullHTML description
+ - VNAFolderFlagNeedCredentials: feed requires credentials which is not yet obtained
+ - VNAFolderFlagError: inform the user that the feed has an error
+ - VNAFolderFlagUnsubscribed: currently unsubscribed from the feed
+ - VNAFolderFlagUpdating: inform the user that the folder is currently being refreshed
+ - VNAFolderFlagLoadFullHTML: load article's web page rather than display feed text
+ - VNAFolderFlagSyncedOK: according to available info, no fresher information is available
+                          on the OpenReader server
  */
 typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
     VNAFolderFlagCheckForImage   = 1 << 0,
@@ -59,7 +61,8 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
     VNAFolderFlagError           = 1 << 2,
     VNAFolderFlagUnsubscribed    = 1 << 3,
     VNAFolderFlagUpdating        = 1 << 4,
-    VNAFolderFlagLoadFullHTML    = 1 << 5
+    VNAFolderFlagLoadFullHTML    = 1 << 5,
+    VNAFolderFlagSyncedOK        = 1 << 6
 };
 
 @interface Folder : NSObject <NSCacheDelegate> {
@@ -103,6 +106,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, getter=isUnsubscribed, readonly) BOOL unsubscribed;
 @property (nonatomic, getter=isUpdating, readonly) BOOL updating;
 @property (nonatomic, getter=isError, readonly) BOOL error;
+@property (nonatomic, getter=isSyncedOK, readonly) BOOL localSynced;
 -(void)setFlag:(VNAFolderFlag)flagToSet;
 -(void)clearFlag:(VNAFolderFlag)flagToClear;
 -(void)setNonPersistedFlag:(VNAFolderFlag)flagToSet;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -354,6 +354,13 @@ static NSArray * iconArray = nil;
     return self.type == VNAFolderTypeRSS;
 }
 
+/* isOpenReaderFolder
+ * Returns YES if this folder is an OpenReader feed folder.
+ */
+-(BOOL)isOpenReaderFolder {
+    return self.type == VNAFolderTypeOpenReader;
+}
+
 // MARK: - VNAFolderFlag methods
 
 /* loadsFullHTML

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -77,6 +77,7 @@ static NSArray * iconArray = nil;
 		self.lastUpdateString = @"";
 		self.username = @"";
 		_lastUpdate = [NSDate distantPast];
+		self.remoteId = @"0";
 	}
 	return self;
 }
@@ -315,6 +316,22 @@ static NSArray * iconArray = nil;
 -(void)setFeedURL:(NSString *)newURL
 {
 	[self.attributes setValue:newURL forKey:@"FeedURL"];
+}
+
+/* remoteId
+ * Returns the identifier used by the remote OpenReader server
+ */
+-(NSString *)remoteId
+{
+	return [self.attributes valueForKey:@"remoteId"];
+}
+
+/* setRemoteId
+ * Stores the identifier used by the remote OpenReader server for this feed.
+ */
+-(void)setRemoteId:(NSString *)newId
+{
+	[self.attributes setValue:newId forKey:@"remoteId"];
 }
 
 /* name

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -382,6 +382,10 @@ static NSArray * iconArray = nil;
     return (self.nonPersistedFlags & VNAFolderFlagError);
 }
 
+-(BOOL)isSyncedOK {
+    return (self.nonPersistedFlags & VNAFolderFlagSyncedOK);
+}
+
 /* setFlag
  * Set the specified flag on the folder.
  */

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -214,4 +214,9 @@ extern NSString * const kMA_Notify_UseWebPluginsChange;
 
 // username used for syncing
 @property (nonatomic, copy) NSString *syncingUser;
+
+// application ID and key needed by specific OpenReader services
+@property (nonatomic, copy) NSString *syncingAppId;
+@property (nonatomic, copy) NSString *syncingAppKey;
+
 @end

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -192,6 +192,8 @@ static Preferences * _standardPreferences = nil;
         prefersGoogleNewSubscription = [self boolForKey:MAPref_GoogleNewSubscription];
 		syncServer = [userPrefs valueForKey:MAPref_SyncServer];
 		syncingUser = [userPrefs valueForKey:MAPref_SyncingUser];
+		_syncingAppId = [userPrefs valueForKey:MAPref_SyncingAppId];
+		_syncingAppKey = [userPrefs valueForKey:MAPref_SyncingAppKey];
 				
 		//Sparkle autoupdate
 		checkForNewOnStartup = [SUUpdater sharedUpdater].automaticallyChecksForUpdates;
@@ -284,6 +286,8 @@ static Preferences * _standardPreferences = nil;
     defaultValues[MAPref_ConcurrentDownloads] = @(MA_Default_ConcurrentDownloads);
     defaultValues[MAPref_SyncGoogleReader] = boolNo;
     defaultValues[MAPref_GoogleNewSubscription] = boolNo;
+    defaultValues[MAPref_SyncingAppId] = @"1000001359";
+    defaultValues[MAPref_SyncingAppKey] = @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn";
     defaultValues[MAPref_AlwaysAcceptBetas] = boolNo;
 	
 	return [defaultValues copy];

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -78,6 +78,8 @@ extern NSString * MAPref_GoogleNewSubscription;
 extern NSString * MAPref_ConcurrentDownloads;
 extern NSString * MAPref_SyncServer;
 extern NSString * MAPref_SyncingUser;
+extern NSString * MAPref_SyncingAppId;
+extern NSString * MAPref_SyncingAppKey;
 extern NSString * MAPref_SendSystemProfileInfo;
 extern NSString * MAPref_AlwaysAcceptBetas;
 

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -77,6 +77,8 @@ NSString * MAPref_GoogleNewSubscription = @"GoogleNewSubscription";
 NSString * MAPref_ConcurrentDownloads = @"ConcurrentDownloads"; 
 NSString * MAPref_SyncServer = @"SyncServer";
 NSString * MAPref_SyncingUser = @"SyncingUser";
+NSString * MAPref_SyncingAppId = @"SyncingAppId";
+NSString * MAPref_SyncingAppKey = @"SyncingAppKey";
 NSString * MAPref_SendSystemProfileInfo = @"SUSendProfileInfo";
 NSString * MAPref_AlwaysAcceptBetas = @"AlwayAcceptBetas";
 

--- a/Vienna/Sources/Shared/SubscriptionModel.m
+++ b/Vienna/Sources/Shared/SubscriptionModel.m
@@ -63,7 +63,7 @@
 		NSURL * myURL = [NSURL URLWithString:feedPart relativeToURL:rssFeedURL];
 		if (myURL ==nil)
 		{
-            NSString * urlString = [NSString stringByCleaningURLString:feedPart];
+            NSString * urlString = feedPart.stringByUnescapingExtendedCharacters;
 			myURL = [NSURL URLWithString:urlString relativeToURL:rssFeedURL];
 		}
 		return myURL;


### PR DESCRIPTION
Various improvements related to operations with FreshRSS servers, TheOldReader.com and Inoreader.com

- sensibly decrease the number of network requests: 
    - use single 'mark-all-as-read' requests for marking folders read
    - avoid requesting feeds which haven't been updated
- work around a blockade put on by Inoreader
- add hidden preference to use specific AppId/AppKey with Inoreader: 
    > Each user of Inoreader user is able to define (and monitor) a personal
    > set of AppId / AppKey values through Inoreader preferences located at
    > https://www.inoreader.com/all_articles#preferences-developer
    > 
    > To have Vienna use these values instead of the default one, you have to
    > type in Terminal two commands similar to the following:
    > 
   >> defaults write uk.co.opencommunity.vienna2 SyncingAppId 9876543210
   >> defaults write uk.co.opencommunity.vienna2 SyncingAppKey JrS2smGyidtsxBOytDN1OWsSPcGURKWR
   > 
   > To get back to the default values:
   > 
   >> defaults delete uk.co.opencommunity.vienna2 SyncingAppId
   >> defaults delete uk.co.opencommunity.vienna2 SyncingAppKey
   > 
- adapt to feed identifiers used by TheOldReader and FreshRSS (hexadecimal Ids instead of URLs)
- improve feed infos synchronisation between Vienna and servers (feed name, homepage, folder/label)
- improve first authentication on OpenReader server
- fix RSS subscription button in browser pane

Other improvements were suggested at https://github.com/ViennaRSS/vienna-rss/issues/1252 , especially pooling the updates of status when individual articles are marked read.
I intend to work further on this, but as the above mentioned changes bring significant progresses, I submit the current pull request with the intent of publishing a final version of Vienna compatible with macOS 10.9. This version will be based on the current `stable` branch.

