### PR TITLE
Improve OpenReader (v3)

### DIFF
--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -162,7 +162,6 @@
 -(void)handleRSSLink:(NSString *)linkPath;
 -(void)selectFolder:(NSInteger)folderId;
 -(void)createNewSubscription:(NSString *)urlString underFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId;
--(void)createNewGoogleReaderSubscription:(NSString *)url underFolder:(NSInteger)parentId withTitle:(NSString*)title afterChild:(NSInteger)predecessorId;
 -(void)markSelectedFoldersRead:(NSArray *)arrayOfFolders;
 -(void)doSafeInitialisation;
 -(void)clearUndoStack;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2392,43 +2392,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     }
 }
 
-/* createNewGoogleReaderSubscription
- * Create a new Open Reader subscription for the specified URL under the given parent folder.
- */
-
--(void)createNewGoogleReaderSubscription:(NSString *)url underFolder:(NSInteger)parentId withTitle:(NSString*)title afterChild:(NSInteger)predecessorId
-{
-	NSLog(@"Adding Open Reader Feed: %@ with Title: %@",url,title);
-	// Replace feed:// with http:// if necessary
-	if ([url hasPrefix:@"feed://"])
-		url = [NSString stringWithFormat:@"http://%@", [url substringFromIndex:7]];
-	
-	// If the folder already exists, just select it.
-	Folder * folder = [db folderFromFeedURL:url];
-	if (folder != nil)
-	{
-		//[self.browser setActiveTabToPrimaryTab];
-		//[self.foldersTree selectFolder:[folder itemId]];
-		return;
-	}
-	
-	// Create then select the new folder.
-	NSInteger folderId = [db addGoogleReaderFolder:title
-                                       underParent:parentId
-                                        afterChild:predecessorId
-                                   subscriptionURL:url];
-		
-	if (folderId != -1)
-	{
-		//		[self.foldersTree selectFolder:folderId];
-		//		if (isAccessible(url))
-		//{
-			Folder * folder = [db folderFromID:folderId];
-			[[RefreshManager sharedManager] refreshSubscriptions:@[folder] ignoringSubscriptionStatus:NO];
-		//}
-	}
-}
-
 /* createNewSubscription
  * Create a new subscription for the specified URL under the given parent folder.
  */
@@ -2451,14 +2414,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	// Create the new folder.
 	if ([Preferences standardPreferences].syncGoogleReader && [Preferences standardPreferences].prefersGoogleNewSubscription)
-	{	//creates in Google
-		OpenReader * myGoogle = [OpenReader sharedManager];
-		[myGoogle subscribeToFeed:urlString];
+	{	//creates in OpenReader
 		NSString * folderName = [db folderFromID:parentId].name;
-		if (folderName != nil)
-			[myGoogle setFolderLabel:folderName forFeed:urlString set:TRUE];
-		[myGoogle loadSubscriptions];
-
+		[[OpenReader sharedManager] subscribeToFeed:urlString withLabel:folderName];
 	}
 	else
 	{ //creates locally
@@ -2817,7 +2775,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
             
 			if (folder.type == VNAFolderTypeOpenReader) {
 				NSLog(@"Unsubscribe Open Reader folder");
-				[[OpenReader sharedManager] unsubscribeFromFeed:folder.feedURL];
+				[[OpenReader sharedManager] unsubscribeFromFeedIdentifier:folder.remoteId];
 			}
 		}
 	}

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3254,18 +3254,17 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)refreshAllSubscriptions:(id)sender
 {
-    // Reset the refresh timer
-    [self handleCheckFrequencyChange:nil];
-
-    // Kick off the refresh
     if (!self.connecting) {
         if ([Preferences standardPreferences].syncGoogleReader){
             [[OpenReader sharedManager] loadSubscriptions];
         }
+
+        // Reset the refresh timer
+        [self handleCheckFrequencyChange:nil];
+        // Kick off the refresh
         [[RefreshManager sharedManager] refreshSubscriptions:[self.foldersTree folders:0]
           ignoringSubscriptionStatus:NO];
     }
-
 }
 
 -(IBAction)forceRefreshSelectedSubscriptions:(id)sender {

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1266,7 +1266,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     if (self.mainWindow.keyWindow) {
         NSAlert *alert = [NSAlert new];
         alert.messageText = NSLocalizedString(@"Open Reader Authentication Failed",nil);
-        alert.informativeText = NSLocalizedString(@"Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences. Also check your network access.",nil);
+        if (![nc.object isEqualToString:@""]) {
+            alert.informativeText = nc.object;
+        } else {
+            alert.informativeText = NSLocalizedString(@"Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences. Also check your network access.",nil);
+        }
         [alert beginSheetModalForWindow:self.mainWindow completionHandler:nil];
     }
 }

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -60,6 +60,7 @@ extern NSNotificationName const databaseDidDeleteFolderNotification;
 -(NSArray *)arrayOfFolders:(NSInteger)parentId;
 -(Folder *)folderFromID:(NSInteger)wantedId;
 -(Folder *)folderFromFeedURL:(NSString *)wantedFeedURL;
+-(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId;
 -(Folder *)folderFromName:(NSString *)wantedName;
 -(NSInteger)addFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId folderName:(NSString *)name type:(NSInteger)type canAppendIndex:(BOOL)canAppendIndex;
 -(BOOL)deleteFolder:(NSInteger)folderId;
@@ -67,6 +68,7 @@ extern NSNotificationName const databaseDidDeleteFolderNotification;
 -(BOOL)setDescription:(NSString *)newDescription forFolder:(NSInteger)folderId;
 -(BOOL)setHomePage:(NSString *)homePageURL forFolder:(NSInteger)folderId;
 -(BOOL)setFeedURL:(NSString *)feed_url forFolder:(NSInteger)folderId;
+-(BOOL)setRemoteId:(NSString *)remoteId forFolder:(NSInteger)folderId;
 -(BOOL)setFolderUsername:(NSInteger)folderId newUsername:(NSString *)name;
 -(void)purgeDeletedArticles;
 -(void)purgeArticlesOlderThanDays:(NSUInteger)daysToKeep;
@@ -87,7 +89,8 @@ extern NSNotificationName const databaseDidDeleteFolderNotification;
 -(NSInteger)addRSSFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId subscriptionURL:(NSString *)url;
 
 // Open Reader folder functions
--(NSInteger)addGoogleReaderFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId subscriptionURL:(NSString *)url;
+-(NSInteger)addOpenReaderFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId
+        subscriptionURL:(NSString *)url remoteId:(NSString *)remoteId;
 
 // Smart folder functions
 -(void)initSmartfoldersDict;

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -659,6 +659,37 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
 	return YES;
 }
 
+/**
+ *  Sets the identifier of the feed to a value which is returned by the OpenReader server.
+ *  Identifiers format vary with servers :
+ *  - most common form is URL-based :                         feed/https://www.lemonde.fr/rss/une.xml
+ *  - TheOldReader identifiers are based on hex data :        feed/5bdadad8c70bc2e3ae000e3a
+ *  - FreshRSS ones are based on decimal sequences per user : feed/16
+ *
+ *  @param remoteId the identifier to set the folder's feed to
+ *  @param folderId the ID of the folder whose remote identifier we are setting
+ *
+ *  @return YES on success
+ */
+-(BOOL)setRemoteId:(NSString *)remoteId forFolder:(NSInteger)folderId
+{
+	// Exit now if we're read-only
+    if (self.readOnly) {
+		return NO;
+    }
+
+	Folder * folder = [self folderFromID:folderId];
+	if (folder != nil && ![folder.remoteId isEqualToString:remoteId])
+	{
+		folder.remoteId = remoteId;
+        FMDatabaseQueue *queue = self.databaseQueue;
+        [queue inDatabase:^(FMDatabase *db) {
+            [db executeUpdate:@"update rss_folders set bloglines_id=? where folder_id=?", remoteId, @(folderId)];
+        }];
+	}
+	return YES;
+}
+
 /*!
  *  Add a Google Reader RSS Feed folder and return the ID of the new folder.
  *
@@ -669,33 +700,38 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
  *
  *  @return The ID of the new folder
  */
--(NSInteger)addGoogleReaderFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId subscriptionURL:(NSString *)feed_url {
-	NSInteger folderId = [self addFolder:parentId afterChild:predecessorId folderName:feedName type:VNAFolderTypeOpenReader canAppendIndex:YES];
-	//TODO: optimization using unique add function for addRSSFolder
-	if (folderId != -1)
-	{
+-(NSInteger)addOpenReaderFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId
+        subscriptionURL:(NSString *)feed_url remoteId:(NSString *)remoteId
+{
+    NSInteger folderId =
+        [self addFolder:parentId afterChild:predecessorId folderName:feedName type:VNAFolderTypeOpenReader canAppendIndex:YES];
+    if (folderId != -1) {
         FMDatabaseQueue *queue = self.databaseQueue;
         __block BOOL success;
         [queue inDatabase:^(FMDatabase *db) {
-            success = [db executeUpdate:@"insert into rss_folders (folder_id, description, username, home_page, last_update_string, feed_url, bloglines_id) values (?, ?, '', '', '', ?, 0)",
-             @(folderId),
-             feedName, // description
-             // username
-             // home_page
-             // last_update_string
-             feed_url];
-        }];
+                   success =
+                   [db executeUpdate:
+                   @"insert into rss_folders (folder_id, description, username, home_page, last_update_string, feed_url, bloglines_id) values (?, ?, '', '', '', ?, ?)",
+                   @(folderId),
+                   feedName, // description
+                   // username
+                   // home_page
+                   // last_update_string
+                   feed_url,
+                   remoteId];
+               }];
         if (!success) {
             return -1;
         }
-		
-		// Add this new folder to our internal cache
-		Folder * folder = [self folderFromID:folderId];
-		folder.feedURL = feed_url;
-	}
-	return folderId;
-}
 
+        // Add this new folder to our internal cache
+        Folder *folder = [self folderFromID:folderId];
+        folder.feedDescription = feedName;
+        folder.feedURL = feed_url;
+        folder.remoteId = remoteId;
+    }
+    return folderId;
+} /* addOpenReaderFolder */
 
 /*!
  *  Add a RSS Feed folder and return the ID of the new folder.
@@ -1391,6 +1427,26 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
 	return folder;
 }
 
+/*!
+ *  folderFromRemoteId
+ *
+ *  @param wantedRemoteId The remote identifier the folder is wanted for
+ *
+ *  @return An OpenReaderFolder that corresponds
+ */
+
+-(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId
+{
+	Folder * folder;
+
+	for (folder in [self.foldersDict objectEnumerator])
+	{
+		if ([folder.remoteId isEqualToString:wantedRemoteId])
+			break;
+	}
+	return folder;
+}
+
 /* handleAutoSortFoldersTreeChange
  * Called when preference changes for sorting folders tree.
  * Store the new method in the database.
@@ -1813,7 +1869,7 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
             [results close];
 		
         	// Load all RSS folders and add them to the list.
-			results = [db executeQuery:@"select folder_id, feed_url, username, last_update_string, description, home_page from rss_folders"];
+			results = [db executeQuery:@"select folder_id, feed_url, username, last_update_string, description, home_page, bloglines_id from rss_folders"];
 			while ([results next])
 			{
 				NSInteger folderId = [results stringForColumnIndex:0].integerValue;
@@ -1822,6 +1878,7 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
 				NSString * lastUpdateString = [results stringForColumnIndex:3];
 				NSString * descriptiontext = [results stringForColumnIndex:4];
 				NSString * linktext = [results stringForColumnIndex:5];
+				NSString * remoteId = [results stringForColumnIndex:6];
 				
 				Folder * folder = [self folderFromID:folderId];
 				folder.feedDescription = descriptiontext;
@@ -1829,6 +1886,7 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
 				folder.feedURL = url;
 				folder.lastUpdateString = lastUpdateString;
 				folder.username = username;
+				folder.remoteId = remoteId;
 			}
 			[results close];
 		}];

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -939,10 +939,11 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
 	// Adjust unread counts on parents
 	folder = [self folderFromID:folderId];
 	NSInteger adjustment = -folder.unreadCount;
-	while (folder.parentId != VNAFolderTypeRoot)
+	folder = [self folderFromID:folder.parentId];
+	while (folder != nil)
 	{
-		folder = [self folderFromID:folder.parentId];
 		folder.childUnreadCount = folder.childUnreadCount + adjustment;
+		folder = [self folderFromID:folder.parentId];
 	}
 
 	// Delete all articles in this folder then delete ourselves.
@@ -2525,13 +2526,12 @@ NSNotificationName const databaseDidDeleteFolderNotification = @"Database Did De
         [db executeUpdate:@"UPDATE folders set unread_count=? where folder_id=?", @(newCount), @(folder.itemId)];
     }];
 
-	// Update childUnreadCount for our parent. Since we're just working
-	// on one article, we do this the faster way.
-	Folder * tmpFolder = folder;
-	while (tmpFolder.parentId != VNAFolderTypeRoot)
+	// Update childUnreadCount for parents.
+	Folder * tmpFolder = [self folderFromID:folder.parentId];
+	while (tmpFolder != nil)
 	{
-		tmpFolder = [self folderFromID:tmpFolder.parentId];
 		tmpFolder.childUnreadCount = tmpFolder.childUnreadCount + adjustment;
+		tmpFolder = [self folderFromID:tmpFolder.parentId];
 	}
 }
 

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -29,6 +29,7 @@
 -(void)unsubscribeFromFeed:(NSString *)feedURL;
 -(void)markRead:(Article *)article readFlag:(BOOL)flag;
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag;
+-(void)markAllRead:(Folder *)folder;
 -(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
 -(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedURL;
 -(void)refreshFeed:(Folder*)thisFolder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:(BOOL)ignoreLimit;

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -26,13 +26,13 @@
 -(void)clearAuthentication;
 -(void)resetAuthentication;
 
--(void)subscribeToFeed:(NSString *)feedURL;
--(void)unsubscribeFromFeed:(NSString *)feedURL;
+-(void)subscribeToFeed:(NSString *)feedURL withLabel:(NSString *)label;
+-(void)unsubscribeFromFeedIdentifier:(NSString *)feedIdentifier;
 -(void)markRead:(Article *)article readFlag:(BOOL)flag;
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag;
--(void)markAllRead:(Folder *)folder;
--(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedURL set:(BOOL)flag;
--(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedURL;
+-(void)markAllReadInFolder:(Folder *)folder;
+-(void)setFolderLabel:(NSString *)folderName forFeed:(NSString *)feedIdentifier set:(BOOL)flag;
+-(void)setFolderTitle:(NSString *)folderName forFeed:(NSString *)feedIdentifier;
 -(void)refreshFeed:(Folder*)thisFolder withLog:(ActivityItem *)aItem shouldIgnoreArticleLimit:(BOOL)ignoreLimit;
 @property (nonatomic, readonly) NSUInteger countOfNewArticles;
 

--- a/Vienna/Sources/Fetching/OpenReader.h
+++ b/Vienna/Sources/Fetching/OpenReader.h
@@ -20,6 +20,7 @@
 
 // Check if an accessToken is available
 @property (nonatomic, getter=isReady, readonly) BOOL ready;
+@property (nonatomic) NSOperation * unreadCountOperation;
 
 -(void)loadSubscriptions;
 -(void)clearAuthentication;

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -137,8 +137,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 -(void)specificHeadersPrepare:(NSMutableURLRequest *)request
 {
     if (hostRequiresInoreaderHeaders) {
-        [request setValue:@"1000001359" forHTTPHeaderField:@"AppID"];
-        [request setValue:@"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn" forHTTPHeaderField:@"AppKey"];
+        [request setValue:[Preferences standardPreferences].syncingAppId forHTTPHeaderField:@"AppID"];
+        [request setValue:[Preferences standardPreferences].syncingAppKey forHTTPHeaderField:@"AppKey"];
         [request setValue:@"Mozilla/5.0 (compatible)" forHTTPHeaderField:@"User-Agent"];
     }
 }

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -91,7 +91,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             @"AppID": @"1000001359",
             @"AppKey": @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn"
         };
-        _asyncQueue = dispatch_queue_create("uk.co.opencommunity.vienna2.openReaderTasks", NULL);
+        _asyncQueue = dispatch_queue_create("uk.co.opencommunity.vienna2.openReaderTasks", DISPATCH_QUEUE_SERIAL);
     }
 
     return self;

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -744,7 +744,9 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
         } else { //response status other than OK (200)
             [aItem appendDetail:[NSString stringWithFormat:@"%@ %@", NSLocalizedString(@"Error", nil),
                                     [NSHTTPURLResponse localizedStringForStatusCode:((NSHTTPURLResponse *)response).statusCode]]];
-            [aItem setStatus:NSLocalizedString(@"Error", nil)];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [aItem setStatus:NSLocalizedString(@"Error", nil)];
+            });
             [refreshedFolder clearNonPersistedFlag:VNAFolderFlagUpdating];
             [refreshedFolder setNonPersistedFlag:VNAFolderFlagError];
         }

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -1057,6 +1057,54 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 }
 
+-(void)markAllRead:(Folder *)folder
+{
+    NSURL *markReadURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@mark-all-as-read", APIBaseURL]];
+    NSMutableURLRequest *request = [self authentifiedFormRequestFromURL:markReadURL];
+    [request setUserInfo: @{ @"folder": folder}];
+    NSString *feedIdentifier;
+    if (hostRequiresHexaForFeedId) {
+        feedIdentifier = folder.feedURL.lastPathComponent;
+    } else {
+        feedIdentifier = folder.feedURL;
+    }
+    [request setPostValue:[NSString stringWithFormat:@"feed/%@", feedIdentifier] forKey:@"s"];
+    NSString *folderLastUpdateString = folder.lastUpdateString;
+    //This is a workaround throw a BAD folderupdate value on DB
+    if (folderLastUpdateString == nil || [folderLastUpdateString isEqualToString:@""] ||
+        [folderLastUpdateString isEqualToString:@"(null)"])
+    {
+        folderLastUpdateString = @"0";
+    }
+    NSInteger localTimestamp = (folderLastUpdateString.longLongValue +1)* 1000000 ; // next second converted to microseconds
+    NSString * microsecondsUpdateString = @(localTimestamp).stringValue; // string value of NSNumber
+    [request setPostValue:microsecondsUpdateString forKey:@"ts"];
+    __weak typeof(self) weakSelf = self;
+    [[RefreshManager sharedManager] addConnection:request
+		completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+			if (error) {
+			[weakSelf requestFailed:request response:response error:error];
+			} else {
+			[weakSelf markAllReadDone:request response:response data:data];
+			}
+		}
+    ];
+} // markAllRead
+
+// callback : we check if the server did confirm the read status change
+-(void)markAllReadDone:(NSMutableURLRequest *)request response:(NSURLResponse *)response data:(NSData *)data
+{
+    NSString *requestResponse = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    if ([requestResponse isEqualToString:@"OK"]) {
+        Folder *folder = ((NSDictionary *)[request userInfo])[@"folder"];
+        [[Database sharedManager] markFolderRead:folder.itemId];
+        [folder markArticlesInCacheRead];
+        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+        [nc postNotificationOnMainThreadWithName:@"MA_Notify_FoldersUpdated" object:@(folder.itemId)];
+        [nc postNotificationOnMainThreadWithName:@"MA_Notify_ArticleListStateChange" object:@(folder.itemId)];
+    }
+}
+
 -(void)markStarred:(Article *)article starredFlag:(BOOL)flag
 {
     NSURL *markStarredURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@edit-tag", APIBaseURL]];

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -63,7 +63,6 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 @property (atomic) NSString *clientAuthToken;
 @property (nonatomic) NSTimer *tTokenTimer;
 @property (nonatomic) NSTimer *clientAuthTimer;
-@property (nonatomic) NSMutableArray *tTokenWaitQueue;
 @property (nonatomic) dispatch_queue_t asyncQueue;
 @property (nonatomic) OpenReaderStatus openReaderStatus;
 @property (readonly, class, nonatomic) NSString *currentTimestamp;
@@ -79,7 +78,6 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     self = [super init];
     if (self) {
         // Initialization code here.
-        _tTokenWaitQueue = [[NSMutableArray alloc] init];
         _openReaderStatus = notAuthenticated;
         _countOfNewArticles = 0;
         openReaderHost = nil;
@@ -269,28 +267,19 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 -(void)getTokenForRequest:(NSMutableURLRequest *)clientRequest
 {
     static NSOperation * tTokenOperation;
+    dispatch_semaphore_t sema;
 
     if (self.openReaderStatus == fullyAuthenticated) {
         [clientRequest setPostValue:self.tToken forKey:@"T"];
         return;
-    } else if (self.openReaderStatus == waitingTToken && tTokenOperation != nil && !tTokenOperation.isFinished) {
-        if (clientRequest != nil) {
-            [clientRequest setInUserInfo:tTokenOperation forKey:@"dependency"];
-            [self.tTokenWaitQueue addObject:clientRequest];
-        }
-        return;
-    } else if (self.openReaderStatus == notAuthenticated || self.openReaderStatus == waitingClientToken) {
-        // in principle, this should only happen with _openReaderStatus == notAuthenticated, after failure to get clientAuthToken
-        if (clientRequest != nil) {
-            [self.tTokenWaitQueue addObject:clientRequest];
-        }
-        return;
     } else {
-        // openReaderStatus ==  missingTToken
+        // we might get here when status is missingTToken or waitingClientToken or notAuthenticated
         NSMutableURLRequest * myRequest = [self requestFromURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@token", APIBaseURL]]];
         self.openReaderStatus = waitingTToken;
-        [[RefreshManager sharedManager] suspendConnectionsQueue];
-        tTokenOperation = [[RefreshManager sharedManager] addConnection:myRequest
+        // semaphore with count equal to zero for synchronizing completion of work
+        sema = dispatch_semaphore_create(0);
+        tTokenOperation = [NSBlockOperation blockOperationWithBlock:^(void) {
+          NSURLSessionDataTask * task = [[NSURLSession sharedSession] dataTaskWithRequest:myRequest
             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                 if (error) {
                     NSLog(@"tTokenOperation error for URL %@", myRequest.URL);
@@ -300,15 +289,9 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                     NSLog(@"Response data %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
                     self.tToken = nil;
                     self.openReaderStatus = missingTToken;
-                    [self.tTokenWaitQueue removeAllObjects];
                 } else {
-                    [[RefreshManager sharedManager] suspendConnectionsQueue];
                     self.tToken = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                     self.openReaderStatus = fullyAuthenticated;
-                    for (id obj in self.tTokenWaitQueue) {
-                        [(NSMutableURLRequest *)obj setPostValue:self.tToken forKey:@"T"];
-                    }
-                    [self.tTokenWaitQueue removeAllObjects];
                     if (self.tTokenTimer == nil || !self.tTokenTimer.valid) {
                         //tokens expire after 30 minutes : renew them every 25 minutes
                         self.tTokenTimer = [NSTimer scheduledTimerWithTimeInterval:25 * 60
@@ -317,15 +300,20 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                                                                           userInfo:nil
                                                                            repeats:YES];
                     }
-                    [[RefreshManager sharedManager] resumeConnectionsQueue];
                 }
+				// Signal that we are done with the synchronous task
+				dispatch_semaphore_signal(sema);
+          }];
+          if (@available(macOS 10.10, *)) {
+              task.priority = NSURLSessionTaskPriorityHigh;
+          };
+          [task resume];
         }];
-        if (clientRequest != nil) {
-            [clientRequest setInUserInfo:tTokenOperation forKey:@"dependency"];
-            [self.tTokenWaitQueue addObject:clientRequest];
-        }
-        [[RefreshManager sharedManager] resumeConnectionsQueue];
-    } // missingTToken
+        [tTokenOperation start];
+        // we wait until the task response block above will send a signal
+        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        [clientRequest setPostValue:self.tToken forKey:@"T"];
+    } // missingTToken or waitingClientToken or notAuthenticated
 } // getTokenForRequest
 
 -(void)renewTToken

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -463,8 +463,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 
     // Request id's of unread items
     NSString *args =
-        [NSString stringWithFormat:@"?ck=%@&client=%@&s=feed/%@&xt=user/-/state/com.google/read&n=1000&output=json",
-         OpenReader.currentTimestamp, ClientName,
+        [NSString stringWithFormat:@"?client=%@&s=feed/%@&xt=user/-/state/com.google/read&n=1000&output=json", ClientName,
          percentEscape(feedIdentifier)];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@", APIBaseURL, @"stream/items/ids", args]];
     NSMutableURLRequest *request2 = [self requestFromURL:url];
@@ -480,7 +479,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 
     NSString *args3 =
-        [NSString stringWithFormat:@"?ck=%@&client=%@&s=feed/%@&%@&n=1000&output=json", OpenReader.currentTimestamp, ClientName,
+        [NSString stringWithFormat:@"?client=%@&s=feed/%@&%@&n=1000&output=json", ClientName,
          percentEscape(feedIdentifier), starredSelector];
     NSURL *url3 = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@%@", APIBaseURL, @"stream/items/ids", args3]];
     NSMutableURLRequest *request3 = [self requestFromURL:url3];

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -193,37 +193,32 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             NSURLSessionDataTask * task = [[NSURLSession sharedSession] dataTaskWithRequest:myRequest
                 completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                     self.openReaderStatus = notAuthenticated;
-                    if (error) {
-                        NSLog(@"clientAuthOperation error for URL %@", ((NSHTTPURLResponse *)response).URL);
-                        NSLog(@"Headers %@", ((NSHTTPURLResponse *)response).allHeaderFields);
-                        NSLog(@"Response data %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
-                        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_GoogleAuthFailed" object:nil];
-                    } else {
-                        if (((NSHTTPURLResponse *)response).statusCode != 200) {
-                            NSLog(@"clientAuthOperation statusCode %ld for URL %@", ((NSHTTPURLResponse *)response).statusCode, ((NSHTTPURLResponse *)response).URL);
-                            NSLog(@"Headers %@", ((NSHTTPURLResponse *)response).allHeaderFields);
-                            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_GoogleAuthFailed" object:nil];
-                        } else {         // statusCode 200
-                            NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                            NSArray *components = [response componentsSeparatedByString:@"\n"];
-                            for (NSString * item in components) {
-                                if([item hasPrefix:@"Auth="]) {
-                                    self.clientAuthToken = [item substringFromIndex:5];
-                                    self.openReaderStatus = missingTToken;
-                                    break;
-                                }
-                            }
+					if (error) {
+						NSString * info = error.localizedDescription;
+						[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_GoogleAuthFailed" object:info];
+					} else if (((NSHTTPURLResponse *)response).statusCode != 200) {
+						NSString * info = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+						[[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"MA_Notify_GoogleAuthFailed" object:info];
+ 					} else {         // statusCode 200
+						NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+						NSArray *components = [response componentsSeparatedByString:@"\n"];
+						for (NSString * item in components) {
+							if([item hasPrefix:@"Auth="]) {
+								self.clientAuthToken = [item substringFromIndex:5];
+								self.openReaderStatus = missingTToken;
+								break;
+							}
+						}
 
-                            if (self.openReaderStatus == missingTToken && (self.clientAuthTimer == nil || !self.clientAuthTimer.valid)) {
-                                //new request every 6 days
-                                self.clientAuthTimer = [NSTimer scheduledTimerWithTimeInterval:6 * 24 * 3600
-                                                                                        target:self
-                                                                                      selector:@selector(resetAuthentication)
-                                                                                      userInfo:nil
-                                                                                       repeats:YES];
-                            }
-                        }
-                    }  // if error
+						if (self.openReaderStatus == missingTToken && (self.clientAuthTimer == nil || !self.clientAuthTimer.valid)) {
+							//new request every 6 days
+							self.clientAuthTimer = [NSTimer scheduledTimerWithTimeInterval:6 * 24 * 3600
+																					target:self
+																				  selector:@selector(resetAuthentication)
+																				  userInfo:nil
+																				   repeats:YES];
+						}
+                    }  // if statusCode 200
 
                     // Signal that we are done
                     dispatch_semaphore_signal(sema);

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -1121,13 +1121,6 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
     [completionOperation addDependency:op];
     [[NSOperationQueue mainQueue] addOperation:completionOperation];
 
-    NSOperation *requiredOperation = ((NSDictionary *)[urlRequest userInfo])[@"dependency"];
-    if (requiredOperation != nil) {
-        op.queuePriority = NSOperationQueuePriorityLow;
-        [op addDependency:requiredOperation];
-        [urlRequest setInUserInfo:nil forKey:@"dependency"];
-    }
-
     [networkQueue addOperation:op];
     if (networkQueue.operationCount == 1) {       // networkQueue is NOT YET started
         [self updateStatus];

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -95,6 +95,8 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         config.timeoutIntervalForRequest = 180;
         config.URLCache = nil;
         config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent};
+        config.HTTPMaximumConnectionsPerHost = 6;
+        config.HTTPShouldUsePipelining = YES;
         _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:[NSOperationQueue mainQueue]];
 
         NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -995,7 +995,7 @@
 		{
 			NSArray * articleArray = [folder arrayOfUnreadArticlesRefs];
 			[refArray addObjectsFromArray:articleArray];
-			[self innerMarkReadByRefsArray:articleArray readFlag:YES];
+			[[OpenReader sharedManager] markAllRead:folder];
 		}
 		else
 		{

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -995,7 +995,7 @@
 		{
 			NSArray * articleArray = [folder arrayOfUnreadArticlesRefs];
 			[refArray addObjectsFromArray:articleArray];
-			[[OpenReader sharedManager] markAllRead:folder];
+			[[OpenReader sharedManager] markAllReadInFolder:folder];
 		}
 		else
 		{

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1142,7 +1142,7 @@
         {
             [dbManager setName:newName forFolder:folder.itemId];
             if (folder.type == VNAFolderTypeOpenReader) {
-                [[OpenReader sharedManager] setFolderTitle:newName forFeed:folder.feedURL];
+                [[OpenReader sharedManager] setFolderTitle:newName forFeed:folder.remoteId];
             }
         }
 	}
@@ -1336,13 +1336,13 @@
 			{
 				if (folder.type == VNAFolderTypeOpenReader)
 				{
-					OpenReader * myGoogle = [OpenReader sharedManager];
+					OpenReader * myReader = [OpenReader sharedManager];
 					// remove old label
 					NSString * folderName = [dbManager folderFromID:oldParentId].name;
-					[myGoogle setFolderLabel:folderName forFeed:folder.feedURL set:FALSE];
+					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:FALSE];
 					// add new label
 					folderName = [dbManager folderFromID:newParentId].name;
-					[myGoogle setFolderLabel:folderName forFeed:folder.feedURL set:TRUE];
+					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
 				}
 			}
 			else

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -147,7 +147,7 @@
 	[nc addObserver:self selector:@selector(handleFolderFontChange:) name:@"MA_Notify_FolderFontChange" object:nil];
 	[nc addObserver:self selector:@selector(handleShowFolderImagesChange:) name:@"MA_Notify_ShowFolderImages" object:nil];
 	[nc addObserver:self selector:@selector(handleAutoSortFoldersTreeChange:) name:@"MA_Notify_AutoSortFoldersTreeChange" object:nil];
-    [nc addObserver:self selector:@selector(handleGRSFolderChange:) name:@"MA_Notify_GRSFolderChange" object:nil];
+    [nc addObserver:self selector:@selector(handleOpenReaderFolderChange:) name:@"MA_Notify_OpenReaderFolderChange" object:nil];
 }
 
 -(NSMenu *)folderMenu
@@ -192,10 +192,10 @@
     return folderMenu;
 }
 
--(void)handleGRSFolderChange:(NSNotification *)nc
+-(void)handleOpenReaderFolderChange:(NSNotification *)nc
 {
-    // No need to sync with Google because this is triggered when Open Reader
-    // folder layout has changed. Making a sync call would be redundant.
+    // No need to sync with OpenReader server because this is triggered when
+    // folder layout has changed at server level. Making a sync call would be redundant.
     [self moveFolders:nc.object withGoogleSync:NO];
 }
 
@@ -1334,7 +1334,7 @@
 				[newParent setCanHaveChildren:YES];
 			if ([dbManager setParent:newParentId forFolder:folderId])
 			{
-				if (folder.type == VNAFolderTypeOpenReader)
+				if (sync && folder.type == VNAFolderTypeOpenReader)
 				{
 					OpenReader * myReader = [OpenReader sharedManager];
 					// remove old label
@@ -1342,7 +1342,9 @@
 					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:FALSE];
 					// add new label
 					folderName = [dbManager folderFromID:newParentId].name;
-					[myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
+					if (folderName) {
+					    [myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
+					}
 				}
 			}
 			else

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -85,6 +85,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, readonly, copy) NSArray<Article *> *articles;
 -(NSArray<Article *> *)articlesWithFilter:(NSString *)filterString;
 @property (nonatomic, readonly) NSInteger itemId;
+@property (nonatomic, copy) NSString *remoteId;
 @property (nonatomic) NSInteger parentId;
 @property (nonatomic) NSInteger nextSiblingId;
 @property (nonatomic) NSInteger firstChildId;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -98,6 +98,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, getter=isGroupFolder, readonly) BOOL groupFolder;
 @property (nonatomic, getter=isSmartFolder, readonly) BOOL smartFolder;
 @property (nonatomic, getter=isRSSFolder, readonly) BOOL RSSFolder;
+@property (nonatomic, getter=isOpenReaderFolder, readonly) BOOL OpenReaderFolder;
 @property (nonatomic, readonly) BOOL loadsFullHTML;
 @property (nonatomic, getter=isUnsubscribed, readonly) BOOL unsubscribed;
 @property (nonatomic, getter=isUpdating, readonly) BOOL updating;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -47,11 +47,13 @@ typedef NS_ENUM(NSInteger, VNAFolderType) {
  Folder flags
  
  - VNAFolderFlagCheckForImage: asks the refresh code to update the folder image
- - VNAFolderFlagNeedCredentials: VNAFolderFlagNeedCredentials description
- - VNAFolderFlagError: VNAFolderFlagError description
- - VNAFolderFlagUnsubscribed: VNAFolderFlagUnsubscribed description
- - VNAFolderFlagUpdating: VNAFolderFlagUpdating description
- - VNAFolderFlagLoadFullHTML: VNAFolderFlagLoadFullHTML description
+ - VNAFolderFlagNeedCredentials: feed requires credentials which is not yet obtained
+ - VNAFolderFlagError: inform the user that the feed has an error
+ - VNAFolderFlagUnsubscribed: currently unsubscribed from the feed
+ - VNAFolderFlagUpdating: inform the user that the folder is currently being refreshed
+ - VNAFolderFlagLoadFullHTML: load article's web page rather than display feed text
+ - VNAFolderFlagSyncedOK: according to available info, no fresher information is available
+                          on the OpenReader server
  */
 typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
     VNAFolderFlagCheckForImage   = 1 << 0,
@@ -59,7 +61,8 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
     VNAFolderFlagError           = 1 << 2,
     VNAFolderFlagUnsubscribed    = 1 << 3,
     VNAFolderFlagUpdating        = 1 << 4,
-    VNAFolderFlagLoadFullHTML    = 1 << 5
+    VNAFolderFlagLoadFullHTML    = 1 << 5,
+    VNAFolderFlagSyncedOK        = 1 << 6
 };
 
 @interface Folder : NSObject <NSCacheDelegate> {
@@ -103,6 +106,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, getter=isUnsubscribed, readonly) BOOL unsubscribed;
 @property (nonatomic, getter=isUpdating, readonly) BOOL updating;
 @property (nonatomic, getter=isError, readonly) BOOL error;
+@property (nonatomic, getter=isSyncedOK, readonly) BOOL localSynced;
 -(void)setFlag:(VNAFolderFlag)flagToSet;
 -(void)clearFlag:(VNAFolderFlag)flagToClear;
 -(void)setNonPersistedFlag:(VNAFolderFlag)flagToSet;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -354,6 +354,13 @@ static NSArray * iconArray = nil;
     return self.type == VNAFolderTypeRSS;
 }
 
+/* isOpenReaderFolder
+ * Returns YES if this folder is an OpenReader feed folder.
+ */
+-(BOOL)isOpenReaderFolder {
+    return self.type == VNAFolderTypeOpenReader;
+}
+
 // MARK: - VNAFolderFlag methods
 
 /* loadsFullHTML

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -77,6 +77,7 @@ static NSArray * iconArray = nil;
 		self.lastUpdateString = @"";
 		self.username = @"";
 		_lastUpdate = [NSDate distantPast];
+		self.remoteId = @"0";
 	}
 	return self;
 }
@@ -315,6 +316,22 @@ static NSArray * iconArray = nil;
 -(void)setFeedURL:(NSString *)newURL
 {
 	[self.attributes setValue:newURL forKey:@"FeedURL"];
+}
+
+/* remoteId
+ * Returns the identifier used by the remote OpenReader server
+ */
+-(NSString *)remoteId
+{
+	return [self.attributes valueForKey:@"remoteId"];
+}
+
+/* setRemoteId
+ * Stores the identifier used by the remote OpenReader server for this feed.
+ */
+-(void)setRemoteId:(NSString *)newId
+{
+	[self.attributes setValue:newId forKey:@"remoteId"];
 }
 
 /* name

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -382,6 +382,10 @@ static NSArray * iconArray = nil;
     return (self.nonPersistedFlags & VNAFolderFlagError);
 }
 
+-(BOOL)isSyncedOK {
+    return (self.nonPersistedFlags & VNAFolderFlagSyncedOK);
+}
+
 /* setFlag
  * Set the specified flag on the folder.
  */

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -214,4 +214,9 @@ extern NSString * const kMA_Notify_UseWebPluginsChange;
 
 // username used for syncing
 @property (nonatomic, copy) NSString *syncingUser;
+
+// application ID and key needed by specific OpenReader services
+@property (nonatomic, copy) NSString *syncingAppId;
+@property (nonatomic, copy) NSString *syncingAppKey;
+
 @end

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -192,6 +192,8 @@ static Preferences * _standardPreferences = nil;
         prefersGoogleNewSubscription = [self boolForKey:MAPref_GoogleNewSubscription];
 		syncServer = [userPrefs valueForKey:MAPref_SyncServer];
 		syncingUser = [userPrefs valueForKey:MAPref_SyncingUser];
+		_syncingAppId = [userPrefs valueForKey:MAPref_SyncingAppId];
+		_syncingAppKey = [userPrefs valueForKey:MAPref_SyncingAppKey];
 				
 		//Sparkle autoupdate
 		checkForNewOnStartup = [SUUpdater sharedUpdater].automaticallyChecksForUpdates;
@@ -284,6 +286,8 @@ static Preferences * _standardPreferences = nil;
     defaultValues[MAPref_ConcurrentDownloads] = @(MA_Default_ConcurrentDownloads);
     defaultValues[MAPref_SyncGoogleReader] = boolNo;
     defaultValues[MAPref_GoogleNewSubscription] = boolNo;
+    defaultValues[MAPref_SyncingAppId] = @"1000001359";
+    defaultValues[MAPref_SyncingAppKey] = @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn";
     defaultValues[MAPref_AlwaysAcceptBetas] = boolNo;
 	
 	return [defaultValues copy];

--- a/Vienna/Sources/Preferences window/SyncingPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/SyncingPreferencesViewController.m
@@ -239,7 +239,11 @@ static BOOL _credentialsChanged;
     {
         NSAlert *alert = [NSAlert new];
         alert.messageText = NSLocalizedString(@"Open Reader Authentication Failed",nil);
-        alert.informativeText = NSLocalizedString(@"Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences. Also check your network access.",nil);
+        if (![nc.object isEqualToString:@""]) {
+            alert.informativeText = nc.object;
+        } else {
+            alert.informativeText = NSLocalizedString(@"Make sure the username and password needed to access the Open Reader server are correctly set in Vienna's preferences. Also check your network access.",nil);
+        }
         [alert beginSheetModalForWindow:self.view.window completionHandler:^(NSModalResponse returnCode) {
             [[OpenReader sharedManager] clearAuthentication];
         }];

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -78,6 +78,8 @@ extern NSString * MAPref_GoogleNewSubscription;
 extern NSString * MAPref_ConcurrentDownloads;
 extern NSString * MAPref_SyncServer;
 extern NSString * MAPref_SyncingUser;
+extern NSString * MAPref_SyncingAppId;
+extern NSString * MAPref_SyncingAppKey;
 extern NSString * MAPref_SendSystemProfileInfo;
 extern NSString * MAPref_AlwaysAcceptBetas;
 

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -77,6 +77,8 @@ NSString * MAPref_GoogleNewSubscription = @"GoogleNewSubscription";
 NSString * MAPref_ConcurrentDownloads = @"ConcurrentDownloads"; 
 NSString * MAPref_SyncServer = @"SyncServer";
 NSString * MAPref_SyncingUser = @"SyncingUser";
+NSString * MAPref_SyncingAppId = @"SyncingAppId";
+NSString * MAPref_SyncingAppKey = @"SyncingAppKey";
 NSString * MAPref_SendSystemProfileInfo = @"SUSendProfileInfo";
 NSString * MAPref_AlwaysAcceptBetas = @"AlwayAcceptBetas";
 


### PR DESCRIPTION
Various improvements related to operations with FreshRSS servers, TheOldReader.com and Inoreader.com
Replaces pull request #1314 

- sensibly decrease the number of network requests: 
    - use single 'mark-all-as-read' requests for marking folders read
    - avoid requesting feeds which haven't been updated
- work around a blockade put on by Inoreader
- add hidden preference to use specific AppId/AppKey with Inoreader: 
    > Each user of Inoreader user is able to define (and monitor) a personal
    > set of AppId / AppKey values through Inoreader preferences located at
    > https://www.inoreader.com/all_articles#preferences-developer
    > 
    > To have Vienna use these values instead of the default one, you have to
    > type in Terminal two commands similar to the following:
    > 
   >> defaults write uk.co.opencommunity.vienna2 SyncingAppId 9876543210
   >> defaults write uk.co.opencommunity.vienna2 SyncingAppKey JrS2smGyidtsxBOytDN1OWsSPcGURKWR
   > 
   > To get back to the default values:
   > 
   >> defaults delete uk.co.opencommunity.vienna2 SyncingAppId
   >> defaults delete uk.co.opencommunity.vienna2 SyncingAppKey
   > 
- adapt to feed identifiers used by TheOldReader and FreshRSS (numerical Ids instead of URLs)
- improve feed infos synchronisation between Vienna and servers (feed name, homepage, folder/label)
- improve first authentication on OpenReader server

Other improvements were suggested at https://github.com/ViennaRSS/vienna-rss/issues/1252 , especially pooling the updates of status when individual articles are marked read.
I intend to work further on this, but as the above mentioned changes bring significant progresses, I submit the current pull request with the intent of publishing a final version of Vienna compatible with macOS 10.9. This version will be based on the current `stable` branch.
