### PR TITLE
Fix syncing preferences panel

### DIFF
--- a/Vienna/Sources/Preferences window/SyncingPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/SyncingPreferencesViewController.m
@@ -33,16 +33,14 @@ static BOOL _credentialsChanged;
 
 @synthesize syncButton;
 
-- (void)viewDidLoad {
-    // Set up to be notified if preferences change outside this window
+- (void)viewWillAppear {
+    // Set up to be notified
     NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(handleGoogleAuthFailed:) name:@"MA_Notify_GoogleAuthFailed" object:nil];
     [nc addObserver:self selector:@selector(handleServerTextDidChange:) name:NSControlTextDidChangeNotification object:openReaderHost];
     [nc addObserver:self selector:@selector(handleUserTextDidChange:) name:NSControlTextDidChangeNotification object:username];
-    [nc addObserver:self selector:@selector(handlePasswordTextDidChange:) name:NSControlTextDidEndEditingNotification object:password];
-}
+    [nc addObserver:self selector:@selector(handlePasswordTextDidChange:) name:NSControlTextDidChangeNotification object:password];
 
-- (void)viewWillAppear {
     if([NSViewController instancesRespondToSelector:@selector(viewWillAppear)]) {
         [super viewWillAppear];
     }


### PR DESCRIPTION
User input was not always taken into account.
- as notification handling is removed on panel disappearance, we need
  to reinstate it on following appearance
- use the same kind of notification on each control