### PR TITLE
Prevent crash when parsing non XML data

### DIFF
--- a/Vienna/Sources/Parsing/RichXMLParser.m
+++ b/Vienna/Sources/Parsing/RichXMLParser.m
@@ -66,6 +66,8 @@
                         return NO;
                     case NSXMLParserTagNameMismatchError:
                         return NO;
+                    case NSXMLParserEmptyDocumentError:
+                        return NO;
                 }
             }
 


### PR DESCRIPTION
As reported at https://forums.cocoaforge.com/viewtopic.php?f=18&t=27218
Vienna may crash when trying to parse a JSON feed…