### PR TITLE
Fix empty ArticleView on returning to same article

### DIFF
--- a/Vienna/Sources/Main window/ArticleView.m
+++ b/Vienna/Sources/Main window/ArticleView.m
@@ -252,6 +252,7 @@ static NSMutableDictionary * stylePathMappings = nil;
 {
     self.hidden = YES;
     self.mainFrameURL = @"about:blank";
+    currentHTML = @"";
 }
 
 /* setHTML


### PR DESCRIPTION
After we applied a fix to issue #1154, issue #1266 (that I could not
reproduce beforehand) becomes apparent: if we have an article visible,
then choose a different subscription without selecting any article, and
afterwards return to the original article, this one will not re-appear
in thhe article view.