### PR TITLE
sync cleanedUpURLFromString with stringByCleaningURLString

### DIFF
--- a/Vienna Tests/models/ArticleTests.m
+++ b/Vienna Tests/models/ArticleTests.m
@@ -279,7 +279,8 @@ static NSString * const Body =
 {
     NSString *string = @"$ArticleLink$";
 
-    NSString *expectedString = [NSString stringWithFormat:@"%@/", Link];
+    //previously, we expected a '/' at the end of the link, but that was only webkit behavior and is not necessary.
+    NSString *expectedString = [NSString stringWithFormat:@"%@", Link];
 
     self.article.link = Link;
 

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2406,7 +2406,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	if ([urlString hasPrefix:@"feed://"])
 		urlString = [NSString stringWithFormat:@"http://%@", [urlString substringFromIndex:7]];
 
-	urlString = cleanedUpUrlFromString(urlString).absoluteString;
+	urlString = urlFromUserString(urlString).absoluteString;
 	
 	// If the folder already exists, just select it.
 	Folder * folder = [db folderFromFeedURL:urlString];

--- a/Vienna/Sources/Main window/BrowserPane.m
+++ b/Vienna/Sources/Main window/BrowserPane.m
@@ -206,7 +206,7 @@
 	}
 
 	// cleanUpUrl is a hack to handle Internationalized Domain Names. WebKit handles them automatically, so we tap into that.
-	NSURL *urlToLoad = cleanedUpUrlFromString(theURL);
+	NSURL *urlToLoad = urlFromUserString(theURL);
 	if (urlToLoad != nil)
 	{
 		//set url and load immediately, because action was invoked by user

--- a/Vienna/Sources/Main window/EnclosureView.m
+++ b/Vienna/Sources/Main window/EnclosureView.m
@@ -74,9 +74,10 @@
 {
 
 	// Keep this for the download/open
-    enclosureURLString = cleanedUpUrlFromString(newFilename).absoluteString;
+    NSURL *enclosureUrl = cleanedUpUrlFromString(newFilename);
+    enclosureURLString = enclosureUrl.absoluteString;
 
-	NSString * basename = [NSURL URLWithString:enclosureURLString].lastPathComponent;
+	NSString * basename = enclosureUrl.lastPathComponent;
 	if (basename==nil)
 	{
 		return;

--- a/Vienna/Sources/Models/Article.m
+++ b/Vienna/Sources/Models/Article.m
@@ -313,7 +313,7 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
  */
 -(NSString *)tagArticleLink
 {
-    return cleanedUpUrlFromString(self.link).absoluteString;
+    return [NSString stringByCleaningURLString:self.link];
 }
 
 /* tagArticleTitle
@@ -362,7 +362,7 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
  */
 -(NSString *)tagArticleEnclosureLink
 {
-    return cleanedUpUrlFromString(self.enclosure).absoluteString;
+    return [NSString stringByCleaningURLString:self.enclosure];
 }
 
 /* tagArticleEnclosureFilename
@@ -388,7 +388,7 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
 -(NSString *)tagFeedLink
 {
     Folder * folder = [[Database sharedManager] folderFromID:self.folderId];
-    return cleanedUpUrlFromString(folder.homePage).absoluteString;
+    return [NSString stringByCleaningURLString:folder.homePage];
 }
 
 /* tagFeedDescription

--- a/Vienna/Sources/Plug-ins/SearchMethod.m
+++ b/Vienna/Sources/Plug-ins/SearchMethod.m
@@ -121,7 +121,7 @@
 {
 	NSURL * queryURL;
 	NSString * temp = [self.searchQueryString stringByReplacingOccurrencesOfString:@"$SearchTerm$" withString:searchString];
-	queryURL = cleanedUpUrlFromString(temp);
+	queryURL = urlFromUserString(temp);
     return queryURL;
 }
 

--- a/Vienna/Sources/Shared/HelperFunctions.h
+++ b/Vienna/Sources/Shared/HelperFunctions.h
@@ -43,6 +43,7 @@ void runOKAlertPanel(NSString * titleString, NSString * bodyText, ...);
 void runOKAlertSheet(NSString * titleString, NSString * bodyText, ...);
 NSMenuItem * menuItemWithAction(SEL theSelector);
 NSString * getDefaultBrowser(void);
-NSURL * cleanedUpUrlFromString(NSString * theUrl);
+NSURL *_Nullable cleanedUpUrlFromString(NSString *_Nullable theUrl);
+NSURL *_Nullable urlFromUserString(NSString *_Nullable theUrl);
 BOOL hasOSScriptsMenu(void);
 NSString * percentEscape(NSString *string);

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -18,6 +18,7 @@
 // 
 
 #import "HelperFunctions.h"
+#import "StringExtensions.h"
 
 /* hasOSScriptsMenu
  * Determines whether the OS script menu is present or not.
@@ -84,23 +85,12 @@ NSString * percentEscape(NSString *string)
  * Uses WebKit to clean up user-entered URLs that might contain umlauts, diacritics and other
  * IDNA related stuff in the domain, or God knows what in filenames and arguments.
  */
-NSURL * cleanedUpUrlFromString(NSString * theUrl)
+NSURL *_Nullable cleanedUpUrlFromString(NSString * theUrl)
 {
     NSURL *urlToLoad = nil;
-    if (theUrl != nil) {
-        NSPasteboard * pasteboard = [NSPasteboard pasteboardWithUniqueName];
-        [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-        @try
-        {
-            if ([pasteboard setString:theUrl forType:NSPasteboardTypeString]) {
-                urlToLoad = [WebView URLFromPasteboard:pasteboard];
-            }
-        }
-        @catch (NSException * exception)
-        {
-            urlToLoad = nil;
-        }
-        [pasteboard releaseGlobally];
+    NSString *cleanedUpURLString = [NSString stringByCleaningURLString:theUrl];
+    if (![cleanedUpURLString isEqualToString:@""]) {
+        urlToLoad = [[NSURL alloc] initWithString:cleanedUpURLString];
     }
     return urlToLoad;
 }

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -18,7 +18,6 @@
 // 
 
 #import "HelperFunctions.h"
-#import "StringExtensions.h"
 
 /* hasOSScriptsMenu
  * Determines whether the OS script menu is present or not.
@@ -83,16 +82,12 @@ NSString * percentEscape(NSString *string)
 
 /* cleanedUpUrlFromString
  * Uses WebKit to clean up user-entered URLs that might contain umlauts, diacritics and other
- * IDNA related stuff in the domain, or God knows what in filenames and arguments.
+ * IDNA related stuff in the domain, or whatever may hide in filenames and arguments.
+ * See also stringByCleaningURLString in StringExtensions
  */
-NSURL *_Nullable cleanedUpUrlFromString(NSString * theUrl)
+NSURL *_Nullable cleanedUpUrlFromString(NSString *_Nullable theUrl)
 {
-    NSURL *urlToLoad = nil;
-    NSString *cleanedUpURLString = [NSString stringByCleaningURLString:theUrl];
-    if (![cleanedUpURLString isEqualToString:@""]) {
-        urlToLoad = [[NSURL alloc] initWithString:cleanedUpURLString];
-    }
-    return urlToLoad;
+    return theUrl ? [NSURLComponents componentsWithString:theUrl].URL : nil;
 }
 
 /* loadMapFromPath

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -80,14 +80,38 @@ NSString * percentEscape(NSString *string)
 	    @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"]];
 }
 
-/* cleanedUpUrlFromString
- * Uses WebKit to clean up user-entered URLs that might contain umlauts, diacritics and other
- * IDNA related stuff in the domain, or whatever may hide in filenames and arguments.
+/*
+ * does a minimum of cleaning on a url string and convert it to NSURL
  * See also stringByCleaningURLString in StringExtensions
  */
 NSURL *_Nullable cleanedUpUrlFromString(NSString *_Nullable theUrl)
 {
     return theUrl ? [NSURLComponents componentsWithString:theUrl].URL : nil;
+}
+
+/* urlFromUserString
+ * Uses WebKit to clean up user-entered URLs that might contain umlauts, diacritics and other
+ * IDNA related stuff in the domain, or whatever may hide in filenames and arguments.
+ */
+NSURL *_Nullable urlFromUserString(NSString *_Nullable theUrl)
+{
+    NSURL *urlToLoad = nil;
+    if (theUrl != nil) {
+        NSPasteboard * pasteboard = [NSPasteboard pasteboardWithUniqueName];
+        [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
+        @try
+        {
+            if ([pasteboard setString:theUrl forType:NSPasteboardTypeString]) {
+                urlToLoad = [WebView URLFromPasteboard:pasteboard];
+            }
+        }
+        @catch (NSException * exception)
+        {
+            urlToLoad = nil;
+        }
+        [pasteboard releaseGlobally];
+    }
+    return urlToLoad;
 }
 
 /* loadMapFromPath

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -728,15 +728,9 @@ static NSMutableDictionary * entityMap = nil;
  *   User-entered URLs might contain umlauts, diacritics and other
  *   IDNA related stuff in the domain, or God knows what in filenames and arguments.
  */
-+(NSString * )stringByCleaningURLString:(NSString *) urlString
++(NSString *_Nonnull)stringByCleaningURLString:(NSString *_Nullable)urlString
 {
-    NSString * newString;
-    if (urlString == nil) {
-        newString = @"";
-    } else {
-        newString = [NSURLComponents componentsWithString:urlString].string;
-    }
-    return newString;
+    return urlString ? [NSURLComponents componentsWithString:urlString].string : @"";
 }
 
 + (NSString *)toBase64String:(NSString *)string {

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -725,8 +725,6 @@ static NSMutableDictionary * entityMap = nil;
  * Percent escape invalid and reserved URL characters and return a legal URL string.
  *   Should handle unescaped or partially escaped URL strings where sequences are unpredictable,
  *   for instance will preserve # announcing fragment from being escaped.
- *   User-entered URLs might contain umlauts, diacritics and other
- *   IDNA related stuff in the domain, or God knows what in filenames and arguments.
  */
 +(NSString *_Nonnull)stringByCleaningURLString:(NSString *_Nullable)urlString
 {


### PR DESCRIPTION
In addition to @barijaona s changes to the way URLs are cleaned in stringByCleaningURLString, this syncs the way cleanedUpURLFromString works. Previously, both methods used the pasteboard and WebView to clean the URL. Since we deemed the way NSURLComponents works suitable for one method, I rewrote the other method that shared the exact same implementation prior to the refactoring. Now it calls the stringByCleaningURLString method to avoid a duplicate implementation.