### PR TITLE
Update README.md with correct information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![Build Status](https://travis-ci.org/ViennaRSS/vienna-rss.svg?branch=master)](https://travis-ci.org/ViennaRSS/vienna-rss)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/vienna-rss/localized.svg)](https://crowdin.com/project/vienna-rss)
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/ViennaRSS/Lobby)
 
-[Vienna](http://www.vienna-rss.com) is an RSS/Atom reader for macOS.
+[Vienna](https://www.vienna-rss.com) is an RSS/Atom reader for macOS.
 
 Vienna can connect directly to the websites you want to track.
 Additionally or alternatively, you can also sync with a server supporting the [Open Reader API](http://rss-sync.github.io/Open-Reader-API/rssconsensus/) (an adaptation of the now deceased Google Reader API). Vienna has been successfully tested with BazQux.com, FreshRSS.org, FeedHQ.org, InoReader.com and TheOldReader.com.
@@ -13,8 +12,9 @@ Additionally or alternatively, you can also sync with a server supporting the [O
 Compatibility
 -------------
 
-Since version 3.2, Vienna requires a minimum of OS X 10.9 (Mavericks). Future versions of Vienna may require OS&nbsp;X 10.11 (El Capitan) or newer. 
+Since version 3.6, Vienna requires a minimum of macOS 10.11 (El Capitan).
 
+Vienna 3.5.x requires a minimum of macOS 10.9 (Mavericks)
 Vienna 3.1.x requires a minimum of OS X 10.8 (Mountain Lion).
 Vienna 3.0.x requires a minimum of OS X 10.6 (Snow Leopard).
 
@@ -35,7 +35,7 @@ brew cask install vienna
 Getting support
 ---------------
 
-If the in-application help files and the [FAQs](http://www.vienna-rss.com/?page_id=96) don’t answer your questions, head over to our [Support forum](https://forums.cocoaforge.com/viewforum.php?f=18) which is hosted by Cocoaforge.
+If the in-application help files and the [FAQs](https://www.vienna-rss.com/faq.html) don’t answer your questions, head over to our [Support forum](https://forums.cocoaforge.com/viewforum.php?f=18) which is hosted by Cocoaforge.
 
 Reporting an issue
 ------------------
@@ -63,13 +63,13 @@ We need help keeping Vienna translations up to date into different languages. Yo
 
 Vienna supports a variety of different display styles for articles. These styles are provided on the Styles sub-menu off the View menu. A style is a combination of an HTML template that is used to control the placement of various parts of the article and a CSS stylesheet that controls the appearance of the article.
 
-You can write styles by referring to [this document](http://www.vienna-rss.com/?page_id=65). Have a look at existing styles in the __Styles__ folder.
+You can write styles by referring to [this document](https://www.vienna-rss.com/extras/creating-custom-styles/). Have a look at existing styles in the __Styles__ folder.
 
 ### Writing plugins
 
 Vienna supports plugins which are installed in menus and/or on the toolbar and can run defined actions. These plugins are XML-based and can be created by editing a simple .plist-file without any knowledge of Cocoa programming, in as little as 15 minutes.
 
-You can write plugins by referring to [this document](http://www.vienna-rss.com/?page_id=120). Have a look at existing plugins in the __Plugins__ folder.
+You can write plugins by referring to [this document](https://www.vienna-rss.com/development/creating-plugins-for-vienna-2-5/). Have a look at existing plugins in the __Plugins__ folder.
 
 Licensing
 ---------


### PR DESCRIPTION
- Remove old gitter link
- Update text about minimum supported versions of macOS & OS X
- Update Vienna website links to point to the locations on the new website