### PR TITLE
Add a fallback if string to URL conversion fails

### DIFF
--- a/Vienna Tests/models/ArticleTests.m
+++ b/Vienna Tests/models/ArticleTests.m
@@ -7,6 +7,7 @@
 
 #import <XCTest/XCTest.h>
 #import "Article.h"
+#import "ArticleView.h"
 
 static NSString * const GUID = @"07f446d2-8d6b-4d99-b488-cebc9eac7c33";
 static NSString * const Author = @"Author McAuthorface";
@@ -346,6 +347,20 @@ static NSString * const Body =
     NSString *expandedString = [self.article expandTags:string withConditional:YES];
 
     XCTAssertEqualObjects(expandedString, expectedString);
+}
+
+- (void)testURLIDNinArticleView
+{
+    ArticleView * view = [[ArticleView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)];
+
+    self.article.link = @"http://ουτοπία.δπθ.gr/نجيب_محفوظ/";
+    NSString * htmlText = [view articleTextFromArray:@[self.article]];
+    [view setHTML:htmlText];
+
+    self.article.link = @"http://xn--kxae4bafwg.xn--pxaix.gr/%D9%86%D8%AC%D9%8A%D8%A8_%D9%85%D8%AD%D9%81%D9%88%D8%B8/";
+    NSString * htmlText2 = [view articleTextFromArray:@[self.article]];
+
+    XCTAssertEqualObjects(htmlText, htmlText2);
 }
 
 @end

--- a/Vienna Tests/models/ArticleTests.m
+++ b/Vienna Tests/models/ArticleTests.m
@@ -277,9 +277,9 @@ static NSString * const Body =
 
 - (void)testExpandLinkTag
 {
-    NSString *string = @"$ArticleLink$";
+    NSString *string = @"$ArticleLink$/development";
 
-    NSString *expectedString = [NSString stringWithFormat:@"%@/", Link];
+    NSString *expectedString = [NSString stringWithFormat:@"%@/development", Link];
 
     self.article.link = Link;
 

--- a/Vienna Tests/models/ArticleTests.m
+++ b/Vienna Tests/models/ArticleTests.m
@@ -354,13 +354,13 @@ static NSString * const Body =
     ArticleView * view = [[ArticleView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)];
 
     self.article.link = @"http://ουτοπία.δπθ.gr/نجيب_محفوظ/";
-    NSString * htmlText = [view articleTextFromArray:@[self.article]];
-    [view setHTML:htmlText];
+    NSString * htmlTextFromIDNALink = [view articleTextFromArray:@[self.article]];
+    [view setHTML:htmlTextFromIDNALink];
 
     self.article.link = @"http://xn--kxae4bafwg.xn--pxaix.gr/%D9%86%D8%AC%D9%8A%D8%A8_%D9%85%D8%AD%D9%81%D9%88%D8%B8/";
-    NSString * htmlText2 = [view articleTextFromArray:@[self.article]];
+    NSString * htmlTextFromResolvedIDNALink = [view articleTextFromArray:@[self.article]];
 
-    XCTAssertEqualObjects(htmlText, htmlText2);
+    XCTAssertEqualObjects(htmlTextFromIDNALink, htmlTextFromResolvedIDNALink);
 }
 
 @end

--- a/Vienna/Sources/Shared/HelperFunctions.h
+++ b/Vienna/Sources/Shared/HelperFunctions.h
@@ -43,6 +43,7 @@ void runOKAlertPanel(NSString * titleString, NSString * bodyText, ...);
 void runOKAlertSheet(NSString * titleString, NSString * bodyText, ...);
 NSMenuItem * menuItemWithAction(SEL theSelector);
 NSString * getDefaultBrowser(void);
-NSURL * cleanedUpUrlFromString(NSString * theUrl);
+NSURL *_Nullable cleanedUpUrlFromString(NSString *_Nullable urlString);
+NSURL *_Nullable urlFromUserString(NSString *_Nonnull urlString);
 BOOL hasOSScriptsMenu(void);
 NSString * percentEscape(NSString *string);

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -18,6 +18,7 @@
 // 
 
 #import "HelperFunctions.h"
+#import "StringExtensions.h"
 
 /* hasOSScriptsMenu
  * Determines whether the OS script menu is present or not.
@@ -84,29 +85,34 @@ NSString * percentEscape(NSString *string)
  * Uses WebKit to clean up user-entered URLs that might contain umlauts, diacritics and other
  * IDNA related stuff in the domain, or God knows what in filenames and arguments.
  */
-NSURL *_Nullable cleanedUpUrlFromString(NSString * theUrl)
+NSURL *_Nullable cleanedUpUrlFromString(NSString * urlString)
 {
     NSURL *urlToLoad;
-    if (theUrl == nil) {
+    if (urlString == nil) {
         urlToLoad = nil;
     } else {
-        // Try simple conversion first
-        urlToLoad = [NSURLComponents componentsWithString:theUrl].URL;
-        if (!urlToLoad) {
-            // Fallback : use WebKit to clean up user-entered URLs that might contain umlauts, diacritics
-            // and other IDNA related stuff in the domain, or whatever may hide in filenames and arguments
-            NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
-            [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-            @try
-            {
-                if ([pasteboard setString:theUrl forType:NSPasteboardTypeString]) {
-                    urlToLoad = [WebView URLFromPasteboard:pasteboard];
-                }
-            } @catch (NSException *exception)   {
-                urlToLoad = nil;
+        urlToLoad = urlFromUserString(urlString);
+    }
+    return urlToLoad;
+}
+
+NSURL *_Nullable urlFromUserString(NSString *_Nonnull urlString) {
+    // Try simple conversion first
+    NSURL *urlToLoad = [NSURLComponents componentsWithString:urlString].URL;
+    if (urlToLoad == nil) {
+        // Fallback : use WebKit to clean up user-entered URLs that might contain umlauts, diacritics
+        // and other IDNA related stuff in the domain, or whatever may hide in filenames and arguments
+        NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
+        [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
+        @try
+        {
+            if ([pasteboard setString:urlString forType:NSPasteboardTypeString]) {
+                urlToLoad = [WebView URLFromPasteboard:pasteboard];
             }
-            [pasteboard releaseGlobally];
+        } @catch (NSException *exception)   {
+            NSLog(@"Failed to convert URL for string %@", urlString);
         }
+        [pasteboard releaseGlobally];
     }
     return urlToLoad;
 }

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -104,12 +104,11 @@ NSURL *_Nullable urlFromUserString(NSString *_Nonnull urlString) {
         // and other IDNA related stuff in the domain, or whatever may hide in filenames and arguments
         NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
         [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-        @try
-        {
+        @try {
             if ([pasteboard setString:urlString forType:NSPasteboardTypeString]) {
                 urlToLoad = [WebView URLFromPasteboard:pasteboard];
             }
-        } @catch (NSException *exception)   {
+        } @catch (NSException *exception) {
             NSLog(@"Failed to convert URL for string %@", urlString);
         }
         [pasteboard releaseGlobally];

--- a/Vienna/Sources/Shared/StringExtensions.h
+++ b/Vienna/Sources/Shared/StringExtensions.h
@@ -36,7 +36,7 @@
     +(NSString *)stringByConvertingHTMLEntities:(NSString *)stringToProcess;
     +(NSString *)toBase64String:(NSString *)stringToProcess;
     +(NSString *)fromBase64String:(NSString *)stringToProcess;
-    +(NSString * )stringByCleaningURLString:(NSString *) urlString;
+    +(NSString *_Nonnull)stringByCleaningURLString:(NSString *_Nullable) urlString;
 	@property (nonatomic, readonly, copy) NSString *firstNonBlankLine;
 	@property (nonatomic, readonly, copy) NSString *summaryTextFromHTML;
 	@property (nonatomic, readonly, copy) NSString *titleTextFromHTML;

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -19,6 +19,7 @@
 //
 
 #import "StringExtensions.h"
+#import "HelperFunctions.h"
 
 @implementation NSMutableString (MutableStringExtensions)
 
@@ -728,30 +729,17 @@ static NSMutableDictionary * entityMap = nil;
  *   User-entered URLs might contain umlauts, diacritics and other
  *   IDNA related stuff in the domain, or God knows what in filenames and arguments.
  */
-+(NSString * )stringByCleaningURLString:(NSString *) urlString
++(NSString *_Nonnull)stringByCleaningURLString:(NSString *_Nullable) urlString
 {
     NSString * newString;
     if (urlString == nil) {
         newString = @"";
     } else {
-        // Try simple conversion first
-        NSURL *urlToLoad = [NSURLComponents componentsWithString:urlString].URL;
-        if (urlToLoad) {
-            newString = urlToLoad.absoluteString;
+        NSURL *url = urlFromUserString(urlString);
+        if (url != nil) {
+            newString = url.absoluteString;
         } else {
-            // Fallback : use WebKit to clean up user-entered URLs that might contain umlauts, diacritics
-            // and other IDNA related stuff in the domain, or whatever may hide in filenames and arguments
-            NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
-            [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-            @try
-            {
-                if ([pasteboard setString:urlString forType:NSPasteboardTypeString]) {
-                    newString = [WebView URLFromPasteboard:pasteboard].absoluteString;
-                }
-            } @catch (NSException *exception)   {
-                newString = @"";
-            }
-            [pasteboard releaseGlobally];
+            newString = @"";
         }
     }
     return newString;

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -734,7 +734,25 @@ static NSMutableDictionary * entityMap = nil;
     if (urlString == nil) {
         newString = @"";
     } else {
-        newString = [NSURLComponents componentsWithString:urlString].string;
+        // Try simple conversion first
+        NSURL *urlToLoad = [NSURLComponents componentsWithString:urlString].URL;
+        if (urlToLoad) {
+            newString = urlToLoad.absoluteString;
+        } else {
+            // Fallback : use WebKit to clean up user-entered URLs that might contain umlauts, diacritics
+            // and other IDNA related stuff in the domain, or whatever may hide in filenames and arguments
+            NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
+            [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
+            @try
+            {
+                if ([pasteboard setString:urlString forType:NSPasteboardTypeString]) {
+                    newString = [WebView URLFromPasteboard:pasteboard].absoluteString;
+                }
+            } @catch (NSException *exception)   {
+                newString = @"";
+            }
+            [pasteboard releaseGlobally];
+        }
     }
     return newString;
 }


### PR DESCRIPTION
Temporary solution for discussion at #1341
Fix crash https://forums.cocoaforge.com/viewtopic.php?f=18&t=27220#p140913

We use the old WebKit hack as a fallback for converting string to URL if
our simple attempt fails. Also sync cleanedUpURLFromString method with
stringByCleaningUpURLString.