### PR TITLE
Update stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,30 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 366
+
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 30
+
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: "stale ⏳"
+
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+
+only: issues


### PR DESCRIPTION
- Changes the stale label from `wontfix` to `stale ⏳`
- Allows stale bot to only mark issues, not pull requests
- Adds exemptions for issues linked to projects and milestones

The label “stale” is more to the point. “wontfix” can imply a deliberate decision not to address/change the issue. 
 The label has [already been used](https://github.com/ViennaRSS/vienna-rss/issues?q=label%3A%22won%27t+fix+%3A-1%3A%22+is%3Aclosed) for this purpose.

I also think it should not apply to pull requests or issues that have been linked to projects and milestones, since these have perhaps already been worked on or are deemed important enough to address while working on other changes.