### PR TITLE
Small documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Compatibility
 
 Since version 3.6, Vienna requires a minimum of macOS 10.11 (El Capitan).
 
-Vienna 3.5.x requires a minimum of macOS 10.9 (Mavericks)
-Vienna 3.1.x requires a minimum of OS X 10.8 (Mountain Lion).
+Vienna 3.5.x requires a minimum of macOS 10.9 (Mavericks).  
+Vienna 3.1.x requires a minimum of OS X 10.8 (Mountain Lion).  
 Vienna 3.0.x requires a minimum of OS X 10.6 (Snow Leopard).
 
 

--- a/Release Instructions.md
+++ b/Release Instructions.md
@@ -86,6 +86,7 @@ There are two distinct ways to get the different files needed to publish an upda
 
 ### Building through the command line
 
+- If you have multiple versions of Xcode installed on your machine, ensure that an adequate version is selected. For instance, you might have to type `sudo xcode-select --switch /Applications/Xcode-beta.app` at the command line
 - At the command line, run `make release`
 - You will have enough time to take a tea, walk the dog or read your mails…
 - At the end of the process, the Uploads window should open in the Finder,


### PR DESCRIPTION
Add info about xcode-select in release instructions : 
I had to use Xcode 12.2 release candidate to welcome the first machines
running on Apple M1 processors, as this version of Xcode was the first
official one coming with macOS 11 SDK

Fix punctuation in README