### PR TITLE
Update GitHub action for Xcode 12.2

### DIFF
--- a/.github/workflows/Vienna.yml
+++ b/.github/workflows/Vienna.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: macos-11.0
 
     steps:
+    - name: Use Xcode 12
+      run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
     - name: Install SwiftLint
       run: brew install swiftlint
     - name: Set up Git repository


### PR DESCRIPTION
GitHub still defaults to Xcode 11 on 11.0 Big Sur.

See: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md