### PR TITLE
Modify code to allow user to change the Vienna user agent name using defaults write

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -89,7 +89,10 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         } else {
             osVersion = @"10_9_x";
         }
-        NSString * userAgent = [NSString stringWithFormat:MA_DefaultUserAgentString, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], osVersion];
+        Preferences * prefs = [Preferences standardPreferences];
+        NSString *name = prefs.userAgentName;
+
+        NSString * userAgent = [NSString stringWithFormat:MA_DefaultUserAgentString, name, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], osVersion];
         NSURLSessionConfiguration * config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.timeoutIntervalForRequest = 180;
         config.URLCache = nil;

--- a/Vienna/Sources/Main window/TabbedWebView.m
+++ b/Vienna/Sources/Main window/TabbedWebView.m
@@ -57,8 +57,11 @@ static NSString * _userAgent ;
         if (!shortSafariVersion) {
             shortSafariVersion = @"6.0";
         }
+        Preferences * prefs = [Preferences standardPreferences];
+        NSString *name = prefs.userAgentName;
+
         _userAgent =
-            [NSString stringWithFormat:MA_BrowserUserAgentString, osVersion, webkitVersion, shortSafariVersion,
+            [NSString stringWithFormat:MA_BrowserUserAgentString, osVersion, webkitVersion, shortSafariVersion, name,
              ((ViennaApp *)NSApp).applicationVersion.firstWord];
     }
     return _userAgent;

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -67,6 +67,7 @@
 	NSUInteger concurrentDownloads;
 	NSString * syncServer;
 	NSString * syncingUser;
+    NSString * userAgentName;
 }
 
 // String constants for NSNotificationCenter
@@ -201,6 +202,9 @@ extern NSString * const kMA_Notify_UseWebPluginsChange;
 
 // Do we show updated articles as new ?
 @property (nonatomic) BOOL markUpdatedAsNew;
+
+// User Agent Name
+@property (nonatomic) NSString *userAgentName;
 
 #pragma mark -
 #pragma mark Open Reader syncing

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -186,6 +186,7 @@ static Preferences * _standardPreferences = nil;
 		shouldSaveFeedSource = [self boolForKey:MAPref_ShouldSaveFeedSource];
 		searchMethod = [NSKeyedUnarchiver unarchiveObjectWithData:[userPrefs objectForKey:MAPref_SearchMethod]];
 		concurrentDownloads = [self integerForKey:MAPref_ConcurrentDownloads];
+        userAgentName = [self stringForKey:MAPref_UserAgentName];
         
         // Open Reader sync
         syncGoogleReader = [self boolForKey:MAPref_SyncGoogleReader];
@@ -289,7 +290,8 @@ static Preferences * _standardPreferences = nil;
     defaultValues[MAPref_SyncingAppId] = @"1000001359";
     defaultValues[MAPref_SyncingAppKey] = @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn";
     defaultValues[MAPref_AlwaysAcceptBetas] = boolNo;
-	
+    defaultValues[MAPref_UserAgentName] = @"Vienna";
+
 	return [defaultValues copy];
 }
 
@@ -836,6 +838,16 @@ static Preferences * _standardPreferences = nil;
 -(BOOL)markUpdatedAsNew
 {
 	return markUpdatedAsNew;
+}
+
+/* userAgentName
+ * Returns the apps user agent name.
+ * If not overridden by setting a user default preference it returns 'Vienna'.
+ * Value is cached and there is no change notification if the value changes while the app is running.
+ */
+-(NSString *)userAgentName
+{
+    return userAgentName;
 }
 
 /* setMarkUpdatedAsNew

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -82,6 +82,7 @@ extern NSString * MAPref_SyncingAppId;
 extern NSString * MAPref_SyncingAppKey;
 extern NSString * MAPref_SendSystemProfileInfo;
 extern NSString * MAPref_AlwaysAcceptBetas;
+extern NSString * MAPref_UserAgentName;
 
 extern NSInteger MA_Default_BackTrackQueueSize;
 extern NSInteger MA_Default_RefreshThreads;

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -20,8 +20,8 @@
 
 @import Foundation;
 
-NSString * MA_DefaultUserAgentString = @"Vienna/%@ (Macintosh; Intel macOS %@)";
-NSString * MA_BrowserUserAgentString = @"(Macintosh; Intel Mac OS X %@) AppleWebKit/%@ (KHTML, like Gecko) Version/%@ Safari/604.1.38 Vienna/%@";
+NSString * MA_DefaultUserAgentString = @"%@/%@ (Macintosh; Intel macOS %@)";
+NSString * MA_BrowserUserAgentString = @"(Macintosh; Intel Mac OS X %@) AppleWebKit/%@ (KHTML, like Gecko) Version/%@ Safari/604.1.38 %@/%@";
 
 NSString * MAPref_ArticleListFont = @"MessageListFont";
 NSString * MAPref_AutoSortFoldersTree = @"AutomaticallySortFoldersTree";
@@ -81,6 +81,7 @@ NSString * MAPref_SyncingAppId = @"SyncingAppId";
 NSString * MAPref_SyncingAppKey = @"SyncingAppKey";
 NSString * MAPref_SendSystemProfileInfo = @"SUSendProfileInfo";
 NSString * MAPref_AlwaysAcceptBetas = @"AlwayAcceptBetas";
+NSString * MAPref_UserAgentName = @"UserAgentName";
 
 const NSInteger MA_Default_BackTrackQueueSize = 20;
 const NSInteger MA_Default_RefreshThreads = 20;


### PR DESCRIPTION
If the user executes:

    defaults write uk.co.opencommunity.vienna2 UserAgentName Bern

The user agent name reported by Vienna will change from `Vienna` to `Bern` after Vienna is restarted.

This pull request allows the user to fix bug #1357, if needed.

The docs (CONTRIBUTING.md -> Spotify Objective-C Coding Style) say to use 4 spaces for indentation, but in `Preferences.h` the surrounding code uses tabs. I opted to follow the docs, but in retrospect that may not have been the best decision because it looks funky.

If you have any problems with this pull request let me know and I'll redo it.

Thanks,
Neil

Edited to note that the change in user agent name only becomes active after a restart.