### PR TITLE
Remove carthage reference from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ clean:
 	xcodebuild -project $(PROJECT) -scheme "Vienna" -configuration Development clean
 	xcodebuild -project $(PROJECT) -scheme "Vienna" -configuration Deployment clean
 	rm -fr build
-	rm -fr Carthage/Build
 
 localize:
 	for locale in $(LOCALES); do \


### PR DESCRIPTION
Remove the step to clean the carthage build folder now we no longer use carthage.