### PR TITLE
Resolve build warnings

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 		3A5482F7168F5F4800887F91 /* Sparkle-setup.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Sparkle-setup.sh"; sourceTree = "<group>"; };
 		3A60E6092114AD740004D81D /* URLRequestExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = URLRequestExtensions.h; sourceTree = "<group>"; };
 		3A60E60A2114AD740004D81D /* URLRequestExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = URLRequestExtensions.m; sourceTree = "<group>"; };
-		3A6CC18623BBA49D0084ABEE /* CS-ID.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "CS-ID.xcconfig"; path = "Scripts/Resources/CS-ID.xcconfig"; sourceTree = SOURCE_ROOT; };
+		3A6CC18623BBA49D0084ABEE /* Codesigning.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Codesigning.xcconfig; sourceTree = "<group>"; };
 		3A7BD0DB1989AC7700E9444B /* VNAVerticallyCenteredTextFieldCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VNAVerticallyCenteredTextFieldCell.h; sourceTree = "<group>"; };
 		3A7BD0DC1989AC7700E9444B /* VNAVerticallyCenteredTextFieldCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VNAVerticallyCenteredTextFieldCell.m; sourceTree = "<group>"; };
 		3A932D8823BB999A009B8061 /* Vienna.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Vienna.entitlements; sourceTree = "<group>"; };
@@ -1092,7 +1092,6 @@
 				F62580A81E286A8B0035E43C /* Localizable.strings */,
 				F6FEE7AF209E500800BCAEC6 /* Localizable.stringsdict */,
 				3AEE7DE81695FC570018A17D /* vienna_public_key.pem */,
-				3A6CC18623BBA49D0084ABEE /* CS-ID.xcconfig */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1241,6 +1240,7 @@
 				430C4AE0166175C20079C9FC /* Info.plist */,
 				3A932D8823BB999A009B8061 /* Vienna.entitlements */,
 				3A932D8923BB999A009B8061 /* ViennaDeployment.entitlements */,
+				3A6CC18623BBA49D0084ABEE /* Codesigning.xcconfig */,
 			);
 			path = Vienna;
 			sourceTree = "<group>";
@@ -2701,7 +2701,7 @@
 		};
 		3AE9F73923CB80C900DC6D8A /* Deployment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3A6CC18623BBA49D0084ABEE /* CS-ID.xcconfig */;
+			baseConfigurationReference = 3A6CC18623BBA49D0084ABEE /* Codesigning.xcconfig */;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -2763,7 +2763,7 @@
 		};
 		AA4F9AB40855422400C18279 /* Deployment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3A6CC18623BBA49D0084ABEE /* CS-ID.xcconfig */;
+			baseConfigurationReference = 3A6CC18623BBA49D0084ABEE /* Codesigning.xcconfig */;
 			buildSettings = {
 				APPLY_RULES_IN_COPY_FILES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -2905,7 +2905,7 @@
 		};
 		EAAF335B14BDE402002A8837 /* Deployment */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3A6CC18623BBA49D0084ABEE /* CS-ID.xcconfig */;
+			baseConfigurationReference = 3A6CC18623BBA49D0084ABEE /* Codesigning.xcconfig */;
 			buildSettings = {
 				PRODUCT_NAME = "Archive and Prep for Upload";
 			};

--- a/Vienna/Codesigning.xcconfig
+++ b/Vienna/Codesigning.xcconfig
@@ -1,0 +1,7 @@
+//
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+//
+
+// This file has to be created manually, per release instructions.
+#include? "../Scripts/Resources/CS-ID.xcconfig"

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -67,7 +67,6 @@
 	NSUInteger concurrentDownloads;
 	NSString * syncServer;
 	NSString * syncingUser;
-    NSString * userAgentName;
 }
 
 // String constants for NSNotificationCenter

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -186,7 +186,7 @@ static Preferences * _standardPreferences = nil;
 		shouldSaveFeedSource = [self boolForKey:MAPref_ShouldSaveFeedSource];
 		searchMethod = [NSKeyedUnarchiver unarchiveObjectWithData:[userPrefs objectForKey:MAPref_SearchMethod]];
 		concurrentDownloads = [self integerForKey:MAPref_ConcurrentDownloads];
-        userAgentName = [self stringForKey:MAPref_UserAgentName];
+        _userAgentName = [self stringForKey:MAPref_UserAgentName];
         
         // Open Reader sync
         syncGoogleReader = [self boolForKey:MAPref_SyncGoogleReader];
@@ -838,16 +838,6 @@ static Preferences * _standardPreferences = nil;
 -(BOOL)markUpdatedAsNew
 {
 	return markUpdatedAsNew;
-}
-
-/* userAgentName
- * Returns the apps user agent name.
- * If not overridden by setting a user default preference it returns 'Vienna'.
- * Value is cached and there is no change notification if the value changes while the app is running.
- */
--(NSString *)userAgentName
-{
-    return userAgentName;
 }
 
 /* setMarkUpdatedAsNew


### PR DESCRIPTION
The warning was caused by commit aac54b4, because the `userAgentName` variable was not synthesized. Fixed by using an implicit instance variable and getter method.