### PR TITLE
Limit requests to unresponding websites

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -94,7 +94,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
         NSString * userAgent = [NSString stringWithFormat:MA_DefaultUserAgentString, name, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], osVersion];
         NSURLSessionConfiguration * config = [NSURLSessionConfiguration defaultSessionConfiguration];
-        config.timeoutIntervalForRequest = 180;
+        config.timeoutIntervalForResource = 300;
         config.URLCache = nil;
         config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent};
         config.HTTPMaximumConnectionsPerHost = 6;


### PR DESCRIPTION
As default value of timeoutIntervalForResource is 7 days, a background
task would try contacting/waiting unresponding website for a long time
without calling back its delegate (issue #1380)

tiemeoutIntervalForRequest is deprecated. The default 60 seconds value
seems fine (the associated timer is reset whenever new data arrives).