### PR TITLE
Fix URLSession authentication challenge

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.h
+++ b/Vienna/Sources/Fetching/RefreshManager.h
@@ -24,7 +24,7 @@
 @class FeedCredentials;
 @class Folder;
 
-@interface RefreshManager : NSObject <NSURLSessionDelegate> {
+@interface RefreshManager : NSObject <NSURLSessionTaskDelegate> {
 	NSUInteger countOfNewArticles;
 	NSMutableArray * authQueue;
 	FeedCredentials * credentialsController;

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -1191,16 +1191,11 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
 #pragma mark NSURLSession Authentication delegates
 
--(void)URLSession:(NSURLSession *)session
-    task:(NSURLSessionTask *)task
-    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-    completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *_Nullable))completionHandler
 {
-    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
-        NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
-        completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
-    }
-
     if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] ||
         [challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPDigest])
     {
@@ -1226,6 +1221,8 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
                 [self getCredentialsForFolder];
             }
         }
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
 } // URLSession
 


### PR DESCRIPTION
Resolves #1380

I believe the problem was that the method provided no fallback handling for authentication challenges, i.e. other than server trust and HTTP authentication handling. There was also no return statement after a handler was called, e.g. after server trust handling.

This will add a default handler to catch those cases and also removes the explicit handling of server trust challenges that Vienna did not do anything particular with.