### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Alternatively, you can download releases from the [GitHub Releases page](https:/
 
 Vienna is also available as a Cask for [Homebrew Cask](https://github.com/phinze/homebrew-cask).
 ```bash
-brew cask install vienna
+brew install --cask vienna
 ```
 
 Getting support


### PR DESCRIPTION
Fix error when installing using latest Homebrew. Just fix README.md.

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103052015-718aac80-45db-11eb-8646-33a45b091bcd.png)


