### PR TITLE
Use main operation queue for refresh's NSURLSession

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -95,7 +95,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent};
         config.HTTPMaximumConnectionsPerHost = 6;
         config.HTTPShouldUsePipelining = YES;
-        _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
+        _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:[NSOperationQueue mainQueue]];
 
         NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
         [nc addObserver:self selector:@selector(handleGotAuthenticationForFolder:) name:@"MA_Notify_GotAuthenticationForFolder" object:nil];


### PR DESCRIPTION
Fix refresh process being stuck on last remaining feed on older systems
(seen in macOS 10.11).
Reverts commit 7e70023f0cad339fa5fb82d0e0fd7f9d267c3d01
Issue #1405