### PR TITLE
Update GitHub action for Xcode 12.3

### DIFF
--- a/.github/workflows/Vienna.yml
+++ b/.github/workflows/Vienna.yml
@@ -8,12 +8,10 @@ jobs:
     runs-on: macos-11.0
 
     steps:
-    - name: Use Xcode 12
-      run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
-    - name: Install SwiftLint
-      run: brew install swiftlint
+    - name: Use Xcode 12.3
+      run: sudo xcode-select -s "/Applications/Xcode_12.3.app"
     - name: Set up Git repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Build Xcode project
       run: xcodebuild -project Vienna.xcodeproj -scheme Vienna -configuration Development build-for-testing | xcpretty && exit ${PIPESTATUS[0]}
     - name: Test Xcode project


### PR DESCRIPTION
Xcode 12.3 is installed, but not the default.

Additional changes:
 - Removes the unneeded SwiftLint installation step
 - Updates the checkout action to version 2