### PR TITLE
Swap Bintray URLs with GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Vienna 3.0.x requires a minimum of OS X 10.6 (Snow Leopard).
 Installing
 ----------
 
-Admins upload release and test versions at [Sourceforge](https://sourceforge.net/projects/vienna-rss/files/).  
-Alternatively, you can download releases from the [GitHub Releases page](https://github.com/ViennaRSS/vienna-rss/releases).
+Admins upload release and test versions at the [GitHub Releases page](https://github.com/ViennaRSS/vienna-rss/releases).  
+Alternatively, you can download releases from [Sourceforge](https://sourceforge.net/projects/vienna-rss/files/).
 
 **Homebrew**
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Vienna 3.0.x requires a minimum of OS X 10.6 (Snow Leopard).
 Installing
 ----------
 
-Admins upload release and test versions at [bintray](https://bintray.com/viennarss/vienna-rss/vienna-rss/) and [Sourceforge](https://sourceforge.net/projects/vienna-rss/files/).  
+Admins upload release and test versions at [Sourceforge](https://sourceforge.net/projects/vienna-rss/files/).  
 Alternatively, you can download releases from the [GitHub Releases page](https://github.com/ViennaRSS/vienna-rss/releases).
 
 **Homebrew**

--- a/Release Instructions.md
+++ b/Release Instructions.md
@@ -101,15 +101,17 @@ There are two distinct ways to get the different files needed to publish an upda
 ### On Github:
 
    1. Go to Vienna's releases page on Github : <https://github.com/ViennaRSS/vienna-rss/releases>
-   2. Choose "Draft a new release", type the tag name (`v/3.3.0_beta4`), a description ("Vienna 3.3.0 Beta 4"). Upload the `Vienna3.3.0_beta4.tar.gz` file.
-   3. For beta and release candidates, check the "This is a prerelease" box.
-   4. Click the "Publish" button.
-   5. Verify the uploaded file: download it, uncompress it and check that it runs OK.
+   2. Choose "Draft a new release", type the tag name (`v/3.3.0_beta4`), a description ("Vienna 3.3.0 Beta 4").
+   3. Upload the `Vienna3.3.0_beta4.tar.gz` file.
+   4. Upload also the compressed dSYM file (whose nome should be something similar to `Vienna3.3.0_beta4.5b272a6-dSYM.tar.gz`)
+   5. For beta and release candidates, check the "This is a prerelease" box.
+   6. Click the "Publish" button.
+   7. Verify the uploaded app: download it, uncompress it and check that it runs OK.
 
 ### On Sourceforge.net:
 
    12. Check that the SourceForge Downloads page for Vienna at <https://sourceforge.net/projects/vienna-rss/files/> got the new files.
-   13. For stable releases only : from the Sourceforge site, choose the ℹ️ button ("View details") of "Vienna3.3.0.tar.gz" (be careful to select the binary and not the code source file !) and set the file as default download for Mac OS X. Don't do this for beta releases!
+   13. For stable releases only : from the Sourceforge site, choose the ℹ️ button ("View details") of "Vienna3.3.0.tar.gz" (be careful to select the binary and not the code source file or the dSYM file!) and set the file as default download for Mac OS X. Don't do this for beta releases!
 
 ### On viennarss.github.io
 

--- a/Release Instructions.md
+++ b/Release Instructions.md
@@ -1,4 +1,4 @@
-Instructions for building and uploading Vienna binaries to Github, Sourceforge and Bintray.
+Instructions for building and uploading Vienna binaries to Github and Sourceforge.
 
 ## One time setup step: ##
 
@@ -105,15 +105,6 @@ There are two distinct ways to get the different files needed to publish an upda
    3. For beta and release candidates, check the "This is a prerelease" box.
    4. Click the "Publish" button.
    5. Verify the uploaded file: download it, uncompress it and check that it runs OK.
-
-### On Bintray.com:
-	
-   6. Sign in and go to <https://bintray.com/viennarss/vienna-rss/vienna-rss/view>
-   7. Choose "New version".
-   8. Fill the name ("3.3.0Beta4"), the description from the version notes, then click "Create version". Add the VCS tag (`v/3.3.0_beta4`) and update.
-   9. Check the version (at <https://bintray.com/viennarss/vienna-rss/vienna-rss/3.3.0Beta4>), click "Upload files" to go to <https://bintray.com/viennarss/vienna-rss/vienna-rss/3.3.0Beta4/upload> and upload the two .tar.gz files (whose name should be like `Vienna3.3.0_beta4.tar.gz` and `Vienna3.3.0_beta4.5b272a6-dSYM.tar.gz`).
-   10. Click "Save Changes", then click "Publish".
-   11. Go back to the files list (<https://bintray.com/viennarss/vienna-rss/vienna-rss/3.3.0Beta4/#files>), select the binary ("Vienna3.3.0_beta4.tar.gz") and choose "Show in download list" in the contextual menu.
 
 ### On Sourceforge.net:
 

--- a/Scripts/Release-for-upload.sh
+++ b/Scripts/Release-for-upload.sh
@@ -4,7 +4,9 @@
 
 # Directory created during the Changes-and-Notes.sh stage
 VIENNA_UPLOADS_DIR="${SOURCE_ROOT}/Build/Uploads"
-DOWNLOAD_BASE_URL="${BASE_URL_TYP}://${BASE_URL_LOC}"
+GITHUB_REPO="https://github.com/ViennaRSS/vienna-rss"
+GITHUB_RELEASE_URL="${GITHUB_REPO}/releases/tag/${VCS_TAG}"
+GITHUB_ASSETS_URL="${GITHUB_REPO}/releases/download/${VCS_TAG}"
 
 TGZ_FILENAME="Vienna${N_VCS_TAG}.tar.gz"
 dSYM_FILENAME="Vienna${N_VCS_TAG}.${VCS_SHORT_HASH}-dSYM"
@@ -55,9 +57,9 @@ cat > "${VIENNA_CHANGELOG}" << EOF
 		<item>
 			<title>Vienna ${V_VCS_TAG} :${VCS_SHORT_HASH}:</title>
 			<pubDate>${pubDate}</pubDate>
-			<link>${DOWNLOAD_BASE_URL}/${TGZ_FILENAME}</link>
+			<link>${GITHUB_RELEASE_URL}</link>
 			<sparkle:minimumSystemVersion>${MACOSX_DEPLOYMENT_TARGET}.0</sparkle:minimumSystemVersion>
-			<enclosure url="${DOWNLOAD_BASE_URL}/${TGZ_FILENAME}" sparkle:version="${N_VCS_NUM}" sparkle:shortVersionString="${V_VCS_TAG} :${VCS_SHORT_HASH}:" length="${TGZSIZE}" sparkle:dsaSignature="${SIGNATURE}" type="application/octet-stream"/>
+			<enclosure url="${GITHUB_ASSETS_URL}/${TGZ_FILENAME}" sparkle:version="${N_VCS_NUM}" sparkle:shortVersionString="${V_VCS_TAG} :${VCS_SHORT_HASH}:" length="${TGZSIZE}" sparkle:dsaSignature="${SIGNATURE}" type="application/octet-stream"/>
 			<sparkle:releaseNotesLink>https://viennarss.github.io/sparkle-files/noteson${N_VCS_TAG}.html</sparkle:releaseNotesLink>
 		</item>
 	</channel>

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1848,6 +1848,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3A5482F6168F5C1700887F91 /* Configure Sparkle */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2990,8 +2991,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BASE_URL_LOC = "dl.bintray.com/viennarss/vienna-rss";
-				BASE_URL_TYP = https;
 				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -3037,8 +3036,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BASE_URL_LOC = "dl.bintray.com/viennarss/vienna-rss";
-				BASE_URL_TYP = https;
 				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Bintray is discontinued as of 1 May 2021. I updated the release scripts and documentation accordingly.

Resolves #1434