### PR TITLE
Update GitHub action to use default Xcode

### DIFF
--- a/.github/workflows/Vienna.yml
+++ b/.github/workflows/Vienna.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: macos-11.0
 
     steps:
-    - name: Use Xcode 12.3
-      run: sudo xcode-select -s "/Applications/Xcode_12.3.app"
     - name: Set up Git repository
       uses: actions/checkout@v2
     - name: Build Xcode project


### PR DESCRIPTION
Currently for macos-11, default is Xcode 12.5