### PR TITLE
Use NSFileManager library paths instead of hard-coded paths

### DIFF
--- a/Vienna Tests/NSFileManager+PathsTests.swift
+++ b/Vienna Tests/NSFileManager+PathsTests.swift
@@ -1,0 +1,45 @@
+//
+//  NSFileManager+PathsTests.swift
+//  Vienna Tests
+//
+//  Copyright 2021 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+class NSFileManagerPathsTests: XCTestCase {
+
+    let homePath = NSHomeDirectory()
+    let bundleID = Bundle.main.bundleIdentifier!
+
+    func testApplicationScriptsPath() throws {
+        let result = FileManager.default.applicationScriptsDirectory
+        let fullPath = "\(homePath)/Library/Scripts/Applications/Vienna"
+        XCTAssertEqual(result.path, fullPath)
+    }
+
+    func testApplicationSupportPath() throws {
+        let result = FileManager.default.applicationSupportDirectory
+        let fullPath = "\(homePath)/Library/Application Support/Vienna"
+        XCTAssertEqual(result.path, fullPath)
+    }
+
+    func testCachesPath() throws {
+        let result = FileManager.default.cachesDirectory
+        let fullPath = "\(homePath)/Library/Caches/\(bundleID)"
+        XCTAssertEqual(result.path, fullPath)
+    }
+
+}

--- a/Vienna Tests/Vienna Tests-Bridging-Header.h
+++ b/Vienna Tests/Vienna Tests-Bridging-Header.h
@@ -7,4 +7,5 @@
 #import "Database.h"
 #import "Export.h"
 #import "FoldersTree.h"
+#import "NSFileManager+Paths.h"
 #import "SubscriptionModel.h"

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		F6D572B71E26AAA100CDA909 /* RSSFeed.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572B91E26AAA100CDA909 /* RSSFeed.xib */; };
 		F6D572BA1E26AAA900CDA909 /* SearchFolder.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6D572BC1E26AAA900CDA909 /* SearchFolder.xib */; };
 		F6EB26031E58D37100570B22 /* DirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EB26021E58D37100570B22 /* DirectoryMonitor.swift */; };
+		F6F12AFD25ABDDE3005B2DCE /* NSFileManager+Paths.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F12AFC25ABDDE3005B2DCE /* NSFileManager+Paths.m */; };
 		F6FEE7AD209E500800BCAEC6 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = F6FEE7AF209E500800BCAEC6 /* Localizable.stringsdict */; };
 /* End PBXBuildFile section */
 
@@ -950,6 +951,8 @@
 		F6DFB033209EFE8500262069 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tr; path = tr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		F6E771C3209EFD00002EC659 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = da; path = da.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		F6EB26021E58D37100570B22 /* DirectoryMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoryMonitor.swift; sourceTree = "<group>"; };
+		F6F12AFB25ABDDE3005B2DCE /* NSFileManager+Paths.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "NSFileManager+Paths.h"; sourceTree = "<group>"; };
+		F6F12AFC25ABDDE3005B2DCE /* NSFileManager+Paths.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "NSFileManager+Paths.m"; sourceTree = "<group>"; };
 		F6FB2EC7209EF1AC00521B61 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F6FB2EC8209EF22D00521B61 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F6FB2EC9209EF22E00521B61 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1614,6 +1617,8 @@
 				AAFAF3FB088056D800DAFF04 /* KeyChain.h */,
 				AAFAF3FC088056D800DAFF04 /* KeyChain.m */,
 				2FE44CAC25B7995400554E82 /* NSApplication+AppController.swift */,
+				F6F12AFB25ABDDE3005B2DCE /* NSFileManager+Paths.h */,
+				F6F12AFC25ABDDE3005B2DCE /* NSFileManager+Paths.m */,
 				3A23F13315276935008AF863 /* NSNotificationAdditions.h */,
 				4350283D165DE7F60018EDB7 /* NSNotificationAdditions.m */,
 				B85F93E4255AE48000B54B68 /* NSPopUpButtonExtensions.swift */,
@@ -2033,6 +2038,7 @@
 				AA9FE2EE08BC133600A9E977 /* Preferences.m in Sources */,
 				AA60238108C298FB002CFD06 /* HelperFunctions.m in Sources */,
 				F6164C591E32A6660086261C /* DisclosureView.m in Sources */,
+				F6F12AFD25ABDDE3005B2DCE /* NSFileManager+Paths.m in Sources */,
 				031E083019DFA3A900194F9F /* SubscriptionModel.m in Sources */,
 				2F125EE024D066ED00868E11 /* AsyncHelper.swift in Sources */,
 				AA71168F09BEB17300E3EA8A /* AddressBarCell.m in Sources */,

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		F696D23E2561F9FC003DF0C0 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = F696D23D2561F9FC003DF0C0 /* Sparkle */; };
 		F69964F71F13029600FC8493 /* OverlayStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69964F61F13029500FC8493 /* OverlayStatusBar.swift */; };
 		F69AE79A1F2215D600342640 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F69AE79C1F2215D600342640 /* InfoPlist.strings */; };
+		F6A179D326B82BE3008DDA42 /* NSFileManager+PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A179D226B82BE3008DDA42 /* NSFileManager+PathsTests.swift */; };
 		F6A4E8481F040D58001C9191 /* PluginToolbarItemButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A4E8471F040D58001C9191 /* PluginToolbarItemButton.swift */; };
 		F6A7DE341E47138B0017BE5E /* advanced.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2A1E47138B0017BE5E /* advanced.html */; };
 		F6A7DE351E47138B0017BE5E /* faq.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE2C1E47138B0017BE5E /* faq.html */; };
@@ -740,6 +741,7 @@
 		F69AE7C81F22195300342640 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/EmptyTrashWarning.strings; sourceTree = "<group>"; };
 		F69AE7D71F221B2800342640 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoWindow.strings; sourceTree = "<group>"; };
 		F69AE7E91F2224F500342640 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = da; path = da.lproj/RSSSources.plist; sourceTree = "<group>"; };
+		F6A179D226B82BE3008DDA42 /* NSFileManager+PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFileManager+PathsTests.swift"; sourceTree = "<group>"; };
 		F6A403CF209EFCE70024470C /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cs; path = cs.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		F6A4E8471F040D58001C9191 /* PluginToolbarItemButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginToolbarItemButton.swift; sourceTree = "<group>"; };
 		F6A7DDCA1E470E980017BE5E /* Vienna.help */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Vienna.help; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1002,6 +1004,7 @@
 				2F437B3B25CF336400AD1B57 /* URL+URIEquivalence.swift */,
 				F648C2B71E7F3BEA00CE4043 /* DirectoryMonitorTests.swift */,
 				F6AC41AB25A4FAF6007DED7B /* FeedDiscovererTests.swift */,
+				F6A179D226B82BE3008DDA42 /* NSFileManager+PathsTests.swift */,
 				0377BDEB1D3A009B00960555 /* Vienna Tests-Bridging-Header.h */,
 				F6AC41C525A501B9007DED7B /* Files */,
 				035B703719E0E4AE00197334 /* Supporting Files */,
@@ -1998,6 +2001,7 @@
 				3A8D9AE325A9DA4B0016F30F /* ArticleTests.swift in Sources */,
 				3A50011B259A5EF800AA6AAD /* WebViewArticleConverter.swift in Sources */,
 				2F437B3C25CF336400AD1B57 /* SubscriptionModelTests.swift in Sources */,
+				F6A179D326B82BE3008DDA42 /* NSFileManager+PathsTests.swift in Sources */,
 				F6AC41AC25A4FAF6007DED7B /* FeedDiscovererTests.swift in Sources */,
 				4D36B44B1D37F91E009736C1 /* VNAArticleTests.m in Sources */,
 				F648C2B81E7F3BEA00CE4043 /* DirectoryMonitorTests.swift in Sources */,

--- a/Vienna/Sources/Main window/WebKitArticleConverter.swift
+++ b/Vienna/Sources/Main window/WebKitArticleConverter.swift
@@ -28,8 +28,7 @@ class WebKitArticleConverter: ArticleConverter {
     }
 
     private func getCachesPath() -> URL {
-        let cachesPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
-        let directory = URL(fileURLWithPath: cachesPath[0]).appendingPathComponent(Bundle.main.bundleIdentifier ?? "Vienna").appendingPathComponent("article")
+        let directory = FileManager.default.cachesDirectory.appendingPathComponent("article")
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
         } catch {

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -25,8 +25,6 @@
 #import <Sparkle/Sparkle.h>
 
 // Initial paths
-NSString * MA_ApplicationSupportFolder = @"~/Library/Application Support/Vienna";
-NSString * MA_ScriptsFolder = @"~/Library/Scripts/Applications/Vienna";
 NSString * MA_DefaultStyleName = @"Default";
 NSString * MA_Database_Name = @"messages.db";
 NSString * MA_ImagesFolder_Name = @"Images";
@@ -114,11 +112,13 @@ static Preferences * _standardPreferences = nil;
 			
 			// Application-specific folder locations
 			defaultDatabase = [userPrefs valueForKey:MAPref_DefaultDatabase];
-			imagesFolder = [MA_ApplicationSupportFolder stringByAppendingPathComponent:MA_ImagesFolder_Name].stringByExpandingTildeInPath;
-			stylesFolder = [MA_ApplicationSupportFolder stringByAppendingPathComponent:MA_StylesFolder_Name].stringByExpandingTildeInPath;
-			pluginsFolder = [MA_ApplicationSupportFolder stringByAppendingPathComponent:MA_PluginsFolder_Name].stringByExpandingTildeInPath;
-			scriptsFolder = MA_ScriptsFolder.stringByExpandingTildeInPath;
-			feedSourcesFolder = [MA_ApplicationSupportFolder stringByAppendingPathComponent:MA_FeedSourcesFolder_Name].stringByExpandingTildeInPath;
+			NSFileManager *fileManager = NSFileManager.defaultManager;
+			NSString *appSupportPath = fileManager.applicationSupportDirectory.path;
+			imagesFolder = [appSupportPath stringByAppendingPathComponent:MA_ImagesFolder_Name];
+			stylesFolder = [appSupportPath stringByAppendingPathComponent:MA_StylesFolder_Name];
+			pluginsFolder = [appSupportPath stringByAppendingPathComponent:MA_PluginsFolder_Name];
+			scriptsFolder = fileManager.applicationScriptsDirectory.path;
+			feedSourcesFolder = [appSupportPath stringByAppendingPathComponent:MA_FeedSourcesFolder_Name];
 		}
 		else
 		{
@@ -247,8 +247,11 @@ static Preferences * _standardPreferences = nil;
 	
 	NSNumber * boolNo = @NO;
 	NSNumber * boolYes = @YES;
-	
-	defaultValues[MAPref_DefaultDatabase] = [MA_ApplicationSupportFolder stringByAppendingPathComponent:MA_Database_Name];
+
+	NSFileManager *fileManager = NSFileManager.defaultManager;
+	NSString *appSupportPath = fileManager.applicationSupportDirectory.path;
+
+	defaultValues[MAPref_DefaultDatabase] = [appSupportPath stringByAppendingPathComponent:MA_Database_Name];
 	defaultValues[MAPref_CheckForUpdatedArticles] = boolNo;
 	defaultValues[MAPref_ShowUnreadArticlesInBold] = boolYes;
 	defaultValues[MAPref_ArticleListFont] = defaultArticleListFont;

--- a/Vienna/Sources/Shared/NSFileManager+Paths.h
+++ b/Vienna/Sources/Shared/NSFileManager+Paths.h
@@ -1,0 +1,39 @@
+//
+//  NSFileManager+Paths.h
+//  Vienna
+//
+//  Copyright 2021 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSFileManager (Paths)
+
+/// The scripts directory for the current user (Library/Application Scripts or
+/// Library/Scripts/Applications depending on whether sandboxing is enabled).
+@property (readonly, copy, nonatomic) NSURL *applicationScriptsDirectory;
+
+/// The application support directory for the current user (Library/Application
+/// Support).
+@property (readonly, copy, nonatomic) NSURL *applicationSupportDirectory;
+
+/// The caches directory for the current user (Library/Caches).
+@property (readonly, copy, nonatomic) NSURL *cachesDirectory;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Shared/NSFileManager+Paths.m
+++ b/Vienna/Sources/Shared/NSFileManager+Paths.m
@@ -1,0 +1,112 @@
+//
+//  NSFileManager+Paths.m
+//  Vienna
+//
+//  Copyright 2021 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "NSFileManager+Paths.h"
+
+@implementation NSFileManager (Paths)
+
+// The NSApplicationScriptsDirectory search path returns a subdirectory in the
+// Library/Application Scripts directory. Vienna currently uses a subdirectory
+// in Library/Scripts/Applications instead. The sandboxing migration performs
+// an automatic migration to Library/Application Scripts/<bundle identifier>
+// and places a symlink at the old location. This code needs to be updated
+// accordingly.
+- (NSURL *)applicationScriptsDirectory {
+    static NSURL *url = nil;
+    if (url) {
+        return [url copy];
+    }
+
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    NSError *error = nil;
+    url = [fileManager URLForDirectory:NSLibraryDirectory
+                              inDomain:NSUserDomainMask
+                     appropriateForURL:nil
+                                create:YES
+                                 error:&error];
+    url = [url URLByAppendingPathComponent:@"Scripts/Applications/Vienna"
+                               isDirectory:YES];
+// This is the replacement code for sandboxing:
+//
+//    NSURL *url = [fileManager URLForDirectory:NSApplicationScriptsDirectory
+//                                     inDomain:NSUserDomainMask
+//                            appropriateForURL:nil
+//                                       create:YES
+//                                        error:&error];
+    if (!url && error) {
+        [NSApp presentError:error];
+    }
+
+    return [url copy];
+}
+
+// According to Apple's file-system programming guide, the bundle identifier
+// should be used as the subdirectory name. However, Vienna presently uses the
+// app name instead. This should be changed when Vienna migrates to sandboxing.
+- (NSURL *)applicationSupportDirectory {
+    static NSURL *url = nil;
+    if (url) {
+        return [url copy];
+    }
+
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    NSError *error = nil;
+    url = [fileManager URLForDirectory:NSApplicationSupportDirectory
+                              inDomain:NSUserDomainMask
+                     appropriateForURL:nil
+                                create:YES
+                                 error:&error];
+    if (!url && error) {
+        [NSApp presentError:error];
+    }
+
+    url = [url URLByAppendingPathComponent:@"Vienna"
+                               isDirectory:YES];
+// This is the replacement code for sandboxing:
+//
+//    url = [url URLByAppendingPathComponent:NSBundle.mainBundle.bundleIdentifier
+//                               isDirectory:YES];
+
+    return [url copy];
+}
+
+- (NSURL *)cachesDirectory {
+    static NSURL *url = nil;
+    if (url) {
+        return [url copy];
+    }
+
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    NSError *error = nil;
+    url = [fileManager URLForDirectory:NSCachesDirectory
+                              inDomain:NSUserDomainMask
+                     appropriateForURL:nil
+                                create:YES
+                                 error:&error];
+    if (!url && error) {
+        [NSApp presentError:error];
+    }
+
+    url = [url URLByAppendingPathComponent:NSBundle.mainBundle.bundleIdentifier
+                               isDirectory:YES];
+
+    return [url copy];
+}
+
+@end

--- a/Vienna/Sources/Vienna-Bridging-Header.h
+++ b/Vienna/Sources/Vienna-Bridging-Header.h
@@ -6,6 +6,7 @@
 #import "DisclosureView.h"
 #import "FolderView.h"
 #import "HelperFunctions.h"
+#import "NSFileManager+Paths.h"
 #import "OpenReader.h"
 #import "PluginManager.h"
 #import "Preferences.h"


### PR DESCRIPTION
- Add properties for library paths to NSFileManager
- Uses NSFileManager properties for library paths

Note: I left some commented code for sandboxing.