### PR TITLE
Fix behavior when clicking on Dock icon

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -361,19 +361,21 @@
 
 }
 
-/* applicationShouldHandleReopen
- * Handle the notification sent when the application is reopened such as when the dock icon
- * is clicked. If the main window was previously hidden, we show it again here.
- */
--(BOOL)applicationShouldHandleReopen:(NSApplication *)theApplication hasVisibleWindows:(BOOL)flag
+/// Handle the notification sent when the application is reopened, such as when
+/// the Dock icon is clicked. If the main window was previously hidden, we show
+/// it again here.
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)sender
+                    hasVisibleWindows:(BOOL)flag
 {
-	if (!didCompleteInitialisation)
-		return NO;
-	
-	[self showMainWindow:self];
-	if (emptyTrashWarning != nil)
-		[emptyTrashWarning showWindow:self];
-	return YES;
+    if (!didCompleteInitialisation) {
+        return NO;
+    }
+
+    if (!flag) {
+        [self showMainWindow:self];
+    }
+
+    return YES;
 }
 
 /* applicationShouldTerminate


### PR DESCRIPTION
Before this commit, the main window is always moved to the front when the Dock icon is clicked, even when another window/panel was key before (e.g. preferences). This commit simply puts Vienna back into focus and retains the previous window order.