### PR TITLE
Address percent-encoding issue

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3177,14 +3177,15 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSString * title;
 	NSString * link;
 	Article * currentArticle;
+	NSCharacterSet *charSet = NSCharacterSet.URLQueryAllowedCharacterSet;
 
     // If the active tab is a web view, mail the URL
     id<Tab> activeBrowserTab = self.browser.activeTab;
     if (activeBrowserTab) {
         NSURL *url = activeBrowserTab.tabUrl;
         if (url != nil) {
-			title = percentEscape(activeBrowserTab.title);
-			link = percentEscape(url.absoluteString);
+			title = [activeBrowserTab.title stringByAddingPercentEncodingWithAllowedCharacters:charSet];
+			link = [url.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:charSet];
 			mailtoLink = [NSMutableString stringWithFormat:@"mailto:?subject=%@&body=%@", title, link];
 		}
 	}
@@ -3197,8 +3198,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			if (articleArray.count == 1)
 			{
 				currentArticle = articleArray[0];
-				title = percentEscape(currentArticle.title);
-				link = percentEscape(currentArticle.link);
+				title = [currentArticle.title stringByAddingPercentEncodingWithAllowedCharacters:charSet];
+				link = [currentArticle.link stringByAddingPercentEncodingWithAllowedCharacters:charSet];
 				mailtoLink = [NSMutableString stringWithFormat: @"mailto:?subject=%@&body=%@", title, link];
 			}
 			else
@@ -3206,8 +3207,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 				mailtoLink = [NSMutableString stringWithFormat:@"mailto:?subject=&body="];
 				for (currentArticle in articleArray)
 				{
-					title = percentEscape(currentArticle.title);
-					link = percentEscape(currentArticle.link);
+					title = [currentArticle.title stringByAddingPercentEncodingWithAllowedCharacters:charSet];
+					link = [currentArticle.link stringByAddingPercentEncodingWithAllowedCharacters:charSet];
 					[mailtoLink appendFormat: @"%@%@%@%@%@", title, mailtoLineBreak, link, mailtoLineBreak, mailtoLineBreak];
 				}
 			}

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -29,7 +29,6 @@
 
 #import "OpenReader.h"
 #import "URLRequestExtensions.h"
-#import "HelperFunctions.h"
 #import "Folder.h"
 #import "Database.h"
 #import "RefreshManager.h"
@@ -1238,14 +1237,20 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
     }
 } // createFolders
 
-
-/**
- * Percent escape the part after "feed/"
- *
- */
-+(NSString *)escapeFeedId:(NSString *)identifier
+// Escape invalid and reserved URL characters to make string suitable for
+// embedding in mailto: URLs and custom app-specific schemes like papers://
+// cf unreserved characters in section 2.3 of RFC3986
++ (NSString *)escapeFeedId:(NSString *)identifier
 {
-    return [NSString stringWithFormat:@"feed/%@", percentEscape([identifier stringByReplacingOccurrencesOfString:@"feed/" withString:@"" options:0 range:NSMakeRange(0, 5)])];
+    NSString *shortenedStr = [identifier stringByReplacingOccurrencesOfString:@"feed/"
+                                                                   withString:@""
+                                                                      options:0
+                                                                        range:NSMakeRange(0, 5)];
+    NSString *chars = @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+    NSCharacterSet *set = [NSCharacterSet characterSetWithCharactersInString:chars];
+    NSString *escapedStr = [shortenedStr stringByAddingPercentEncodingWithAllowedCharacters:set];
+
+    return [NSString stringWithFormat:@"feed/%@", escapedStr];
 }
 
 @end

--- a/Vienna/Sources/Shared/HelperFunctions.h
+++ b/Vienna/Sources/Shared/HelperFunctions.h
@@ -48,4 +48,3 @@ NSString * _Nullable getDefaultBrowser(void);
 NSURL * _Nullable cleanedUpUrlFromString(NSString *_Nullable urlString);
 NSURL * _Nullable urlFromUserString(NSString *_Nonnull urlString);
 BOOL hasOSScriptsMenu(void);
-NSString * _Nullable percentEscape(NSString *_Nullable string);

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -96,24 +96,43 @@ NSURL *_Nullable cleanedUpUrlFromString(NSString * urlString)
     return urlToLoad;
 }
 
-NSURL *_Nullable urlFromUserString(NSString *_Nonnull urlString) {
+NSURL *_Nullable urlFromUserString(NSString *_Nonnull urlString)
+{
+    NSURL *url = nil;
     // Try simple conversion first
-    NSURL *urlToLoad = [NSURLComponents componentsWithString:urlString].URL;
-    if (urlToLoad == nil) {
-        // Fallback : use WebKit to clean up user-entered URLs that might contain umlauts, diacritics
-        // and other IDNA related stuff in the domain, or whatever may hide in filenames and arguments
+    NSURLComponents *urlComponents =
+        [NSURLComponents componentsWithString:urlString];
+    if (urlComponents) {
+        // NSURLComponents percent-encodes the semicolon character in the path
+        // component of the URL. Although it is recommended by Apple, it leads
+        // to problems when the URL is loaded and the server cannot handle the
+        // percent-encoding. This workaround removes the percent-encoding for
+        // the semicolon character in the path component.
+        NSCharacterSet *pathCharSet = NSCharacterSet.URLPathAllowedCharacterSet;
+        NSMutableCharacterSet *extendedCharSet = [pathCharSet mutableCopy];
+        [extendedCharSet addCharactersInString:@";"];
+
+        NSString *path = [urlComponents.path
+            stringByAddingPercentEncodingWithAllowedCharacters:extendedCharSet];
+        urlComponents.percentEncodedPath = path;
+        url = urlComponents.URL;
+    } else {
+        // Use WebKit to clean up user-entered URLs that might contain umlauts,
+        // diacritics and other IDNA related stuff in the domain, or whatever
+        // may hide in filenames and arguments.
         NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
         [pasteboard declareTypes:@[NSPasteboardTypeString] owner:nil];
         @try {
-            if ([pasteboard setString:urlString forType:NSPasteboardTypeString]) {
-                urlToLoad = [WebView URLFromPasteboard:pasteboard];
+            if ([pasteboard setString:urlString
+                              forType:NSPasteboardTypeString]) {
+                url = [WebView URLFromPasteboard:pasteboard];
             }
         } @catch (NSException *exception) {
             NSLog(@"Failed to convert URL for string %@", urlString);
         }
         [pasteboard releaseGlobally];
     }
-    return urlToLoad;
+    return url;
 }
 
 /* loadMapFromPath

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -68,18 +68,6 @@ NSMenuItem * menuItemWithAction(SEL theSelector)
 	return nil;
 }
 
-/* percentEscape
- * Escape invalid and reserved URL characters to make string suitable 
- * for embedding in mailto: URLs and custom app-specific schemes like papers://
- * cf unreserved characters in section 2.3 of RFC3986
- */ 
-NSString * percentEscape(NSString *string)
-{
-	return [string stringByAddingPercentEncodingWithAllowedCharacters:
-	    [NSCharacterSet characterSetWithCharactersInString:
-	    @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"]];
-}
-
 /* cleanedUpUrlFromString
  * Uses WebKit to clean up user-entered URLs that might contain umlauts, diacritics and other
  * IDNA related stuff in the domain, or whatever may hide in filenames and arguments.


### PR DESCRIPTION
- Adds percent-encoding workaround for semicolons on URL path component
- Moves and partially replaces percentEscape() helper function 

Potentially resolves #1462 

I am not sure about this solution, since it technically goes against [Apple’s recommendation](https://developer.apple.com/documentation/foundation/nsurlcomponents/1408161-percentencodedpath).

Based on the information I found, `;` is a reserved character for URIs _generally_, however it does not have a reserved purpose specifically for URL `path` component (cf. `query` component, where `;` is a substitute for `&` as a delimiter for key-value pairs). See: [RFC3986](https://www.ietf.org/rfc/rfc3986.txt) s. 3.3, last paragraph. I do not know why Apple recommends percent-encoding it, and does so by default in NSURLComponents, but it seems NSURL itself is completely fine with it, in fact, when an NSURL is created on its own rather than via NSURLComponents, it does not require percent-encoding at all to be valid.