### PR TITLE
Remove support for web plug-ins

### DIFF
--- a/Vienna/Interfaces/Base.lproj/Preferences.storyboard
+++ b/Vienna/Interfaces/Base.lproj/Preferences.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="VBW-RM-gbf">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="VBW-RM-gbf">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -241,11 +241,11 @@
             <objects>
                 <viewController id="NjZ-bv-EoA" customClass="AdvancedPreferencesViewController" sceneMemberID="viewController">
                     <view key="view" id="8J7-Mc-HHy">
-                        <rect key="frame" x="0.0" y="0.0" width="450" height="324"/>
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="302"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vvG-VT-CVp">
-                                <rect key="frame" x="18" y="272" width="414" height="32"/>
+                                <rect key="frame" x="18" y="250" width="414" height="32"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" id="4Qn-qF-kSp">
                                     <font key="font" metaFont="system"/>
                                     <string key="title">The settings here should not need to be changed for the normal use of Vienna. Refer to the Help file for details of each setting.</string>
@@ -254,7 +254,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HJu-JH-e1a">
-                                <rect key="frame" x="18" y="235" width="412" height="18"/>
+                                <rect key="frame" x="18" y="213" width="412" height="18"/>
                                 <buttonCell key="cell" type="check" title="Preview new browser" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="DDY-fS-V5T">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -264,23 +264,13 @@
                                 </buttonCell>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1u1-uu-U0M">
-                                <rect key="frame" x="18" y="165" width="412" height="18"/>
+                                <rect key="frame" x="18" y="143" width="412" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable JavaScript in the internal browser" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="MnV-8D-Qyq">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="changeUseJavaScript:" target="NjZ-bv-EoA" id="UiT-ZF-E7L"/>
-                                </connections>
-                            </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fnP-kR-L8c">
-                                <rect key="frame" x="18" y="143" width="412" height="18"/>
-                                <buttonCell key="cell" type="check" title="Enable Internet plug-ins in the internal browser" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="9bX-Lt-AWz">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="changeUseWebPlugins:" target="NjZ-bv-EoA" id="izU-ob-bND"/>
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="250" translatesAutoresizingMaskIntoConstraints="NO" id="VMW-g6-f00">
@@ -402,7 +392,7 @@
                                 </connections>
                             </button>
                             <textField verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BGf-AD-UAd">
-                                <rect key="frame" x="18" y="202" width="414" height="26"/>
+                                <rect key="frame" x="18" y="180" width="414" height="26"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" id="Fv8-Xx-YR0">
                                     <font key="font" metaFont="system" size="10"/>
                                     <string key="title">Vienna has a new browser built on top of WebKit. It is faster and more secure.
@@ -424,7 +414,6 @@ After changing this setting, restart Vienna to test it. Feedback is very welcome
                             <constraint firstItem="vvG-VT-CVp" firstAttribute="leading" secondItem="8J7-Mc-HHy" secondAttribute="leading" constant="20" symbolic="YES" id="NlN-UY-n3b"/>
                             <constraint firstAttribute="trailing" secondItem="1u1-uu-U0M" secondAttribute="trailing" constant="20" symbolic="YES" id="PBF-4N-WSt"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8eb-2O-wjd" secondAttribute="trailing" constant="20" symbolic="YES" id="Rtg-SH-5JK"/>
-                            <constraint firstAttribute="trailing" secondItem="fnP-kR-L8c" secondAttribute="trailing" constant="20" symbolic="YES" id="TO7-9Y-6pF"/>
                             <constraint firstItem="HJu-JH-e1a" firstAttribute="leading" secondItem="8J7-Mc-HHy" secondAttribute="leading" constant="20" symbolic="YES" id="U52-Om-beq"/>
                             <constraint firstItem="pfv-Xq-7Aq" firstAttribute="top" secondItem="37K-gU-v9y" secondAttribute="bottom" constant="8" symbolic="YES" id="Wya-pc-Cgb"/>
                             <constraint firstItem="37K-gU-v9y" firstAttribute="leading" secondItem="GDE-ah-5QX" secondAttribute="leading" id="c3X-0q-2dl"/>
@@ -432,24 +421,21 @@ After changing this setting, restart Vienna to test it. Feedback is very welcome
                             <constraint firstAttribute="trailing" secondItem="pfv-Xq-7Aq" secondAttribute="trailing" constant="20" symbolic="YES" id="eAB-Mh-vTh"/>
                             <constraint firstAttribute="bottom" secondItem="pfv-Xq-7Aq" secondAttribute="bottom" constant="20" symbolic="YES" id="fQl-Qa-iAH"/>
                             <constraint firstItem="37K-gU-v9y" firstAttribute="trailing" secondItem="GDE-ah-5QX" secondAttribute="trailing" id="ggE-Ik-kJd"/>
-                            <constraint firstItem="fnP-kR-L8c" firstAttribute="top" secondItem="1u1-uu-U0M" secondAttribute="bottom" constant="6" symbolic="YES" id="ght-wc-p0P"/>
+                            <constraint firstItem="8eb-2O-wjd" firstAttribute="top" secondItem="1u1-uu-U0M" secondAttribute="bottom" constant="20" symbolic="YES" id="ght-wc-p0P"/>
                             <constraint firstAttribute="trailing" secondItem="BGf-AD-UAd" secondAttribute="trailing" constant="20" symbolic="YES" id="khx-C3-8Dc"/>
                             <constraint firstAttribute="trailing" secondItem="GDE-ah-5QX" secondAttribute="trailing" constant="20" symbolic="YES" id="lT0-TT-aR5"/>
                             <constraint firstItem="37K-gU-v9y" firstAttribute="top" secondItem="GDE-ah-5QX" secondAttribute="bottom" constant="8" symbolic="YES" id="mt1-a8-Zmf"/>
                             <constraint firstItem="1u1-uu-U0M" firstAttribute="leading" secondItem="8J7-Mc-HHy" secondAttribute="leading" constant="20" symbolic="YES" id="p1Z-8J-PDc"/>
                             <constraint firstItem="1u1-uu-U0M" firstAttribute="top" secondItem="BGf-AD-UAd" secondAttribute="bottom" constant="20" id="qaV-wu-Khx"/>
                             <constraint firstItem="BGf-AD-UAd" firstAttribute="top" secondItem="HJu-JH-e1a" secondAttribute="bottom" constant="8" symbolic="YES" id="tNk-IT-HgU"/>
-                            <constraint firstItem="fnP-kR-L8c" firstAttribute="leading" secondItem="8J7-Mc-HHy" secondAttribute="leading" constant="20" symbolic="YES" id="v8T-6Y-For"/>
                             <constraint firstAttribute="trailing" secondItem="vvG-VT-CVp" secondAttribute="trailing" constant="20" symbolic="YES" id="vtd-DY-6PJ"/>
                             <constraint firstItem="VMW-g6-f00" firstAttribute="baseline" secondItem="8eb-2O-wjd" secondAttribute="baseline" id="w5o-QA-RVB"/>
-                            <constraint firstItem="8eb-2O-wjd" firstAttribute="top" secondItem="fnP-kR-L8c" secondAttribute="bottom" constant="20" id="xXz-wQ-hax"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="concurrentDownloads" destination="8eb-2O-wjd" id="pIP-FA-KAN"/>
                         <outlet property="previewNewBrowserButton" destination="HJu-JH-e1a" id="yCg-55-dum"/>
                         <outlet property="useJavaScriptButton" destination="1u1-uu-U0M" id="D4j-kD-89C"/>
-                        <outlet property="useWebPluginsButton" destination="fnP-kR-L8c" id="oI5-zU-G58"/>
                     </connections>
                 </viewController>
                 <customObject id="kO8-qM-JFc" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Vienna/Interfaces/da.lproj/Preferences.strings
+++ b/Vienna/Interfaces/da.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Manuelt";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Aktiver udvidelser i den interne browser";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Marker nuværende artikel læst:";
 

--- a/Vienna/Interfaces/de.lproj/Preferences.strings
+++ b/Vienna/Interfaces/de.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Manuell";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Aktiviere Plugins im internen Browser";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Markiere aktuellen Artikel als gelesen:";
 

--- a/Vienna/Interfaces/es.lproj/Preferences.strings
+++ b/Vienna/Interfaces/es.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Manualmente";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Activar plugins en el navegador integrado";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Marcar artículo actual como leído:";
 

--- a/Vienna/Interfaces/fr.lproj/Preferences.strings
+++ b/Vienna/Interfaces/fr.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Manuellement";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Activer les plugins dans le navigateur interne";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Marquer l'article courant comme lu :";
 

--- a/Vienna/Interfaces/lt.lproj/Preferences.strings
+++ b/Vienna/Interfaces/lt.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Rankiniu būdu";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Leisti naudoti įskiepius vidinėje naršyklėje";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Pažymėti straipsnį kaip perskaitytą:";
 

--- a/Vienna/Interfaces/nl.lproj/Preferences.strings
+++ b/Vienna/Interfaces/nl.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Handmatig";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Gebruik plug-ins in interne browser";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Markeer huidige artikel als gelezen:";
 

--- a/Vienna/Interfaces/ru.lproj/Preferences.strings
+++ b/Vienna/Interfaces/ru.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Вручную";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Разрешить плагины во внешнем браузере";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Пометить текущую статью как прочитанную:";
 

--- a/Vienna/Interfaces/sv.lproj/Preferences.strings
+++ b/Vienna/Interfaces/sv.lproj/Preferences.strings
@@ -16,9 +16,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "Manuellt";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "Aktivera JavaScript i inbyggda webbläsaren";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "Markera nuvarande artikel som läst:";
 

--- a/Vienna/Interfaces/zh-Hans.lproj/Preferences.strings
+++ b/Vienna/Interfaces/zh-Hans.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "手动";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "在内置浏览器中启用插件";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "标记当前文章为已读于:";
 

--- a/Vienna/Interfaces/zh-Hant.lproj/Preferences.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/Preferences.strings
@@ -19,9 +19,6 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "手動";
 
-/* Class = "NSButtonCell"; title = "Enable Internet plug-ins in the internal browser"; ObjectID = "9bX-Lt-AWz"; */
-"9bX-Lt-AWz.title" = "在內建瀏覽器中啟用外掛";
-
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "將目前的文章標記為已閱讀：";
 

--- a/Vienna/Sources/Main window/BrowserPane.m
+++ b/Vienna/Sources/Main window/BrowserPane.m
@@ -458,7 +458,7 @@
 {
     [self willChangeValueForKey:@"loading"];
     // stop Javascript and plugings
-    [self.webPane abortJavascriptAndPlugIns];
+    [self.webPane abortJavascript];
     [self.webPane setUIDelegate:nil];
     [self.webPane stopLoading:self];
     [self didChangeValueForKey:@"loading"];

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -47,7 +47,6 @@ class CustomWKWebView: WKWebView {
     }
 
     private var useJavaScriptObservation: NSKeyValueObservation?
-    private var useWebPluginsObservation: NSKeyValueObservation?
 
     override init(frame: CGRect = .zero, configuration: WKWebViewConfiguration = WKWebViewConfiguration()) {
 
@@ -68,19 +67,6 @@ class CustomWKWebView: WKWebView {
                 configuration.defaultWebpagePreferences.allowsContentJavaScript = newValue
             } else {
                  configuration._allowsJavaScriptMarkup = newValue
-            }
-        }
-
-        useWebPluginsObservation = Preferences.standard.observe(\.useWebPlugins, options: [.initial, .new]) { _, change  in
-            guard let newValue = change.newValue else {
-                return
-            }
-            if #available(macOS 11, *) {
-                // TODO: remove the plugins preference once minimal requirement is macOS 11
-                // because plugins are deprecated and unsupported
-            } else {
-                prefs.plugInsEnabled = newValue
-                prefs.javaEnabled = newValue
             }
         }
 

--- a/Vienna/Sources/Main window/TabbedWebView.h
+++ b/Vienna/Sources/Main window/TabbedWebView.h
@@ -35,8 +35,8 @@
 -(void)setOpenLinksInNewBrowser:(BOOL)flag;
 -(void)keyDown:(NSEvent *)theEvent;
 -(void)printDocument:(id)sender;
--(void)abortJavascriptAndPlugIns;
--(void)useUserPrefsForJavascriptAndPlugIns;
+-(void)abortJavascript;
+-(void)useUserPrefsForJavascript;
 -(void)forceJavascript;
 @property (nonatomic, getter=isFeedRedirect, readonly) BOOL feedRedirect;
 @property (nonatomic, getter=isDownload, readonly) BOOL download;

--- a/Vienna/Sources/Main window/TabbedWebView.m
+++ b/Vienna/Sources/Main window/TabbedWebView.m
@@ -94,6 +94,8 @@ static NSString * _userAgent ;
         _webPrefs.standardFontFamily = @"Arial";
         _webPrefs.defaultFontSize = 16;
         _webPrefs.privateBrowsingEnabled = NO;
+        _webPrefs.plugInsEnabled = NO;
+        _webPrefs.javaEnabled = NO;
     });
     return _webPrefs;
 }
@@ -109,6 +111,8 @@ static NSString * _userAgent ;
         _webPrefs.defaultFontSize = 16;
         _webPrefs.privateBrowsingEnabled = NO;
         _webPrefs.javaScriptEnabled = YES;
+        _webPrefs.plugInsEnabled = NO;
+        _webPrefs.javaEnabled = NO;
     });
     return _webPrefs;
 }
@@ -125,6 +129,7 @@ static NSString * _userAgent ;
         _webPrefs.privateBrowsingEnabled = NO;
         _webPrefs.javaScriptEnabled = NO;
         _webPrefs.plugInsEnabled = NO;
+        _webPrefs.javaEnabled = NO;
     });
     return _webPrefs;
 }
@@ -162,16 +167,13 @@ static NSString * _userAgent ;
                name:kMA_Notify_MinimumFontSizeChange object:nil];
 	[nc addObserver:self selector:@selector(handleUseJavaScriptChange:)
                name:kMA_Notify_UseJavaScriptChange object:nil];
-    [nc addObserver:self selector:@selector(handleUseWebPluginsChange:)
-               name:kMA_Notify_UseWebPluginsChange object:nil];
 	
     // handle UserAgent
     self.customUserAgent = [TabbedWebView userAgent];
-	// Handle minimum font size, use of JavaScript, and use of plugins
+	// Handle minimum font size and use of JavaScript.
 	self.preferences = [TabbedWebView defaultWebPrefs];
 	[self loadMinimumFontSize];
 	[self loadUseJavaScript];
-    [self loadUseWebPlugins];
 }
 
 /* setOpenLinksInNewBrowser
@@ -360,14 +362,6 @@ static NSString * _userAgent ;
 	[self loadUseJavaScript];
 }
 
-/* handleUseWebPluginsChange
- * Called when the user changes the 'Use Javascript' setting.
- */
--(void)handleUseWebPluginsChange:(NSNotification *)nc
-{
-    [self loadUseWebPlugins];
-}
-
 /* loadMinimumFontSize
  * Sets up the web preferences for a minimum font size.
  */
@@ -422,33 +416,24 @@ static NSString * _userAgent ;
 	[TabbedWebView defaultWebPrefs].javaScriptEnabled = prefs.useJavaScript;
 }
 
-/* loadUseWebPlugins
- * Sets up the web preferences for using WebPlugins.
+/* abortJavascript
+ * Sets up the web preferences to stop JavaScript
  */
--(void)loadUseWebPlugins
-{
-    Preferences * prefs = [Preferences standardPreferences];
-    [TabbedWebView defaultWebPrefs].plugInsEnabled = prefs.useWebPlugins;
-}
-
-/* abortJavascriptAndPlugIns
- * Sets up the web preferences to stop JavaScript and WebPlugins
- */
--(void)abortJavascriptAndPlugIns
+-(void)abortJavascript
 {
     self.preferences = [TabbedWebView passiveWebPrefs];
 }
 
-/* useUserPrefsForJavascriptAndPlugIns
- * Sets up the web preferences to use JavaScript and WebPlugins as defined by user preferences
+/* useUserPrefsForJavascript
+ * Sets up the web preferences to use JavaScript as defined by user preferences
  */
--(void)useUserPrefsForJavascriptAndPlugIns
+-(void)useUserPrefsForJavascript
 {
     self.preferences = [TabbedWebView defaultWebPrefs];
 }
 
 /* forceJavascript
- * Sets up the web preferences to use JavaScript (without WebPlugins)
+ * Sets up the web preferences to use JavaScript
  */
 -(void)forceJavascript
 {

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -334,7 +334,7 @@
 
                 [sender forceJavascript];
                 offsetHeight = [sender stringByEvaluatingJavaScriptFromString:@"document.documentElement.offsetHeight"];
-                [sender useUserPrefsForJavascriptAndPlugIns];
+                [sender useUserPrefsForJavascript];
                 fittingHeight = offsetHeight.doubleValue;
                 //get the rect of the current webview frame
                 NSRect webViewRect = sender.frame;

--- a/Vienna/Sources/Preferences window/AdvancedPreferencesViewController.h
+++ b/Vienna/Sources/Preferences window/AdvancedPreferencesViewController.h
@@ -24,7 +24,6 @@
     IBOutlet NSButton * previewNewBrowserButton;
     IBOutlet NSButton * useJavaScriptButton;
     IBOutlet NSPopUpButton * concurrentDownloads;
-    IBOutlet NSButton *useWebPluginsButton;
 }
 
 // Action functions
@@ -32,6 +31,5 @@
 -(IBAction)changeUseJavaScript:(id)sender;
 -(IBAction)changeConcurrentDownloads:(id)sender;
 -(IBAction)showAdvancedHelp:(id)sender;
-- (IBAction)changeUseWebPlugins:(NSButton *)sender;
 
 @end

--- a/Vienna/Sources/Preferences window/AdvancedPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/AdvancedPreferencesViewController.m
@@ -53,20 +53,6 @@
     previewNewBrowserButton.state = prefs.useNewBrowser ? NSControlStateValueOn : NSControlStateValueOff;
     useJavaScriptButton.state = prefs.useJavaScript ? NSControlStateValueOn : NSControlStateValueOff;
 
-    if (@available(macOS 11, *)) {
-        // WKWebKit has no more support for plug-ins. The same might not be true
-        // for WebView, however.
-        if (prefs.useNewBrowser) {
-            useWebPluginsButton.enabled = NO;
-            useWebPluginsButton.state = NSControlStateValueOff;
-        } else {
-            useWebPluginsButton.enabled = YES;
-            useWebPluginsButton.state = prefs.useWebPlugins ? NSControlStateValueOn : NSControlStateValueOff;
-        }
-    } else {
-        useWebPluginsButton.state = prefs.useWebPlugins ? NSControlStateValueOn : NSControlStateValueOff;
-    }
-
     [concurrentDownloads selectItemWithTitle:[NSString stringWithFormat:@"%lu",(unsigned long)prefs.concurrentDownloads]];
 }
 
@@ -74,18 +60,6 @@
     BOOL useNewBrowser = sender.state == NSControlStateValueOn;
     Preferences *preferences = Preferences.standardPreferences;
     preferences.useNewBrowser = useNewBrowser;
-
-    if (@available(macOS 11, *)) {
-        // WKWebKit has no more support for plug-ins. The same might not be true
-        // for WebView, however.
-        if (useNewBrowser) {
-            useWebPluginsButton.enabled = NO;
-            useWebPluginsButton.state = NSControlStateValueOff;
-        } else {
-            useWebPluginsButton.enabled = YES;
-            useWebPluginsButton.state = preferences.useWebPlugins ? NSControlStateValueOn : NSControlStateValueOff;
-        }
-    }
 }
 
 /* changeUseJavaScript
@@ -96,16 +70,6 @@
     BOOL useJavaScript = [sender state] == NSControlStateValueOn;
     [Preferences standardPreferences].useJavaScript = useJavaScript;
 }
-
-/* changeUseWebPlugins
- * Toggle whether or not the internel webkit browser should use plugins
- * e.g. Flash
- */
-- (IBAction)changeUseWebPlugins:(NSButton *)sender {
-    BOOL useWebPlugins = sender.state == NSControlStateValueOn;
-    [Preferences standardPreferences].useWebPlugins = useWebPlugins;
-}
-
 
 -(IBAction)changeConcurrentDownloads:(id)sender {
     [Preferences standardPreferences].concurrentDownloads = concurrentDownloads.titleOfSelectedItem.integerValue;

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -45,7 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 	BOOL showFolderImages;
 	BOOL useJavaScript;
     BOOL useNewBrowser;
-    BOOL useWebPlugins;
 	BOOL showAppInStatusBar;
 	BOOL showStatusBar;
 	BOOL showFilterBar;
@@ -73,7 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
 // String constants for NSNotificationCenter
 extern NSString * const kMA_Notify_MinimumFontSizeChange;
 extern NSString * const kMA_Notify_UseJavaScriptChange;
-extern NSString * const kMA_Notify_UseWebPluginsChange;
 
 @property (class, readonly) Preferences *standardPreferences;
 
@@ -145,9 +143,6 @@ extern NSString * const kMA_Notify_UseWebPluginsChange;
 
 // JavaScript settings
 @property (nonatomic) BOOL useJavaScript;
-
-// Web Plugins settings
-@property (nonatomic) BOOL useWebPlugins;
 
 // Refresh frequency
 @property (nonatomic) NSInteger refreshFrequency;

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -40,7 +40,6 @@ NSString * MA_FeedSourcesFolder_Name = @"Sources";
 // NSNotificationCenter string constants
 NSString * const kMA_Notify_MinimumFontSizeChange = @"MA_Notify_MinimumFontSizeChange";
 NSString * const kMA_Notify_UseJavaScriptChange = @"MA_Notify_UseJavaScriptChange";
-NSString * const kMA_Notify_UseWebPluginsChange = @"MA_Notify_UseWebPluginsChange";
 
 
 // The default preferences object.
@@ -185,7 +184,6 @@ static Preferences * _standardPreferences = nil;
 		showFilterBar = [self boolForKey:MAPref_ShowFilterBar];
 		useJavaScript = [self boolForKey:MAPref_UseJavaScript];
         useNewBrowser = [self boolForKey:MAPref_UseNewBrowser];
-        useWebPlugins = [self boolForKey:MAPref_UseWebPlugins];
 		showAppInStatusBar = [self boolForKey:MAPref_ShowAppInStatusBar];
 		folderFont = [NSUnarchiver unarchiveObjectWithData:[userPrefs objectForKey:MAPref_FolderFont]];
 		articleFont = [NSUnarchiver unarchiveObjectWithData:[userPrefs objectForKey:MAPref_ArticleListFont]];
@@ -270,7 +268,6 @@ static Preferences * _standardPreferences = nil;
 	defaultValues[MAPref_ShowFolderImages] = boolYes;
 	defaultValues[MAPref_UseJavaScript] = boolYes;
 	defaultValues[MAPref_UseNewBrowser] = boolNo;
-	defaultValues[MAPref_UseWebPlugins] = boolNo;
 	defaultValues[MAPref_OpenLinksInVienna] = boolYes;
 	defaultValues[MAPref_OpenLinksInBackground] = boolYes;
 	defaultValues[MAPref_ShowAppInStatusBar] = boolNo;
@@ -498,29 +495,6 @@ static Preferences * _standardPreferences = nil;
 {
     [self setBool:flag forKey:MAPref_UseNewBrowser];
     useNewBrowser = flag;
-}
-
-
-/* useWebPlugins
- * Specifies whether or not to enable web plugins
- */
--(BOOL)useWebPlugins
-{
-    return useWebPlugins;
-}
-
-/* setEnableJavaScript
- * Enable whether JavaScript is used.
- */
--(void)setUseWebPlugins:(BOOL)flag
-{
-    if (useWebPlugins != flag)
-    {
-        useWebPlugins = flag;
-        [self setBool:flag forKey:MAPref_UseWebPlugins];
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMA_Notify_UseWebPluginsChange
-                                                            object:nil];
-    }
 }
 
 -(NSUInteger)concurrentDownloads {

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -54,7 +54,6 @@ extern NSString * MAPref_DownloadsList;
 extern NSString * MAPref_ShowFolderImages;
 extern NSString * MAPref_UseJavaScript;
 extern NSString * MAPref_UseNewBrowser;
-extern NSString * MAPref_UseWebPlugins;
 extern NSString * MAPref_CachedArticleGUID;
 extern NSString * MAPref_ArticleSortDescriptors;
 extern NSString * MAPref_FilterMode;

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -53,7 +53,6 @@ NSString * MAPref_DownloadsList = @"DownloadsList";
 NSString * MAPref_ShowFolderImages = @"ShowFolderImages";
 NSString * MAPref_UseJavaScript = @"UseJavaScript";
 NSString * MAPref_UseNewBrowser = @"UseNewBrowser";
-NSString * MAPref_UseWebPlugins = @"UseWebPlugins";
 NSString * MAPref_CachedArticleGUID = @"CachedArticleGUID";
 NSString * MAPref_ArticleSortDescriptors = @"ArticleSortDescriptors";
 NSString * MAPref_FilterMode = @"FilterMode";


### PR DESCRIPTION
This follows #1498 and my suggestion on Slack.

Apple removed the “general” plug-in support with Safari 12 which is preinstalled on macOS 10.14 and available for macOS 10.12 (Vienna’s current minimum). The only supported plug-in from that point on is Adobe Flash, which is officially EOL since the end of 2020 and generally regarded as a security risk. Safari 14 (available for macOS 10.14 at a minimum) removes plug-in support entirely, hence the deprecated APIs in WebKit for macOS 11+.

I inspected some of the package installers for Safari and found that installing Safari also updates the system's WebKit library (WKWebView; WebKit 2) and WebKitLegacy (WebView; WebKit 1). I suppose that users that have Safari 12 installed won’t be able to run plug-ins other than Flash; users that have installed Safari 14 won’t be able to run any plug-ins.

I think it’s sensible to remove it.