### PR TITLE
Add hidden preference for relative or absolute date formatting

### DIFF
--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -294,6 +294,7 @@ static Preferences * _standardPreferences = nil;
     defaultValues[MAPref_SyncingAppKey] = @"rAlfs2ELSuFxZJ5adJAW54qsNbUa45Qn";
     defaultValues[MAPref_AlwaysAcceptBetas] = boolNo;
     defaultValues[MAPref_UserAgentName] = @"Vienna";
+    defaultValues[MAPref_UseRelativeDates] = boolYes;
 
 	return [defaultValues copy];
 }

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -81,6 +81,7 @@ extern NSString * MAPref_SyncingAppId;
 extern NSString * MAPref_SyncingAppKey;
 extern NSString * MAPref_AlwaysAcceptBetas;
 extern NSString * MAPref_UserAgentName;
+extern NSString *const MAPref_UseRelativeDates;
 
 extern NSInteger MA_Default_BackTrackQueueSize;
 extern NSInteger MA_Default_RefreshThreads;

--- a/Vienna/Sources/Shared/DateFormatterExtension.m
+++ b/Vienna/Sources/Shared/DateFormatterExtension.m
@@ -19,6 +19,10 @@
 
 #import "DateFormatterExtension.h"
 
+#import "Constants.h"
+
+NSString *const MAPref_UseRelativeDates = @"DoesRelativeDateFormatting";
+
 @implementation NSDateFormatter (RelativeDateFormatter)
 
 + (NSDateFormatter *)relativeDateFormatter {
@@ -27,10 +31,13 @@
 
     dispatch_once(&onceToken, ^{
         _relativeDateFormatter = [self new];
-        _relativeDateFormatter.doesRelativeDateFormatting = YES;
         _relativeDateFormatter.dateStyle = NSDateFormatterShortStyle;
         _relativeDateFormatter.timeStyle = NSDateFormatterShortStyle;
         _relativeDateFormatter.formattingContext = NSFormattingContextDynamic;
+
+        NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+        BOOL value = [defaults boolForKey:MAPref_UseRelativeDates];
+        _relativeDateFormatter.doesRelativeDateFormatting = value;
     });
 
     return _relativeDateFormatter;


### PR DESCRIPTION
Closes  #1474

This preference is controlled by the key `DoesRelativeDateFormatting`

For now, this is just a hidden preference set at start-up, since it needs implementing observers to respond to preference changes.