### PR TITLE
Update Sparkle to version 2.0 beta 4

### DIFF
--- a/Scripts/Notarize.sh
+++ b/Scripts/Notarize.sh
@@ -12,8 +12,11 @@ fi
 
 local_apps_dir="${ARCHIVE_PATH}/Products/Applications"
 app_path="${local_apps_dir}/Vienna.app"
+frameworks_path="$app_path/Contents/Frameworks"
 
-codesign --verbose --force --deep -o runtime --sign "${CODE_SIGN_IDENTITY}" "${app_path}"
+codesign --verbose --force --sign "$CODE_SIGN_IDENTITY" --options runtime "$frameworks_path/Sparkle.framework/XPCServices/org.sparkle-project.InstallerLauncher.xpc"
+codesign --verbose --force --sign "$CODE_SIGN_IDENTITY" --options runtime --preserve-metadata=entitlements "$frameworks_path/Sparkle.framework/XPCServices/org.sparkle-project.Downloader.xpc"
+codesign --verbose --force --sign "$CODE_SIGN_IDENTITY" --options runtime --deep "$app_path"
 
 if ! spctl --verbose=4 --assess --type execute "${app_path}"; then
     echo "error: Signature will not be accepted by Gatekeeper!" 1>&2

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -164,7 +164,6 @@
 		B85F93E5255AE48000B54B68 /* NSPopUpButtonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85F93E4255AE48000B54B68 /* NSPopUpButtonExtensions.swift */; };
 		B8B9D6D323685C7400EAE65C /* FeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B9D6D223685C7400EAE65C /* FeedItem.swift */; };
 		F41CA694218F56140072F734 /* NSWorkspace+OpenWithMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = F41CA692218F56130072F734 /* NSWorkspace+OpenWithMenu.m */; };
-		F602CFBD26E25B040015D580 /* org.sparkle-project.InstallerLauncher.xpc in Copy XPC Services Bundles */ = {isa = PBXBuildFile; fileRef = F602CFBC26E25A370015D580 /* org.sparkle-project.InstallerLauncher.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F6094E331F10107800677D3B /* ExportAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6094E311F10107800677D3B /* ExportAccessoryViewController.swift */; };
 		F615824323834D6500D2BD41 /* FeedDiscoverer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F615824223834D6500D2BD41 /* FeedDiscoverer.swift */; };
 		F6164C591E32A6660086261C /* DisclosureView.m in Sources */ = {isa = PBXBuildFile; fileRef = F6164C581E32A6660086261C /* DisclosureView.m */; };
@@ -261,17 +260,6 @@
 			);
 			name = "Copy Shared Support Files";
 			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F602CFB826E246D90015D580 /* Copy XPC Services Bundles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 8;
-			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
-			dstSubfolderSpec = 16;
-			files = (
-				F602CFBD26E25B040015D580 /* org.sparkle-project.InstallerLauncher.xpc in Copy XPC Services Bundles */,
-			);
-			name = "Copy XPC Services Bundles";
-			runOnlyForDeploymentPostprocessing = 1;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -486,7 +474,6 @@
 		B8B9D6D223685C7400EAE65C /* FeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItem.swift; sourceTree = "<group>"; };
 		F41CA692218F56130072F734 /* NSWorkspace+OpenWithMenu.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSWorkspace+OpenWithMenu.m"; sourceTree = "<group>"; };
 		F41CA693218F56140072F734 /* NSWorkspace+OpenWithMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSWorkspace+OpenWithMenu.h"; sourceTree = "<group>"; };
-		F602CFBC26E25A370015D580 /* org.sparkle-project.InstallerLauncher.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; name = "org.sparkle-project.InstallerLauncher.xpc"; path = "DerivedData/Vienna/SourcePackages/artifacts/Sparkle/XPCServices/org.sparkle-project.InstallerLauncher.xpc"; sourceTree = SOURCE_ROOT; };
 		F6052438209EFD680000D4E1 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		F60642751F1A314700A12272 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/MainWindowController.strings; sourceTree = "<group>"; };
 		F60642761F1A314900A12272 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/MainWindowController.strings; sourceTree = "<group>"; };
@@ -1223,7 +1210,6 @@
 				43501F8E165DBCCB0018EDB7 /* DSClickableURLTextField */,
 				F6F2CD1A25853B5F003C80D3 /* NSURL+CaminoExtensions */,
 				3A171BDF210B551A00B80FBB /* TRVSURLSessionOperation */,
-				F602CFBC26E25A370015D580 /* org.sparkle-project.InstallerLauncher.xpc */,
 			);
 			path = External;
 			sourceTree = "<group>";
@@ -1681,7 +1667,6 @@
 				8D15AC300486D014006FF6A4 /* Sources */,
 				8D15AC330486D014006FF6A4 /* Frameworks */,
 				8D15AC2B0486D014006FF6A4 /* Resources */,
-				F602CFB826E246D90015D580 /* Copy XPC Services Bundles */,
 				AAEF2001085D685900A0E675 /* Copy Shared Support Files */,
 				3A5482F6168F5C1700887F91 /* Configure Sparkle */,
 			);

--- a/Vienna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vienna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/sparkle-project/Sparkle",
         "state": {
           "branch": null,
-          "revision": "ed9fa9bfed015d5e3446a966c13bcda3d4537e08",
-          "version": "2.0.0-beta.3"
+          "revision": "0d43f88a83698e57d93789831318b053767d1560",
+          "version": "2.0.0-beta.4"
         }
       }
     ]

--- a/Vienna/Info.plist
+++ b/Vienna/Info.plist
@@ -140,6 +140,8 @@
 	<string>Vienna.sdef</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<false/>
 	<key>SUPublicDSAKeyFile</key>
 	<string>SparkleDSAPublicKey.pem</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
The XPC services are now bundled in the Sparkle framework.

Since Vienna is not using sandboxing, the SUEnableInstallerLauncherService key is set to false.

@barijaona I made the necessary changes to Notarize.sh, which I was unable to test myself. I am not entire sure if the explicit signing is needed, but I added them just in case (see https://sparkle-project.org/documentation/sandboxing/).