### PR TITLE
Async corrections

### DIFF
--- a/Vienna/Sources/Main window/ArticleView.m
+++ b/Vienna/Sources/Main window/ArticleView.m
@@ -285,6 +285,10 @@ self.converter = [[WebViewArticleConverter alloc] init];
 	//TODO
 }
 
+- (void)closeTab {
+    [NSException raise:@"ForbiddenMethodException" format:@"Cannot close article tab"];
+}
+
 - (void)activateAddressBar {
     //TODO
 }

--- a/Vienna/Sources/Main window/BrowserPane.m
+++ b/Vienna/Sources/Main window/BrowserPane.m
@@ -752,6 +752,10 @@
     [self handleStopLoading:nil];
 }
 
+- (void)closeTab {
+    [self stopLoadingTab]; //remainder will be handeled by dealloc
+}
+
 - (void)activateWebView {
     [self.window makeFirstResponder:self.webPane];
 }

--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -72,23 +72,23 @@ extension BrowserTab: RSSSource {
     }
 
     func handleNavigationEndRss(success: Bool) {
+        guard success else {
+            self.rssUrls = []
+            return
+        }
         // use javascript to detect RSS feed link
         // TODO: deal with multiple links
-        let group = DispatchGroup()
-        group.enter()
-        self.webView.evaluateJavaScript(BrowserTab.extractRssLinkScript) { result, error in
-            if error == nil, let result = result as? [String] {
-                // RSS feed link(s) detected
-                self.rssUrls = result.compactMap { URL(string: $0 as String) }
-            } else {
-                // error or no rss url available
-                self.rssUrls = []
+        waitForAsyncExecution { finishHandler in
+            self.webView.evaluateJavaScript(BrowserTab.extractRssLinkScript) { result, error in
+                if error == nil, let result = result as? [String] {
+                    // RSS feed link(s) detected
+                    self.rssUrls = result.compactMap { URL(string: $0 as String) }
+                } else {
+                    // error or no rss url available
+                    self.rssUrls = []
+                }
+                finishHandler()
             }
-            group.leave()
-        }
-
-        group.notify(queue: DispatchQueue.main) {
-            self.updateAddressBarButtons()
         }
     }
 }

--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -78,7 +78,7 @@ extension BrowserTab: RSSSource {
         }
         // use javascript to detect RSS feed link
         // TODO: deal with multiple links
-        waitForAsyncExecution { finishHandler in
+        waitForAsyncExecution(until: DispatchTime.now() + DispatchTimeInterval.milliseconds(200)) { finishHandler in
             self.webView.evaluateJavaScript(BrowserTab.extractRssLinkScript) { result, error in
                 if error == nil, let result = result as? [String] {
                     // RSS feed link(s) detected

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -128,7 +128,7 @@ class CustomWKWebView: WKWebView {
 
         let javascriptString = "var x = {contentHeight: document.body.scrollHeight, offsetY: window.scrollY}; x"
 
-        waitForAsyncExecution(until: DispatchTime.now() + DispatchTimeInterval.seconds(1)) { finishHandler in
+        waitForAsyncExecution(until: DispatchTime.now() + DispatchTimeInterval.milliseconds(200)) { finishHandler in
             self.evaluateJavaScript(javascriptString) { info, _ in
 
                 guard let info = info as? [String: Any] else {

--- a/Vienna/Sources/Main window/Tab.swift
+++ b/Vienna/Sources/Main window/Tab.swift
@@ -48,6 +48,8 @@ protocol Tab {
     func loadTab()
     func reloadTab()
     func stopLoadingTab()
+    /// prepare tab for being closed
+    func closeTab()
 
     // MARK: other actions
 

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -257,7 +257,7 @@ extension TabbedBrowserViewController: MMTabBarViewDelegate {
         guard let tab = tabViewItem.viewController as? Tab else {
             return
         }
-        tab.stopLoadingTab()
+        tab.closeTab()
     }
 
     func tabView(_ aTabView: NSTabView, selectOnClosing tabViewItem: NSTabViewItem) -> NSTabViewItem? {

--- a/Vienna/Sources/Main window/WebViewBrowser.m
+++ b/Vienna/Sources/Main window/WebViewBrowser.m
@@ -262,6 +262,7 @@
 {
 	//remove closing tab from tab order
 	[self.tabViewOrder removeObject:tabViewItem];
+    [(id<Tab>)tabViewItem.view closeTab];
 
 }
 


### PR DESCRIPTION
This is a correction for #1503 and #1516. They both introduced / corrected asynchronous code which has issues.

- #1503 might cause the JS callback run _after_ the address bar animation which might cause the RSS button to not show.
- #1516 frees the delegates in stopLoading, which might happen before the tab is released, thus it will stop working properly

Additionally, group.notify does nothing else than scheduling a block for after leaving the group, it does not block the calling thread. This can be done easier by just invoking `DispatchQueue.<main/global>.async { ... }` in the callback block.

I have reintroduced waitForAsyncExecution in the RSS button displaying method, and introduced a close() method in the tab protocol which can be used for breaking cyclic references like to the delegates. Additionally, I have introduced a proper "deadline" to waitForAsyncExecution (previously, it was called "deadline" but was actually a "delay").

I cannot test the changes on older systems. When I have finished this PR, it would be great if @barijaona could test it!