### PR TITLE
Rename a constant for consistency

### DIFF
--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -29,7 +29,7 @@
 @interface Database : NSObject
 
 extern NSNotificationName const VNADatabaseWillDeleteFolderNotification;
-extern NSNotificationName const VNAdatabaseDidDeleteFolderNotification;
+extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 
 @property(nonatomic) Folder * trashFolder;
 @property(nonatomic) Folder * searchFolder;

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -70,7 +70,7 @@ static NSInteger const VNACurrentDatabaseVersion = 23;
 @implementation Database
 
 NSNotificationName const VNADatabaseWillDeleteFolderNotification = @"Database Will Delete Folder";
-NSNotificationName const VNAdatabaseDidDeleteFolderNotification = @"Database Did Delete Folder";
+NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did Delete Folder";
 
 /*!
  *  initialise the Database object with a specific path
@@ -1084,7 +1084,7 @@ NSNotificationName const VNAdatabaseDidDeleteFolderNotification = @"Database Did
 	// Send the post-delete notification after we're finished. Note that the folder actually corresponding to
 	// each numFolder won't exist any more and the handlers need to be aware of this.
     for (numFolder in arrayOfFolderIds) {
-		[[NSNotificationCenter defaultCenter] vna_postNotificationOnMainThreadWithName:VNAdatabaseDidDeleteFolderNotification object:numFolder];
+		[[NSNotificationCenter defaultCenter] vna_postNotificationOnMainThreadWithName:VNADatabaseDidDeleteFolderNotification object:numFolder];
     }
 	
 	return result;

--- a/Vienna/Sources/Info panel/InfoPanelManager.m
+++ b/Vienna/Sources/Info panel/InfoPanelManager.m
@@ -59,7 +59,7 @@
 		controllerList = [[NSMutableDictionary alloc] initWithCapacity:10];
 		
 		NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
-		[nc addObserver:self selector:@selector(handleFolderDeleted:) name:VNAdatabaseDidDeleteFolderNotification object:nil];
+		[nc addObserver:self selector:@selector(handleFolderDeleted:) name:VNADatabaseDidDeleteFolderNotification object:nil];
 		[nc addObserver:self selector:@selector(handleFolderChange:) name:@"MA_Notify_FolderNameChanged" object:nil];
 		[nc addObserver:self selector:@selector(handleFolderChange:) name:@"MA_Notify_FoldersUpdated" object:nil];
 		[nc addObserver:self selector:@selector(handleFolderChange:) name:@"MA_Notify_LoadFullHTMLChange" object:nil];

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -140,7 +140,7 @@
 	[nc addObserver:self selector:@selector(handleFolderUpdate:) name:@"MA_Notify_FoldersUpdated" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderNameChange:) name:@"MA_Notify_FolderNameChanged" object:nil];
 	[nc addObserver:self selector:@selector(handleFolderAdded:) name:@"MA_Notify_FolderAdded" object:nil];
-	[nc addObserver:self selector:@selector(handleFolderDeleted:) name:VNAdatabaseDidDeleteFolderNotification object:nil];
+	[nc addObserver:self selector:@selector(handleFolderDeleted:) name:VNADatabaseDidDeleteFolderNotification object:nil];
 	[nc addObserver:self selector:@selector(handleFolderFontChange:) name:@"MA_Notify_FolderFontChange" object:nil];
 	[nc addObserver:self selector:@selector(handleShowFolderImagesChange:) name:@"MA_Notify_ShowFolderImages" object:nil];
 	[nc addObserver:self selector:@selector(handleAutoSortFoldersTreeChange:) name:@"MA_Notify_AutoSortFoldersTreeChange" object:nil];


### PR DESCRIPTION
All other constants use an uppercase letter after the VNA prefix.
Discrepancy was introduced by commit f917a77