### PR TITLE
Fix default method chosen in toolbar's search box

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1888,9 +1888,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)handleTabChange:(NSNotification *)nc
 {
-	NSView<BaseView> * newView = nc.object;
-	if (newView == ((NSView<BaseView> *)self.browser.primaryTab.view))
+	id<Tab> activeBrowserTab = self.browser.activeTab;
+	if (activeBrowserTab == nil)
 	{
+		//we are in the article view
 		if (self.selectedArticle == nil)
 			[self.mainWindow makeFirstResponder:self.foldersTree.mainView];
 		else
@@ -1898,14 +1899,13 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	}
 	else
 	{
-		BrowserPane * webPane = (BrowserPane *)newView;
-		[self.mainWindow makeFirstResponder:webPane.mainView];
+		[activeBrowserTab activateWebView];
 	}
 	[self updateStatusBarFilterButtonVisibility];
 	[self updateSearchPlaceholderAndSearchMethod];
 }
 
-/* handleTabChange
+/* handleTabCountChange
  * Handle a change in the number of tabs.
  */
 - (void)handleTabCountChange:(NSNotification *)nc

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -302,6 +302,10 @@ extension TabbedBrowserViewController: MMTabBarViewDelegate {
             tab?.loadTab()
         }
     }
+
+    func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "MA_Notify_TabChanged"), object: tabViewItem?.view)
+    }
 }
 
 // MARK: WKUIDelegate + BrowserContextMenuDelegate


### PR DESCRIPTION
Fix issue #1550

The new browser omitted to notify of a tab switch.
Update handling of the notification by AppController.
Also fix a comment.