### PR TITLE
Fix copy of articles in article list

### DIFF
--- a/Vienna/Sources/Main window/MessageListView.h
+++ b/Vienna/Sources/Main window/MessageListView.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 // TODO: Implement this in UnifiedDisplayView and make it non-optional
-- (BOOL)copyTableSelection:(NSArray *)rows
+- (BOOL)copyTableSelection:(NSIndexSet *)rowIndexes
               toPasteboard:(NSPasteboard *)pboard;
 
 @end

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -48,14 +48,7 @@
 	if (self.selectedRow >= 0)
 	{
 		NSIndexSet * selectedRowIndexes = self.selectedRowIndexes;
-		NSMutableArray *rows = [NSMutableArray arrayWithCapacity:selectedRowIndexes.count];
-		NSUInteger  rowIndex = selectedRowIndexes.firstIndex;
-		while (rowIndex != NSNotFound)
-		{
-			[rows addObject:@(rowIndex)];
-			rowIndex = [selectedRowIndexes indexGreaterThanIndex:rowIndex];
-		}
-		[self.delegate copyTableSelection:rows toPasteboard:NSPasteboard.generalPasteboard];
+		[self.delegate copyTableSelection:selectedRowIndexes toPasteboard:NSPasteboard.generalPasteboard];
 	}
 }
 


### PR DESCRIPTION
Fix MessageListView handing an NSArray while ArticleListView’s
‑copyTableSelection:toPasteboard: expects an NSIndexSet

Issue #1527