### PR TITLE
Make 'Bigger/Smaller Text' commands run with new browser

### DIFF
--- a/Vienna/Interfaces/Base.lproj/MainMenu.xib
+++ b/Vienna/Interfaces/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ViennaApp">
@@ -559,6 +559,14 @@ CA
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="1088">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Actual Size" keyEquivalent="0" id="OiG-oc-aVj">
+                                <attributedString key="userComments">
+                                    <fragment content="This string is also used in Safari"/>
+                                </attributedString>
+                                <connections>
+                                    <action selector="makeTextStandardSize:" target="-1" id="waF-l7-Sgn"/>
+                                </connections>
                             </menuItem>
                             <menuItem title="Bigger Text" keyEquivalent="+" id="1084">
                                 <connections>

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3426,6 +3426,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			[menuItem setTitle:NSLocalizedString(@"Show Filter Bar", nil)];
 		return isMainWindowVisible && isAnyArticleView;
 	}
+	else if (theAction == @selector(makeTextStandardSize:))
+	{
+        return self.browser.activeTab != nil;
+	}
 	else if (theAction == @selector(makeTextLarger:))
 	{
         return self.browser.activeTab != nil;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3428,11 +3428,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	}
 	else if (theAction == @selector(makeTextLarger:))
 	{
-        return self.browser.activeTab != nil; //TODO: this does not really work, remove.
+        return self.browser.activeTab != nil;
 	}
 	else if (theAction == @selector(makeTextSmaller:))
 	{
-        return self.browser.activeTab != nil; //TODO: this does not really work, remove.
+        return self.browser.activeTab != nil;
 	}
 	else if (theAction == @selector(doViewColumn:))
 	{

--- a/Vienna/Sources/Main window/ArticleCellView.m
+++ b/Vienna/Sources/Main window/ArticleCellView.m
@@ -133,6 +133,14 @@
 	return NO;
 }
 
+/* makeTextStandardSize
+ * Make webview text size smaller
+ */
+-(IBAction)makeTextStandardSize:(id)sender
+{
+	[articleView resetTextSize];
+}
+
 /* makeTextSmaller
  * Make webview text size smaller
  */

--- a/Vienna/Sources/Main window/ArticleContentView.swift
+++ b/Vienna/Sources/Main window/ArticleContentView.swift
@@ -18,6 +18,7 @@ protocol ArticleContentView {
 
     // MARK: visual settings
 
+    func resetTextSize()
     func decreaseTextSize()
     func increaseTextSize()
 

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -653,6 +653,14 @@
 	[self.controller.articleController goBack];
 }
 
+/* makeTextStandardSize
+ * Reset webview text size to default
+ */
+-(IBAction)makeTextStandardSize:(id)sender
+{
+	[articleText resetTextSize];
+}
+
 /* makeTextSmaller
  * Make webview text size smaller
  */

--- a/Vienna/Sources/Main window/ArticleView.h
+++ b/Vienna/Sources/Main window/ArticleView.h
@@ -38,8 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 // Public functions
 -(void)setArticles:(NSArray<Article *> *)articles;
 -(void)keyDown:(NSEvent *)theEvent;
-- (void)decreaseTextSize;
-- (void)increaseTextSize;
 
 @property (nonatomic) id<ArticleViewDelegate> listView;
 

--- a/Vienna/Sources/Main window/ArticleView.m
+++ b/Vienna/Sources/Main window/ArticleView.m
@@ -170,6 +170,14 @@ self.converter = [[WebViewArticleConverter alloc] init];
 #pragma mark -
 #pragma mark WebView methods overrides
 
+/* makeTextStandardSize
+ */
+-(IBAction)makeTextStandardSize:(id)sender
+{
+	[super makeTextStandardSize:sender];
+	[Preferences standardPreferences].textSizeMultiplier = self.textSizeMultiplier;
+}
+
 /* makeTextSmaller
  */
 -(IBAction)makeTextSmaller:(id)sender
@@ -243,6 +251,10 @@ self.converter = [[WebViewArticleConverter alloc] init];
 
 - (BOOL)forward {
 	return false;
+}
+
+- (void)resetTextSize {
+	[self makeTextStandardSize:self];
 }
 
 - (void)decreaseTextSize {

--- a/Vienna/Sources/Main window/BrowserPane.m
+++ b/Vienna/Sources/Main window/BrowserPane.m
@@ -724,15 +724,6 @@
 	return canGoForward;
 }
 
-- (void)decreaseTextSize {
-	[self.webPane makeTextSmaller:nil];
-}
-
-
-- (void)increaseTextSize {
-	[self.webPane makeTextLarger:nil];
-}
-
 - (void)printPage {
 	[self.webPane printDocument:self];
 }

--- a/Vienna/Sources/Main window/BrowserTab+Interface.swift
+++ b/Vienna/Sources/Main window/BrowserTab+Interface.swift
@@ -128,8 +128,11 @@ extension BrowserTab {
         if let addressBarContainer = addressBarContainer {
             let distanceToTop = addressBarContainer.isHidden ? 0 : addressBarContainer.frame.height
             if #available(macOS 10.14, *) {
-                webView._automaticallyAdjustsContentInsets = false
-                webView._topContentInset = distanceToTop
+                if webView.responds(to: #selector(setter: WKWebView._automaticallyAdjustsContentInsets)),
+                   webView.responds(to: #selector(setter: WKWebView._topContentInset)) {
+                    webView._automaticallyAdjustsContentInsets = false
+                    webView._topContentInset = distanceToTop
+                }
             } else {
                 self.webViewTopConstraint.constant = distanceToTop
             }

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -311,6 +311,11 @@ extension BrowserTab: Tab {
     }
 
     @objc
+    func resetTextSize() {
+        webView.makeTextStandardSize(self)
+    }
+
+    @objc
     func decreaseTextSize() {
         webView.makeTextSmaller(self)
     }

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -312,12 +312,12 @@ extension BrowserTab: Tab {
 
     @objc
     func decreaseTextSize() {
-        // TODO: apple has not implemented this on macOS. There is a property webkit-text-size-adjust on iOS though.
+        webView.makeTextSmaller(self)
     }
 
     @objc
     func increaseTextSize() {
-        // TODO: apple has not implemented this on macOS. There is a property webkit-text-size-adjust on iOS though.
+        webView.makeTextLarger(self)
     }
 
     func printPage() {

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -173,6 +173,50 @@ class CustomWKWebView: WKWebView {
         }
         return text
     }
+
+    // MARK: Text zoom
+
+    var canMakeTextLarger: Bool {
+        guard responds(to: #selector(getter: _supportsTextZoom)),
+              responds(to: #selector(setter: _textZoomFactor)),
+              _supportsTextZoom
+        else {
+            return false
+        }
+
+        return Float(_textZoomFactor) < 3.0
+    }
+
+    var canMakeTextSmaller: Bool {
+        guard responds(to: #selector(getter: _supportsTextZoom)),
+              responds(to: #selector(setter: _textZoomFactor)),
+              _supportsTextZoom
+        else {
+            return false
+        }
+
+        return Float(_textZoomFactor) > 0.5
+    }
+
+    // swiftlint:disable private_action
+    @IBAction func makeTextLarger(_ sender: Any?) {
+        guard canMakeTextLarger
+        else {
+            return
+        }
+
+        _textZoomFactor += 0.1
+    }
+
+    // swiftlint:disable private_action
+    @IBAction func makeTextSmaller(_ sender: Any?) {
+        guard canMakeTextSmaller
+        else {
+            return
+        }
+
+        _textZoomFactor -= 0.1
+    }
 }
 
 // MARK: context menu

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -195,6 +195,7 @@ class CustomWKWebView: WKWebView {
 
     var canMakeTextLarger: Bool {
         guard responds(to: #selector(getter: _supportsTextZoom)),
+              responds(to: #selector(getter: _textZoomFactor)),
               responds(to: #selector(setter: _textZoomFactor)),
               _supportsTextZoom
         else {
@@ -206,6 +207,7 @@ class CustomWKWebView: WKWebView {
 
     var canMakeTextSmaller: Bool {
         guard responds(to: #selector(getter: _supportsTextZoom)),
+              responds(to: #selector(getter: _textZoomFactor)),
               responds(to: #selector(setter: _textZoomFactor)),
               _supportsTextZoom
         else {

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -53,10 +53,15 @@ class CustomWKWebView: WKWebView {
         // preferences
         let prefs = configuration.preferences
         prefs.javaScriptCanOpenWindowsAutomatically = true
-        prefs._fullScreenEnabled = true
+
+        if prefs.responds(to: #selector(setter: WKPreferences._fullScreenEnabled)) {
+            prefs._fullScreenEnabled = true
+        }
 
         #if DEBUG
-        prefs._developerExtrasEnabled = true
+        if prefs.responds(to: #selector(setter: WKPreferences._developerExtrasEnabled)) {
+            prefs._developerExtrasEnabled = true
+        }
         #endif
 
         useJavaScriptObservation = Preferences.standard.observe(\.useJavaScript, options: [.initial, .new]) { _, change  in
@@ -65,8 +70,8 @@ class CustomWKWebView: WKWebView {
             }
             if #available(macOS 11, *) {
                 configuration.defaultWebpagePreferences.allowsContentJavaScript = newValue
-            } else {
-                 configuration._allowsJavaScriptMarkup = newValue
+            } else if configuration.responds(to: #selector(setter: WKWebViewConfiguration._allowsJavaScriptMarkup)) {
+                configuration._allowsJavaScriptMarkup = newValue
             }
         }
 

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -181,6 +181,18 @@ class CustomWKWebView: WKWebView {
 
     // MARK: Text zoom
 
+    // swiftlint:disable private_action
+    @IBAction func makeTextStandardSize(_ sender: Any?) {
+        guard responds(to: #selector(getter: _supportsTextZoom)),
+              responds(to: #selector(setter: _textZoomFactor)),
+              _supportsTextZoom
+        else {
+            return
+        }
+
+        _textZoomFactor = 1.0
+    }
+
     var canMakeTextLarger: Bool {
         guard responds(to: #selector(getter: _supportsTextZoom)),
               responds(to: #selector(setter: _textZoomFactor)),

--- a/Vienna/Sources/Main window/WKPreferences+Private.h
+++ b/Vienna/Sources/Main window/WKPreferences+Private.h
@@ -1,5 +1,5 @@
 //
-//  NSObject+WebKit_Private_h.h
+//  WKPreferences_Private.h
 //  Vienna
 //
 //  Copyright 2020 Tassilo Karge
@@ -19,8 +19,6 @@
 
 @import Foundation;
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface WKPreferences (Private)
 
 #ifdef DEBUG
@@ -30,5 +28,3 @@ NS_ASSUME_NONNULL_BEGIN
 @property (setter=_setFullScreenEnabled:, nonatomic) BOOL _fullScreenEnabled;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/WKWebView+Private.h
+++ b/Vienna/Sources/Main window/WKWebView+Private.h
@@ -26,6 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, setter=_setTopContentInset:) CGFloat _topContentInset;
 @property (nonatomic, setter=_setAutomaticallyAdjustsContentInsets:) BOOL _automaticallyAdjustsContentInsets;
 
+@property (readonly, nonatomic) BOOL _supportsTextZoom;
+@property (setter=_setTextZoomFactor:, nonatomic) double _textZoomFactor;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/WKWebView+Private.h
+++ b/Vienna/Sources/Main window/WKWebView+Private.h
@@ -19,16 +19,12 @@
 
 @import Foundation;
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface WKWebView (Private)
 
-@property (nonatomic, setter=_setTopContentInset:) CGFloat _topContentInset;
-@property (nonatomic, setter=_setAutomaticallyAdjustsContentInsets:) BOOL _automaticallyAdjustsContentInsets;
+@property (setter=_setTopContentInset:, nonatomic) CGFloat _topContentInset;
+@property (setter=_setAutomaticallyAdjustsContentInsets:, nonatomic) BOOL _automaticallyAdjustsContentInsets;
 
 @property (readonly, nonatomic) BOOL _supportsTextZoom;
 @property (setter=_setTextZoomFactor:, nonatomic) double _textZoomFactor;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/WKWebViewConfiguration+Private.h
+++ b/Vienna/Sources/Main window/WKWebViewConfiguration+Private.h
@@ -21,6 +21,8 @@
 
 @interface WKWebViewConfiguration (Private)
 
-@property (setter=_setAllowsJavaScriptMarkup:, nonatomic) BOOL _allowsJavaScriptMarkup;
+// This is implemented by WKWebpagePreferences.allowsContentJavaScript as of
+// macOS 11.
+@property (setter=_setAllowsJavaScriptMarkup:, nonatomic) BOOL _allowsJavaScriptMarkup NS_DEPRECATED_MAC(10.12, 11);
 
 @end

--- a/Vienna/Sources/Main window/WKWebViewConfiguration+Private.h
+++ b/Vienna/Sources/Main window/WKWebViewConfiguration+Private.h
@@ -19,12 +19,8 @@
 
 @import Foundation;
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface WKWebViewConfiguration (Private)
 
 @property (setter=_setAllowsJavaScriptMarkup:, nonatomic) BOOL _allowsJavaScriptMarkup;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -73,14 +73,6 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
         // TODO
     }
 
-    func makeTextSmaller(_ sender: Any) {
-        // TODO
-    }
-
-    func makeTextLarger(_ sender: Any) {
-        // TODO
-    }
-
     // MARK: gui
 
     override func activateAddressBar() {

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -79,6 +79,10 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
         load(URLRequest(url: URL.blank))
      }
 
+    func resetTextSize() {
+        makeTextStandardSize(self)
+    }
+
     func decreaseTextSize() {
         makeTextSmaller(self)
     }

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -48,6 +48,9 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
     @objc
     init(frame: NSRect) {
         super.init(frame: frame, configuration: WKWebViewConfiguration())
+        if responds(to: #selector(setter: _textZoomFactor)) {
+            _textZoomFactor = Preferences.standard.textSizeMultiplier
+        }
         contextMenuProvider = self
     }
 
@@ -89,6 +92,27 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
 
     func increaseTextSize() {
         makeTextLarger(self)
+    }
+
+    override func makeTextStandardSize(_ sender: Any?) {
+        super.makeTextStandardSize(sender)
+        if responds(to: #selector(getter: _textZoomFactor)) {
+            Preferences.standard.textSizeMultiplier = _textZoomFactor
+        }
+    }
+
+    override func makeTextLarger(_ sender: Any?) {
+        super.makeTextLarger(sender)
+        if responds(to: #selector(getter: _textZoomFactor)) {
+            Preferences.standard.textSizeMultiplier = _textZoomFactor
+        }
+    }
+
+    override func makeTextSmaller(_ sender: Any?) {
+        super.makeTextSmaller(sender)
+        if responds(to: #selector(getter: _textZoomFactor)) {
+            Preferences.standard.textSizeMultiplier = _textZoomFactor
+        }
     }
 
     // MARK: CustomWKUIDelegate

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -80,11 +80,11 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
      }
 
     func decreaseTextSize() {
-        // TODO
+        makeTextSmaller(self)
     }
 
     func increaseTextSize() {
-        // TODO
+        makeTextLarger(self)
     }
 
     // MARK: CustomWKUIDelegate


### PR DESCRIPTION
Use private APIs to make WKWebView based browser respond to 'View->Bigger Text'
and 'View->Smaller Text' menu commands.
Also:
- add various safety measures regarding use of private APIs,
- do some minor code cleanup.

Inspired by #1515, but updated to some protocol changes and simplified.
Solves issue #1478.
