### PR TITLE
Fix selector crash on version 3.8 beta 3

### DIFF
--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -92,11 +92,11 @@
 										  },
 								  MA_Field_Headlines: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Subject],
-										  @"selector": NSStringFromSelector(@selector(vna_numericCompare:))
+										  @"selector": NSStringFromSelector(@selector(vna_caseInsensitiveNumericCompare:))
 										  },
 								  MA_Field_Subject: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Subject],
-										  @"selector": NSStringFromSelector(@selector(vna_numericCompare:))
+										  @"selector": NSStringFromSelector(@selector(vna_caseInsensitiveNumericCompare:))
 										  },
 								  MA_Field_Link: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Link],

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -32,6 +32,7 @@
 #import "Article.h"
 #import "Folder.h"
 #import "BackTrackArray.h"
+#import "StringExtensions.h"
 #import "Vienna-Swift.h"
 
 @interface ArticleController ()
@@ -63,51 +64,51 @@
 		articleSortSpecifiers = @{
 								  MA_Field_Folder: @{
 										  @"key": @"containingFolder.name",
-										  @"selector": @"compare:"
+										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Read: @{
 										  @"key": @"isRead",
-										  @"selector": @"compare:"
+										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Flagged: @{
 										  @"key": @"isFlagged",
-										  @"selector": @"compare:"
+										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Comments: @{
 										  @"key": @"hasComments",
-										  @"selector": @"compare:"
+										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Date: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Date],
-										  @"selector": @"compare:"
+										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Author: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Author],
-										  @"selector": @"caseInsensitiveCompare:"
+										  @"selector": NSStringFromSelector(@selector(caseInsensitiveCompare:))
 										  },
 								  MA_Field_Headlines: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Subject],
-										  @"selector": @"numericCompare:"
+										  @"selector": NSStringFromSelector(@selector(vna_numericCompare:))
 										  },
 								  MA_Field_Subject: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Subject],
-										  @"selector": @"numericCompare:"
+										  @"selector": NSStringFromSelector(@selector(vna_numericCompare:))
 										  },
 								  MA_Field_Link: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Link],
-										  @"selector": @"caseInsensitiveCompare:"
+										  @"selector": NSStringFromSelector(@selector(caseInsensitiveCompare:))
 										  },
 								  MA_Field_Summary: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Summary],
-										  @"selector": @"caseInsensitiveCompare:"
+										  @"selector": NSStringFromSelector(@selector(caseInsensitiveCompare:))
 										  },
 								  MA_Field_HasEnclosure: @{
 										  @"key": @"hasEnclosure",
-										  @"selector": @"compare:"
+										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Enclosure: @{
 										  @"key": @"enclosure",
-										  @"selector": @"caseInsensitiveCompare:"
+										  @"selector": NSStringFromSelector(@selector(caseInsensitiveCompare:))
 										  },
 								  };
 

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -87,6 +87,7 @@ extern NSString * const kMA_Notify_UseJavaScriptChange;
 -(void)setString:(NSString *)value forKey:(NSString *)defaultName;
 -(void)setArray:(NSArray *)value forKey:(NSString *)defaultName;
 -(void)setObject:(id)value forKey:(NSString *)defaultName;
+- (void)removeObjectForKey:(NSString *)defaultName;
 
 // Path to default database
 -(NSString *)defaultDatabase;
@@ -161,7 +162,7 @@ extern NSString * const kMA_Notify_UseJavaScriptChange;
 @property (nonatomic) NSInteger articleListFontSize;
 
 // Article list sort descriptors
-@property (nonatomic, copy) NSArray *articleSortDescriptors;
+@property (null_resettable, nonatomic, copy) NSArray *articleSortDescriptors;
 
 // Automatically sort folders tree
 @property (nonatomic) NSInteger foldersTreeSortMethod;

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -31,6 +31,7 @@
 #import "NSKeyedArchiver+Compatibility.h"
 #import "NSKeyedUnarchiver+Compatibility.h"
 #import "SearchMethod.h"
+#import "StringExtensions.h"
 #import "Vienna-Swift.h"
 
 #define VNA_LOG os_log_create("--", "Preferences")
@@ -118,7 +119,7 @@ static Preferences * _standardPreferences = nil;
 		{
 			preferencesPath = nil;
 			userPrefs = [NSUserDefaults standardUserDefaults];
-            [self migratePreferences];
+            [self migrateEncodedPreferences];
 			[userPrefs registerDefaults:defaults];
 			
 			// Application-specific folder locations
@@ -157,7 +158,7 @@ static Preferences * _standardPreferences = nil;
 				preferencesPath = [preferencesPath stringByAppendingString:@".plist"];
 			}
 			userPrefs = [[NSMutableDictionary alloc] initWithDictionary:defaults];
-            [self migratePreferences];
+            [self migrateEncodedPreferences];
 			if (preferencesPath != nil)
 				[userPrefs addEntriesFromDictionary:[NSDictionary dictionaryWithContentsOfFile:preferencesPath]];
             
@@ -324,15 +325,31 @@ static Preferences * _standardPreferences = nil;
 	return [defaultValues copy];
 }
 
-- (void)migratePreferences
+- (void)migrateEncodedPreferences
 {
+    // Users who ran a beta build of Vienna might have invalid sort descriptors.
+    if ([self integerForKey:MAPref_HighestViennaVersionRun] == 7775) {
+        [userPrefs removeObjectForKey:MAPref_ArticleListSortOrders];
+    }
+
     if ([userPrefs objectForKey:MAPref_Deprecated_ArticleListSortOrders]) {
         NSData *archive = [self objectForKey:MAPref_Deprecated_ArticleListSortOrders];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        NSArray *sortDescriptors = [NSUnarchiver unarchiveObjectWithData:archive];
+        NSMutableArray *sortDescriptors = [[NSUnarchiver unarchiveObjectWithData:archive] mutableCopy];
 #pragma clang diagnostic pop
-        NSData *keyedArchive = [NSKeyedArchiver vna_archivedDataWithRootObject:sortDescriptors
+        // Two sort descriptors have a selector that was renamed.
+        [sortDescriptors enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+            NSSortDescriptor *descriptor = obj;
+            if ([NSStringFromSelector(descriptor.selector) isEqualToString:@"numericCompare:"]) {
+                descriptor = [NSSortDescriptor sortDescriptorWithKey:descriptor.key
+                                                           ascending:descriptor.ascending
+                                                            selector:@selector(vna_numericCompare:)];
+                [sortDescriptors replaceObjectAtIndex:idx
+                                           withObject:descriptor];
+            }
+        }];
+        NSData *keyedArchive = [NSKeyedArchiver vna_archivedDataWithRootObject:[sortDescriptors copy]
                                                          requiringSecureCoding:YES];
         [self setObject:keyedArchive forKey:MAPref_ArticleListSortOrders];
         [userPrefs removeObjectForKey:MAPref_Deprecated_ArticleListSortOrders];

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -341,7 +341,7 @@ static Preferences * _standardPreferences = nil;
             if ([NSStringFromSelector(descriptor.selector) isEqualToString:@"numericCompare:"]) {
                 descriptor = [NSSortDescriptor sortDescriptorWithKey:descriptor.key
                                                            ascending:descriptor.ascending
-                                                            selector:@selector(vna_numericCompare:)];
+                                                            selector:@selector(vna_caseInsensitiveNumericCompare:)];
                 [sortDescriptors replaceObjectAtIndex:idx
                                            withObject:descriptor];
             }

--- a/Vienna/Sources/Shared/StringExtensions.h
+++ b/Vienna/Sources/Shared/StringExtensions.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)vna_stringByAppendingURLComponent:(nullable NSString *)newComponent;
 - (BOOL)vna_hasCharacter:(char)ch;
 @property (readonly, nonatomic) NSString *vna_convertStringToValidPath;
-- (NSComparisonResult)vna_numericCompare:(NSString *)aString;
+- (NSComparisonResult)vna_caseInsensitiveNumericCompare:(NSString *)string;
 @property (readonly, nonatomic) NSString *vna_normalised;
 @property (readonly, nonatomic) NSString *vna_baseURL;
 @property (readonly, nonatomic) NSString *vna_host;

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -689,12 +689,12 @@ static NSMutableDictionary * entityMap = nil;
 	return (url && url.host) ? url.host : self;
 }
 
-/* numericCompare
+/* vna_caseInsensitiveNumericCompare
  * Compares two strings using both case insensitivity and numeric comparisons.
  */
--(NSComparisonResult)vna_numericCompare:(NSString *)aString
+- (NSComparisonResult)vna_caseInsensitiveNumericCompare:(NSString *)string
 {
-	return [self compare:aString options:NSCaseInsensitiveSearch|NSNumericSearch];
+    return [self compare:string options:NSCaseInsensitiveSearch | NSNumericSearch];
 }
 
 


### PR DESCRIPTION
Fixes #1559 

I have also added a fix for users who ran beta 3 already. If that doesn’t work, then 
`defaults delete uk.co.opencommunity.vienna2 ArticleListSortOrders` must be used.