### PR TITLE
Remove floodmagazine.com from demo feeds list and update other URLs

### DIFF
--- a/Vienna/Resources/DemoFeeds.plist
+++ b/Vienna/Resources/DemoFeeds.plist
@@ -10,32 +10,32 @@
 	<key>BBC World News</key>
 	<dict>
 		<key>URL</key>
-		<string>http://feeds.bbci.co.uk/news/world/rss.xml</string>
+		<string>https://feeds.bbci.co.uk/news/world/rss.xml</string>
 	</dict>
 	<key>Six Colors: Apple, technology, and other stuff from Jason Snell and Friends</key>
 	<dict>
 		<key>URL</key>
-		<string>http://feedpress.me/sixcolors</string>
+		<string>https://feedpress.me/sixcolors</string>
 	</dict>
 	<key>Astronomy Picture of the Day</key>
 	<dict>
 		<key>URL</key>
-		<string>http://apod.nasa.gov/apod.rss</string>
+		<string>https://apod.nasa.gov/apod.rss</string>
 	</dict>
 	<key>Amusing Planet</key>
 	<dict>
 		<key>URL</key>
-		<string>http://www.amusingplanet.com/feeds/posts/default?alt=rss</string>
+		<string>https://www.amusingplanet.com/feeds/posts/default?alt=rss</string>
 	</dict>
 	<key>Nomadic Matt</key>
 	<dict>
 		<key>URL</key>
-		<string>http://www.nomadicmatt.com/feed/</string>
+		<string>https://www.nomadicmatt.com/feed/</string>
 	</dict>
 	<key>Kottke</key>
 	<dict>
 		<key>URL</key>
-		<string>http://feeds.kottke.org/main</string>
+		<string>https://feeds.kottke.org/main</string>
 	</dict>
 	<key>Cool Hunting</key>
 	<dict>
@@ -50,22 +50,17 @@
 	<key>A Working Library</key>
 	<dict>
 		<key>URL</key>
-		<string>http://aworkinglibrary.com/feed/index.xml</string>
+		<string>https://aworkinglibrary.com/feed/index.xml</string>
 	</dict>
 	<key>It&apos;s Nice That</key>
 	<dict>
 		<key>URL</key>
-		<string>http://feeds2.feedburner.com/itsnicethat/SlXC</string>
-	</dict>
-	<key>Flood Magazine music</key>
-	<dict>
-		<key>URL</key>
-		<string>http://floodmagazine.com/category/content/music/feed/</string>
+		<string>https://feeds2.feedburner.com/itsnicethat/SlXC</string>
 	</dict>
 	<key>Ars Technica</key>
 	<dict>
 		<key>URL</key>
-		<string>http://feeds.arstechnica.com/arstechnica/index/</string>
+		<string>https://feeds.arstechnica.com/arstechnica/index/</string>
 	</dict>
 	<key>Vienna Developer Blog</key>
 	<dict>
@@ -75,7 +70,7 @@
 	<key>Vienna Support</key>
 	<dict>
 		<key>URL</key>
-		<string>http://forums.cocoaforge.com/feed.php?f=18</string>
+		<string>https://forums.cocoaforge.com/app.php/feed/forum/18</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
The feed seems to be discontinued. The URL is invalid and I cannot locate the feed on the site anymore.