### PR TITLE
Show additional feed details in feed credentials dialog

### DIFF
--- a/Vienna/Interfaces/Base.lproj/FeedCredentials.xib
+++ b/Vienna/Interfaces/Base.lproj/FeedCredentials.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16C68" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -10,6 +10,9 @@
             <connections>
                 <outlet property="cancelButton" destination="8" id="19"/>
                 <outlet property="credentialsWindow" destination="5" id="23"/>
+                <outlet property="disclosureView" destination="9sn-iE-dLB" id="Urt-Pt-0Ss"/>
+                <outlet property="feedTextField" destination="wqz-QH-Upv" id="bJE-yV-u2w"/>
+                <outlet property="feedURLTextField" destination="OQl-Ef-CsF" id="z5D-to-BNf"/>
                 <outlet property="okButton" destination="14" id="20"/>
                 <outlet property="password" destination="11" id="18"/>
                 <outlet property="promptString" destination="10" id="22"/>
@@ -19,78 +22,110 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" tabbingMode="disallowed" id="5" userLabel="FeedCredentials" customClass="NSPanel">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" tabbingMode="disallowed" id="5" userLabel="FeedCredentials" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
-            <rect key="contentRect" x="513" y="337" width="420" height="227"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <rect key="contentRect" x="513" y="337" width="420" height="316"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="6">
-                <rect key="frame" x="0.0" y="0.0" width="420" height="227"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <rect key="frame" x="0.0" y="0.0" width="420" height="328"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                        <rect key="frame" x="20" y="143" width="64" height="64"/>
+                        <rect key="frame" x="20" y="244" width="64" height="64"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="64" id="W6s-zh-EAq"/>
                             <constraint firstAttribute="width" constant="64" id="nMT-GZ-fCY"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="NSApplicationIcon" id="36"/>
                     </imageView>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="308" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                        <rect key="frame" x="90" y="173" width="312" height="34"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Access to %@ requires you to provide log in credentials" id="34">
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                        <rect key="frame" x="90" y="276" width="312" height="32"/>
+                        <textFieldCell key="cell" title="Access to %@ requires you to provide log in credentials" id="34">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="308" translatesAutoresizingMaskIntoConstraints="NO" id="15">
-                        <rect key="frame" x="90" y="123" width="312" height="42"/>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="15">
+                        <rect key="frame" x="90" y="226" width="312" height="42"/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="The user name and password you provide will be remembered for the next time you refresh this subscription." id="39">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="180" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                        <rect key="frame" x="90" y="96" width="66" height="17"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Name:" id="33">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
+                        <rect key="frame" x="90" y="200" width="66" height="16"/>
+                        <textFieldCell key="cell" title="Name:" id="33">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7">
-                        <rect key="frame" x="162" y="93" width="238" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" usesSingleLineMode="YES" id="31">
+                    <textField verticalHuggingPriority="750" contentType="username" translatesAutoresizingMaskIntoConstraints="NO" id="7">
+                        <rect key="frame" x="162" y="197" width="238" height="21"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="31">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <connections>
                             <outlet property="nextKeyView" destination="11" id="26"/>
                         </connections>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="180" translatesAutoresizingMaskIntoConstraints="NO" id="13">
-                        <rect key="frame" x="90" y="64" width="66" height="17"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Password:" id="37">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="13">
+                        <rect key="frame" x="90" y="169" width="66" height="16"/>
+                        <textFieldCell key="cell" title="Password:" id="37">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="11" customClass="NSSecureTextField">
-                        <rect key="frame" x="162" y="61" width="238" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" usesSingleLineMode="YES" id="35">
+                    <textField verticalHuggingPriority="750" contentType="password" translatesAutoresizingMaskIntoConstraints="NO" id="11" customClass="NSSecureTextField">
+                        <rect key="frame" x="162" y="166" width="238" height="21"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="35">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <connections>
                             <outlet property="nextKeyView" destination="8" id="27"/>
                         </connections>
                     </textField>
+                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="2" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="749" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OKO-EZ-1BK">
+                        <rect key="frame" x="20" y="144" width="52" height="14"/>
+                        <subviews>
+                            <button identifier="DisclosureButton" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ajh-AN-cfv">
+                                <rect key="frame" x="0.0" y="1" width="13" height="13"/>
+                                <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="only" alignment="left" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Im6-Xi-AOk">
+                                    <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="smallSystem"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleDisclosure:" target="-2" id="yql-vp-PaS"/>
+                                    <binding destination="Yfg-hF-3g0" name="value" keyPath="values.ShowDetailsOnFeedCredentialsDialog" id="0vW-zk-flf"/>
+                                </connections>
+                            </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pvk-KA-dyh">
+                                <rect key="frame" x="13" y="0.0" width="41" height="14"/>
+                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Details" id="VkU-PT-7wf">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <visibilityPriorities>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                        </visibilityPriorities>
+                        <customSpacing>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                        </customSpacing>
+                    </stackView>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                        <rect key="frame" x="247" y="13" width="82" height="32"/>
+                        <rect key="frame" x="262" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="32">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -104,7 +139,7 @@ Gw
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="14">
-                        <rect key="frame" x="329" y="13" width="77" height="32"/>
+                        <rect key="frame" x="336" y="13" width="71" height="32"/>
                         <buttonCell key="cell" type="push" title="Log In" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="38">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -117,17 +152,122 @@ DQ
                             <outlet property="nextKeyView" destination="7" id="28"/>
                         </connections>
                     </button>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="9sn-iE-dLB" customClass="DisclosureView">
+                        <rect key="frame" x="20" y="40" width="380" height="100"/>
+                        <subviews>
+                            <box titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-yM-Ahw">
+                                <rect key="frame" x="-3" y="16" width="386" height="86"/>
+                                <view key="contentView" id="fXd-ic-goi">
+                                    <rect key="frame" x="3" y="3" width="380" height="80"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" spacing="6" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="d2M-JM-t3a">
+                                            <rect key="frame" x="20" y="44" width="340" height="16"/>
+                                            <subviews>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rd5-NV-NK3">
+                                                    <rect key="frame" x="-2" y="0.0" width="40" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Feed:" id="yIO-aF-1Qg">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <connections>
+                                                        <accessibilityConnection property="title" destination="wqz-QH-Upv" id="7U8-Wn-h73"/>
+                                                    </connections>
+                                                </textField>
+                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="900" translatesAutoresizingMaskIntoConstraints="NO" id="wqz-QH-Upv">
+                                                    <rect key="frame" x="40" y="0.0" width="302" height="16"/>
+                                                    <textFieldCell key="cell" selectable="YES" id="lze-Q8-HPT">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <connections>
+                                                        <accessibilityConnection property="link" destination="rd5-NV-NK3" id="v5z-AS-0zB"/>
+                                                    </connections>
+                                                </textField>
+                                            </subviews>
+                                            <visibilityPriorities>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                            </visibilityPriorities>
+                                            <customSpacing>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                            </customSpacing>
+                                        </stackView>
+                                        <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" spacing="6" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="mms-Rm-ILc">
+                                            <rect key="frame" x="20" y="20" width="340" height="16"/>
+                                            <subviews>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CyA-Vh-Jr4">
+                                                    <rect key="frame" x="-2" y="0.0" width="40" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="URL:" id="Lvs-Rd-GZy">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <connections>
+                                                        <accessibilityConnection property="title" destination="OQl-Ef-CsF" id="uYg-cV-X6b"/>
+                                                    </connections>
+                                                </textField>
+                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="900" translatesAutoresizingMaskIntoConstraints="NO" id="OQl-Ef-CsF">
+                                                    <rect key="frame" x="40" y="0.0" width="302" height="16"/>
+                                                    <textFieldCell key="cell" selectable="YES" id="Rq5-ed-ltH">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <connections>
+                                                        <accessibilityConnection property="link" destination="CyA-Vh-Jr4" id="ok8-a4-qPb"/>
+                                                    </connections>
+                                                </textField>
+                                            </subviews>
+                                            <visibilityPriorities>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                            </visibilityPriorities>
+                                            <customSpacing>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                            </customSpacing>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="mms-Rm-ILc" firstAttribute="leading" secondItem="fXd-ic-goi" secondAttribute="leading" constant="20" symbolic="YES" id="15V-3f-IQS"/>
+                                        <constraint firstItem="rd5-NV-NK3" firstAttribute="width" secondItem="CyA-Vh-Jr4" secondAttribute="width" id="5z2-Xd-bdL"/>
+                                        <constraint firstAttribute="trailing" secondItem="mms-Rm-ILc" secondAttribute="trailing" constant="20" symbolic="YES" id="KZK-VO-Cjn"/>
+                                        <constraint firstAttribute="trailing" secondItem="d2M-JM-t3a" secondAttribute="trailing" constant="20" symbolic="YES" id="OYu-Xq-Jpr"/>
+                                        <constraint firstItem="d2M-JM-t3a" firstAttribute="leading" secondItem="fXd-ic-goi" secondAttribute="leading" constant="20" symbolic="YES" id="VL2-gr-bXM"/>
+                                        <constraint firstAttribute="bottom" secondItem="mms-Rm-ILc" secondAttribute="bottom" constant="20" symbolic="YES" id="mxj-aE-POj"/>
+                                        <constraint firstItem="mms-Rm-ILc" firstAttribute="top" secondItem="d2M-JM-t3a" secondAttribute="bottom" constant="8" symbolic="YES" id="v1B-O7-mud"/>
+                                        <constraint firstItem="d2M-JM-t3a" firstAttribute="top" secondItem="fXd-ic-goi" secondAttribute="top" constant="20" symbolic="YES" id="vqv-jA-xhc"/>
+                                    </constraints>
+                                </view>
+                            </box>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="Qas-yM-Ahw" secondAttribute="trailing" id="UbF-xU-F0e"/>
+                            <constraint firstAttribute="bottom" secondItem="Qas-yM-Ahw" secondAttribute="bottom" priority="600" constant="20" symbolic="YES" id="hOz-a5-2Ds"/>
+                            <constraint firstItem="Qas-yM-Ahw" firstAttribute="top" secondItem="9sn-iE-dLB" secondAttribute="top" id="oph-sr-4bq"/>
+                            <constraint firstItem="Qas-yM-Ahw" firstAttribute="leading" secondItem="9sn-iE-dLB" secondAttribute="leading" id="plG-fx-I46"/>
+                        </constraints>
+                        <connections>
+                            <outlet property="disclosedView" destination="Qas-yM-Ahw" id="J5e-Ca-vGC"/>
+                        </connections>
+                    </customView>
                 </subviews>
                 <constraints>
                     <constraint firstItem="12" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="2n8-8e-qz8"/>
                     <constraint firstAttribute="bottom" secondItem="14" secondAttribute="bottom" constant="20" symbolic="YES" id="4Zw-wH-yfI"/>
+                    <constraint firstItem="9sn-iE-dLB" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="4gv-gu-8oZ"/>
                     <constraint firstAttribute="trailing" secondItem="7" secondAttribute="trailing" constant="20" symbolic="YES" id="6hH-9n-Bdn"/>
+                    <constraint firstItem="OKO-EZ-1BK" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="7ox-zE-uPv"/>
                     <constraint firstItem="10" firstAttribute="top" secondItem="6" secondAttribute="top" constant="20" symbolic="YES" id="8ad-sz-z3i"/>
                     <constraint firstAttribute="trailing" secondItem="10" secondAttribute="trailing" constant="20" symbolic="YES" id="8sd-Yv-tYs"/>
                     <constraint firstItem="15" firstAttribute="top" secondItem="10" secondAttribute="bottom" constant="8" symbolic="YES" id="Buc-Yx-X9H"/>
                     <constraint firstItem="13" firstAttribute="leading" secondItem="9" secondAttribute="leading" id="EeZ-9u-adR"/>
                     <constraint firstItem="12" firstAttribute="top" secondItem="6" secondAttribute="top" constant="20" symbolic="YES" id="FwU-f3-p8A"/>
-                    <constraint firstItem="14" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="20" id="IBZ-vo-Zxl"/>
+                    <constraint firstItem="OKO-EZ-1BK" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="8" symbolic="YES" id="GuW-vZ-wyL"/>
                     <constraint firstItem="8" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="IVn-mN-lc7"/>
                     <constraint firstAttribute="trailing" secondItem="11" secondAttribute="trailing" constant="20" symbolic="YES" id="Ked-JH-FiA"/>
                     <constraint firstItem="11" firstAttribute="baseline" secondItem="13" secondAttribute="baseline" id="L4q-yW-2a0"/>
@@ -138,22 +278,27 @@ DQ
                     <constraint firstItem="10" firstAttribute="leading" secondItem="12" secondAttribute="trailing" constant="8" symbolic="YES" id="T2A-Gq-mhm"/>
                     <constraint firstItem="13" firstAttribute="width" secondItem="9" secondAttribute="width" id="VkY-HK-XCl"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="12" secondAttribute="trailing" constant="8" symbolic="YES" id="WuK-Sj-1bE"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OKO-EZ-1BK" secondAttribute="trailing" constant="20" symbolic="YES" id="XtZ-m2-zQb"/>
                     <constraint firstItem="11" firstAttribute="top" secondItem="7" secondAttribute="bottom" constant="10" symbolic="YES" id="Zmc-JF-qlh"/>
                     <constraint firstItem="7" firstAttribute="baseline" secondItem="9" secondAttribute="baseline" id="eLc-Lt-KrO"/>
+                    <constraint firstItem="9sn-iE-dLB" firstAttribute="top" secondItem="OKO-EZ-1BK" secondAttribute="bottom" constant="4" id="eLu-Mi-6zW"/>
                     <constraint firstItem="8" firstAttribute="baseline" secondItem="14" secondAttribute="baseline" id="kDF-RC-cTF"/>
                     <constraint firstAttribute="trailing" secondItem="15" secondAttribute="trailing" constant="20" symbolic="YES" id="p9j-zK-yil"/>
                     <constraint firstItem="11" firstAttribute="leading" secondItem="13" secondAttribute="trailing" constant="8" symbolic="YES" id="pMI-30-Whb"/>
                     <constraint firstItem="14" firstAttribute="leading" secondItem="8" secondAttribute="trailing" constant="12" symbolic="YES" id="plF-aW-5B9"/>
                     <constraint firstAttribute="trailing" secondItem="14" secondAttribute="trailing" constant="20" symbolic="YES" id="yIW-Ji-faT"/>
+                    <constraint firstAttribute="trailing" secondItem="9sn-iE-dLB" secondAttribute="trailing" constant="20" symbolic="YES" id="yPz-UM-ik9"/>
+                    <constraint firstItem="14" firstAttribute="top" secondItem="9sn-iE-dLB" secondAttribute="bottom" id="ycd-5H-IQw"/>
                 </constraints>
             </view>
             <connections>
                 <outlet property="initialFirstResponder" destination="7" id="16"/>
             </connections>
-            <point key="canvasLocation" x="121" y="161.5"/>
+            <point key="canvasLocation" x="121" y="230"/>
         </window>
+        <userDefaultsController representsSharedInstance="YES" id="Yfg-hF-3g0"/>
     </objects>
     <resources>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
     </resources>
 </document>

--- a/Vienna/Interfaces/Base.lproj/FeedCredentials.xib
+++ b/Vienna/Interfaces/Base.lproj/FeedCredentials.xib
@@ -8,15 +8,14 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="FeedCredentials">
             <connections>
-                <outlet property="cancelButton" destination="8" id="19"/>
                 <outlet property="credentialsWindow" destination="5" id="23"/>
                 <outlet property="disclosureView" destination="9sn-iE-dLB" id="Urt-Pt-0Ss"/>
                 <outlet property="feedTextField" destination="wqz-QH-Upv" id="bJE-yV-u2w"/>
                 <outlet property="feedURLTextField" destination="OQl-Ef-CsF" id="z5D-to-BNf"/>
+                <outlet property="messageTextField" destination="10" id="22"/>
                 <outlet property="okButton" destination="14" id="20"/>
-                <outlet property="password" destination="11" id="18"/>
-                <outlet property="promptString" destination="10" id="22"/>
-                <outlet property="userName" destination="7" id="17"/>
+                <outlet property="passwordTextField" destination="11" id="18"/>
+                <outlet property="userNameTextField" destination="7" id="17"/>
                 <outlet property="window" destination="5" id="21"/>
             </connections>
         </customObject>
@@ -134,7 +133,7 @@ Gw
 </string>
                         </buttonCell>
                         <connections>
-                            <action selector="doCancelButton:" target="-2" id="24"/>
+                            <action selector="cancel:" target="-2" id="24"/>
                             <outlet property="nextKeyView" destination="14" id="29"/>
                         </connections>
                     </button>
@@ -148,7 +147,7 @@ DQ
 </string>
                         </buttonCell>
                         <connections>
-                            <action selector="doOKButton:" target="-2" id="25"/>
+                            <action selector="updateCredentials:" target="-2" id="25"/>
                             <outlet property="nextKeyView" destination="7" id="28"/>
                         </connections>
                     </button>

--- a/Vienna/Sources/Alerts/FeedCredentials.h
+++ b/Vienna/Sources/Alerts/FeedCredentials.h
@@ -22,21 +22,9 @@
 
 @class Folder;
 
-@interface FeedCredentials : NSWindowController
-{
-	IBOutlet NSWindow * credentialsWindow;
-	IBOutlet NSButton * cancelButton;
-	IBOutlet NSButton * okButton;
-	IBOutlet NSSecureTextField * password;
-	IBOutlet NSTextField * userName;
-	IBOutlet NSTextField * promptString;
-	Folder * folder;
-}
+@interface FeedCredentials : NSWindowController <NSTextFieldDelegate>
 
-@property NSArray * topObjects;
+- (void)requestCredentialsInWindow:(NSWindow *)window
+                         forFolder:(Folder *)folder;
 
-// Public functions
--(void)credentialsForFolder:(NSWindow *)window folder:(Folder *)folder;
--(IBAction)doCancelButton:(id)sender;
--(IBAction)doOKButton:(id)sender;
 @end

--- a/Vienna/Sources/Alerts/FeedCredentials.m
+++ b/Vienna/Sources/Alerts/FeedCredentials.m
@@ -19,12 +19,23 @@
 //
 
 #import "FeedCredentials.h"
+
 #import "StringExtensions.h"
 #import "Folder.h"
 #import "Database.h"
+#import "DisclosureView.h"
+#import "Constants.h"
+#import "Preferences.h"
 
+NSString * const MAPref_ShowDetailsOnFeedCredentialsDialog = @"ShowDetailsOnFeedCredentialsDialog";
+
+static NSUserInterfaceItemIdentifier const VNADisclosureButtonIdentifier = @"DisclosureButton";
 
 @interface FeedCredentials ()
+
+@property (weak, nonatomic) IBOutlet DisclosureView *disclosureView;
+@property (weak, nonatomic) IBOutlet NSTextField *feedTextField;
+@property (weak, nonatomic) IBOutlet NSTextField *feedURLTextField;
 
 -(void)enableOKButton;
 
@@ -70,7 +81,20 @@
 	// Fill out any existing values.
 	userName.stringValue = folder.username;
 	password.stringValue = folder.password;
-	
+
+    // Fill out feed details.
+    self.feedTextField.stringValue = folder.name;
+    self.feedURLTextField.stringValue = folder.feedURL;
+
+    // Show or hide the details view.
+    Preferences *preferences = Preferences.standardPreferences;
+    BOOL showDetails = [preferences boolForKey:MAPref_ShowDetailsOnFeedCredentialsDialog];
+    if (showDetails) {
+        [self.disclosureView disclose:NO];
+    } else {
+        [self.disclosureView collapse:NO];
+    }
+
 	// Set the focus
 	[credentialsWindow makeFirstResponder:(folder.username.vna_isBlank) ? userName : password];
 
@@ -132,4 +156,19 @@
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
+- (IBAction)toggleDisclosure:(NSButton *)sender
+{
+    if (![sender.identifier isEqualToString:VNADisclosureButtonIdentifier]) {
+        return;
+    }
+
+    BOOL shouldShowDetails = sender.state == NSControlStateValueOn;
+    if (shouldShowDetails) {
+        [self.disclosureView disclose:YES];
+    } else {
+        [self.disclosureView collapse:YES];
+    }
+}
+
 @end

--- a/Vienna/Sources/Alerts/FeedCredentials.m
+++ b/Vienna/Sources/Alerts/FeedCredentials.m
@@ -20,71 +20,76 @@
 
 #import "FeedCredentials.h"
 
-#import "StringExtensions.h"
-#import "Folder.h"
+#import "Constants.h"
 #import "Database.h"
 #import "DisclosureView.h"
-#import "Constants.h"
+#import "Folder.h"
 #import "Preferences.h"
+#import "StringExtensions.h"
 
 NSString * const MAPref_ShowDetailsOnFeedCredentialsDialog = @"ShowDetailsOnFeedCredentialsDialog";
 
+static NSNibName const VNAFeedCredentialsNibName = @"FeedCredentials";
 static NSUserInterfaceItemIdentifier const VNADisclosureButtonIdentifier = @"DisclosureButton";
 
 @interface FeedCredentials ()
 
+// MARK: Outlets
+
+@property (weak, nonatomic) IBOutlet NSWindow *credentialsWindow;
+@property (weak, nonatomic) IBOutlet NSTextField *messageTextField;
+@property (weak, nonatomic) IBOutlet NSTextField *userNameTextField;
+@property (weak, nonatomic) IBOutlet NSSecureTextField *passwordTextField;
 @property (weak, nonatomic) IBOutlet DisclosureView *disclosureView;
 @property (weak, nonatomic) IBOutlet NSTextField *feedTextField;
 @property (weak, nonatomic) IBOutlet NSTextField *feedURLTextField;
+@property (weak, nonatomic) IBOutlet NSButton *okButton;
 
--(void)enableOKButton;
+// MARK: Storage
+
+@property NSArray *topObjects;
+@property Folder *folder;
 
 @end
 
 @implementation FeedCredentials
 
-/* init
- * Initialise an instance of ourselves with the specified database
- */
--(instancetype)init
+// MARK: Initialization
+
+- (void)requestCredentialsInWindow:(NSWindow *)window forFolder:(Folder *)folder
 {
-	if ((self = [super init]) != nil)
-	{
-		folder = nil;
-	}
-	return self;
-}
+    if (!self.credentialsWindow) {
+        NSArray *objects;
+        [NSBundle.mainBundle loadNibNamed:VNAFeedCredentialsNibName
+                                    owner:self
+                          topLevelObjects:&objects];
+        self.topObjects = objects;
+        self.userNameTextField.delegate = self;
+    }
 
-/* credentialsForFolder
- * Obtains the credentials for the specified folder.
- */
--(void)credentialsForFolder:(NSWindow *)window folder:(Folder *)aFolder
-{
-	if (credentialsWindow == nil)
-	{
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleTextDidChange:) name:NSControlTextDidChangeNotification object:userName];
-		NSArray * objects;
-		[[NSBundle bundleForClass:[self class]] loadNibNamed:@"FeedCredentials" owner:self topLevelObjects:&objects];
-		self.topObjects = objects;
-	}
+    // Retain the folder as we need it to update the
+    // username and/or password.
+    self.folder = folder;
 
-	// Retain the folder as we need it to update the
-	// username and/or password.
-	folder = aFolder;
+    // Show the feed URL in the prompt so the user knows which site credentials
+    // are being requested. (We don't use [folder name] here as that is likely
+    // to be "Untitled Folder" mostly).
+    NSURL *secureURL = [NSURL URLWithString:self.folder.feedURL];
+    NSString *prompt =
+        [NSString stringWithFormat:NSLocalizedString(
+                                       @"The subscription for \"%@\" requires "
+                                       @"a user name and password for access.",
+                                       nil),
+                                   secureURL.host];
+    self.messageTextField.stringValue = prompt;
 
-	// Show the feed URL in the prompt so the user knows which site credentials are being
-	// requested. (We don't use [folder name] here as that is likely to be "Untitled Folder" mostly).
-	NSURL * secureURL = [NSURL URLWithString:folder.feedURL];
-	NSString * prompt = [NSString stringWithFormat:NSLocalizedString(@"The subscription for \"%@\" requires a user name and password for access.", nil), secureURL.host];
-	promptString.stringValue = prompt;
-
-	// Fill out any existing values.
-	userName.stringValue = folder.username;
-	password.stringValue = folder.password;
+    // Fill out any existing values.
+    self.userNameTextField.stringValue = self.folder.username;
+    self.passwordTextField.stringValue = self.folder.password;
 
     // Fill out feed details.
-    self.feedTextField.stringValue = folder.name;
-    self.feedURLTextField.stringValue = folder.feedURL;
+    self.feedTextField.stringValue = self.folder.name;
+    self.feedURLTextField.stringValue = self.folder.feedURL;
 
     // Show or hide the details view.
     Preferences *preferences = Preferences.standardPreferences;
@@ -95,67 +100,15 @@ static NSUserInterfaceItemIdentifier const VNADisclosureButtonIdentifier = @"Dis
         [self.disclosureView collapse:NO];
     }
 
-	// Set the focus
-	[credentialsWindow makeFirstResponder:(folder.username.vna_isBlank) ? userName : password];
+    // Set the focus
+    [self.credentialsWindow makeFirstResponder:self.folder.username.vna_isBlank ? self.userNameTextField
+                                                                                : self.passwordTextField];
 
-	[self enableOKButton];
-    [window beginSheet:credentialsWindow completionHandler:nil];
+    self.okButton.enabled = !self.userNameTextField.stringValue.vna_isBlank;
+    [window beginSheet:self.credentialsWindow completionHandler:nil];
 }
 
-/* doCancelButton
- * Respond to the Cancel button being clicked. Just close the UI.
- */
--(IBAction)doCancelButton:(id)sender
-{
-	[credentialsWindow.sheetParent endSheet:credentialsWindow];
-	[credentialsWindow orderOut:self];
-
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_CancelAuthenticationForFolder" object:folder];
-}
-
-/* doOKButton
- * Respond to the OK button being clicked.
- */
--(IBAction)doOKButton:(id)sender
-{
-	NSString * usernameString = (userName.stringValue).vna_trimmed;
-	NSString * passwordString = password.stringValue;
-
-	Database * db = [Database sharedManager];
-	[db setFolderUsername:folder.itemId newUsername:usernameString];
-	folder.password = passwordString;
-	
-	[credentialsWindow.sheetParent endSheet:credentialsWindow];
-	[credentialsWindow orderOut:self];
-	
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_GotAuthenticationForFolder" object:folder];
-}
-
-/* handleTextDidChange [delegate]
- * This function is called when the contents of the input field is changed.
- * We disable the Subscribe button if the input fields are empty or enable it otherwise.
- */
--(void)handleTextDidChange:(NSNotification *)aNotification
-{
-	[self enableOKButton];
-}
-
-/* enableSaveButton
- * Enable or disable the Save button depending on whether or not there is a non-blank
- * string in the input fields.
- */
--(void)enableOKButton
-{
-	okButton.enabled = !(userName.stringValue).vna_isBlank;
-}
-
-/* dealloc
- * Clean up after ourself.
- */
--(void)dealloc
-{
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
-}
+// MARK: Actions
 
 - (IBAction)toggleDisclosure:(NSButton *)sender
 {
@@ -169,6 +122,41 @@ static NSUserInterfaceItemIdentifier const VNADisclosureButtonIdentifier = @"Dis
     } else {
         [self.disclosureView collapse:YES];
     }
+}
+
+- (IBAction)updateCredentials:(id)sender
+{
+    NSString *usernameString = self.userNameTextField.stringValue.vna_trimmed;
+    NSString *passwordString = self.passwordTextField.stringValue;
+
+    Database *database = Database.sharedManager;
+    [database setFolderUsername:self.folder.itemId newUsername:usernameString];
+    self.folder.password = passwordString;
+
+    [self.credentialsWindow.sheetParent endSheet:self.credentialsWindow];
+    [self.credentialsWindow orderOut:self];
+
+    [NSNotificationCenter.defaultCenter postNotificationName:@"MA_Notify_GotAuthenticationForFolder"
+                                                      object:self.folder];
+}
+
+- (IBAction)cancel:(id)sender
+{
+    [self.credentialsWindow.sheetParent endSheet:self.credentialsWindow];
+    [self.credentialsWindow orderOut:self];
+
+    [NSNotificationCenter.defaultCenter postNotificationName:@"MA_Notify_CancelAuthenticationForFolder"
+                                                      object:self.folder];
+}
+
+// MARK: - NSTextFieldDelegate
+
+// This function is called when the contents of the input field is changed. We
+// disable the Subscribe button if the input fields are empty or enable it
+// otherwise.
+- (void)controlTextDidChange:(NSNotification *)obj
+{
+    self.okButton.enabled = !self.userNameTextField.stringValue.vna_isBlank;
 }
 
 @end

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -340,7 +340,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
     // next one.
     if (authQueue.count > 0 && !credentialsController.window.visible) {
         Folder * folder = authQueue[0];
-        [credentialsController credentialsForFolder:NSApp.mainWindow folder:folder];
+        [credentialsController requestCredentialsInWindow:NSApp.mainWindow forFolder:folder];
     }
 }
 

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -304,6 +304,7 @@ static Preferences * _standardPreferences = nil;
 	defaultValues[MAPref_LastViennaVersionRun] = @0;
 	defaultValues[MAPref_ShouldSaveFeedSource] = boolYes;
 	defaultValues[MAPref_ShouldSaveFeedSourceBackup] = boolNo;
+    defaultValues[MAPref_ShowDetailsOnFeedCredentialsDialog] = boolNo;
 
     // Archives
     defaultValues[MAPref_ArticleListFont] = [NSKeyedArchiver vna_archivedDataWithRootObject:defaultFont

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -82,6 +82,7 @@ extern NSString * MAPref_SyncingAppKey;
 extern NSString * MAPref_AlwaysAcceptBetas;
 extern NSString * MAPref_UserAgentName;
 extern NSString *const MAPref_UseRelativeDates;
+extern NSString * const MAPref_ShowDetailsOnFeedCredentialsDialog;
 
 // Deprecated defaults keys
 extern NSString *const MAPref_Deprecated_ArticleListFont;


### PR DESCRIPTION
Resolves #1094

This adds a disclosure triangle to the feed credentials dialog that shows the feed name and feed URL in case it is needed to disambiguate the feed.

<img width="430" alt="Screenshot 2022-05-25 at 01 32 44" src="https://user-images.githubusercontent.com/15073177/170150881-2d566613-0db2-4d63-94d7-0e66f6e2f7b7.png">
<img width="430" alt="Screenshot 2022-05-25 at 01 33 03" src="https://user-images.githubusercontent.com/15073177/170150886-22dabdef-588f-41a4-9144-2e5e33c7454b.png">

