### PR TITLE
Integrate folder search into main search field

### DIFF
--- a/Vienna Help/Resources/cs.lproj/keyboard.html
+++ b/Vienna Help/Resources/cs.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/en.lproj/keyboard.html
+++ b/Vienna Help/Resources/en.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/eu.lproj/keyboard.html
+++ b/Vienna Help/Resources/eu.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/gl.lproj/keyboard.html
+++ b/Vienna Help/Resources/gl.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/ja.lproj/keyboard.html
+++ b/Vienna Help/Resources/ja.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/ko.lproj/keyboard.html
+++ b/Vienna Help/Resources/ko.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/pt-BR.lproj/keyboard.html
+++ b/Vienna Help/Resources/pt-BR.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/pt.lproj/keyboard.html
+++ b/Vienna Help/Resources/pt.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/ru.lproj/keyboard.html
+++ b/Vienna Help/Resources/ru.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/sv.lproj/keyboard.html
+++ b/Vienna Help/Resources/sv.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/tr.lproj/keyboard.html
+++ b/Vienna Help/Resources/tr.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/uk.lproj/keyboard.html
+++ b/Vienna Help/Resources/uk.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Help/Resources/zh-Hans.lproj/keyboard.html
+++ b/Vienna Help/Resources/zh-Hans.lproj/keyboard.html
@@ -32,7 +32,7 @@ menus. To see a contextual menu, press the Control key and click the item.</p>
   </tr>
   <tr>
     <td>h</td>
-    <td>Puts the focus on the search articles field.</td>
+    <td>Puts the focus on the search field.</td>
   </tr>
   <tr>
     <td>k</td>

--- a/Vienna Tests/UnarchiverTests.swift
+++ b/Vienna Tests/UnarchiverTests.swift
@@ -90,7 +90,7 @@ class UnarchiverTests: XCTestCase {
     }
 
     func testUnarchivingSearchMethod() throws {
-        let method = try XCTUnwrap(SearchMethod.allArticles())
+        let method = try XCTUnwrap(SearchMethod.allArticles)
 
         // Note: SearchMethod has never supported NSArchiver, thus no testing for it needed.
 

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1411,7 +1411,6 @@
 		F6A7EA581F1CE60100BD4450 /* Folder list */ = {
 			isa = PBXGroup;
 			children = (
-				F628DFE21ED2698A00FACFD3 /* FilterView.swift */,
 				4350286B165DE9DF0018EDB7 /* FoldersTree.h */,
 				4350286C165DE9DF0018EDB7 /* FoldersTree.m */,
 				793C95311C42A0DD00984D4E /* FoldersFilterable.h */,
@@ -1449,6 +1448,7 @@
 				4350287C165DE9DF0018EDB7 /* ProgressTextCell.m */,
 				4350288D165DE9DF0018EDB7 /* UnifiedDisplayView.h */,
 				4350288E165DE9DF0018EDB7 /* UnifiedDisplayView.m */,
+				F628DFE21ED2698A00FACFD3 /* FilterView.swift */,
 			);
 			name = "Article list";
 			sourceTree = "<group>";

--- a/Vienna/Interfaces/Base.lproj/MainMenu.xib
+++ b/Vienna/Interfaces/Base.lproj/MainMenu.xib
@@ -19,6 +19,7 @@
         <menu systemMenu="main" id="29">
             <items>
                 <menuItem title="Vienna" id="56">
+                    <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Vienna" systemMenu="apple" id="57">
                         <items>
                             <menuItem title="About Vienna" id="58">
@@ -27,9 +28,7 @@
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="I3y-xZ-6an"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="196">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="196"/>
                             <menuItem title="Preferences…" keyEquivalent="," id="129">
                                 <attributedString key="userComments">
                                     <fragment>
@@ -41,13 +40,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem title="Check for Updates" id="1104">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="checkForUpdates:" target="LzF-8y-hiG" id="1176"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="143">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="143"/>
                             <menuItem title="Empty Trash" id="961">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 CA
@@ -63,15 +61,12 @@ CA
                                     <action selector="reindexDatabase:" target="-1" id="BWa-1g-krh"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="962">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="962"/>
                             <menuItem title="Services" id="131">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Services" systemMenu="services" id="130"/>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="144">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="144"/>
                             <menuItem title="Hide Vienna" keyEquivalent="h" id="134">
                                 <connections>
                                     <action selector="hide:" target="-1" id="eb5-m4-c32"/>
@@ -84,13 +79,12 @@ CA
                                 </connections>
                             </menuItem>
                             <menuItem title="Show All" id="150">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="unhideAllApplications:" target="-1" id="EHd-yF-Sbp"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="149">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="149"/>
                             <menuItem title="Quit Vienna" keyEquivalent="q" id="136">
                                 <connections>
                                     <action selector="terminate:" target="-1" id="A3o-k6-T9E"/>
@@ -118,9 +112,7 @@ CA
                                     <action selector="newGroupFolder:" target="-1" id="daB-kl-f5f"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="576">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="576"/>
                             <menuItem title="Open Web Location…" keyEquivalent="l" id="1101">
                                 <connections>
                                     <action selector="openWebLocation:" target="-1" id="c2j-R2-mtx"/>
@@ -131,9 +123,7 @@ CA
                                     <action selector="newTab:" target="-1" id="joQ-qq-nUH"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1102">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1102"/>
                             <menuItem title="Close Window" id="935">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -152,9 +142,7 @@ CA
                                     <action selector="closeAllTabs:" target="-1" id="Qet-88-kSV"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="289">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="289"/>
                             <menuItem title="Refresh All Subscriptions" keyEquivalent="r" id="406">
                                 <connections>
                                     <action selector="refreshAllSubscriptions:" target="-1" id="j9p-gU-Bnc"/>
@@ -188,9 +176,7 @@ CA
                                     <action selector="cancelAllRefreshes:" target="-1" id="46q-rR-uT3"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="591">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="591"/>
                             <menuItem title="Import Subscriptions…" id="780">
                                 <connections>
                                     <action selector="importSubscriptions:" target="-1" id="VmM-Gh-s5C"/>
@@ -201,9 +187,7 @@ CA
                                     <action selector="exportSubscriptions:" target="-1" id="phN-Qb-tH6"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1004">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1004"/>
                             <menuItem title="Page Setup…" keyEquivalent="P" id="77">
                                 <connections>
                                     <action selector="runPageLayout:" target="-1" id="87"/>
@@ -231,9 +215,7 @@ CA
                                     <action selector="redo:" target="-1" id="178"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="156">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="156"/>
                             <menuItem title="Cut" keyEquivalent="x" id="160">
                                 <connections>
                                     <action selector="cut:" target="-1" id="175"/>
@@ -259,9 +241,7 @@ CA
                                     <action selector="selectAll:" target="-1" id="179"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="174">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="174"/>
                             <menuItem title="Find" id="168">
                                 <menu key="submenu" title="Find" id="159">
                                     <items>
@@ -458,9 +438,7 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="390">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="390"/>
                             <menuItem title="Article List" keyEquivalent="y" id="Rs9-r3-soc">
                                 <connections>
                                     <action selector="viewArticlesTab:" target="-1" id="p4V-jV-gaL"/>
@@ -471,9 +449,7 @@ CA
                                     <action selector="viewNextUnread:" target="-1" id="zjw-pE-qp9"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1026">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1026"/>
                             <menuItem title="Stop Reloading Page" keyEquivalent="." id="1027">
                                 <connections>
                                     <action selector="stopReloadingPage:" target="-1" id="8co-E2-z9R"/>
@@ -485,9 +461,7 @@ CA
                                     <action selector="reloadPage:" target="-1" id="2Pe-tj-QfU"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="498">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="498"/>
                             <menuItem title="Layout" id="1108">
                                 <menu key="submenu" title="Layout" id="1109">
                                     <items>
@@ -570,9 +544,7 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1088">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1088"/>
                             <menuItem title="Actual Size" keyEquivalent="0" id="OiG-oc-aVj">
                                 <attributedString key="userComments">
                                     <fragment content="This string is also used in Safari"/>
@@ -591,9 +563,7 @@ CA
                                     <action selector="makeTextSmaller:" target="-1" id="1142"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="829">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="829"/>
                             <menuItem title="Back" keyEquivalent="[" id="422">
                                 <connections>
                                     <action selector="goBack:" target="-1" id="boc-Iz-ltd"/>
@@ -604,9 +574,7 @@ CA
                                     <action selector="goForward:" target="-1" id="W9b-gw-hWo"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1256">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1256"/>
                             <menuItem title="Hide Toolbar" id="1258">
                                 <connections>
                                     <action selector="toggleToolbarShown:" target="-1" id="1262"/>
@@ -617,9 +585,7 @@ CA
                                     <action selector="runToolbarCustomizationPalette:" target="-1" id="1263"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1260">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1260"/>
                             <menuItem title="Show Filter Bar" keyEquivalent="B" id="1325">
                                 <connections>
                                     <action selector="showHideFilterBar:" target="-1" id="WfC-Sk-kRK"/>
@@ -687,9 +653,7 @@ CA
                                     <action selector="getInfo:" target="-1" id="xhQ-n2-HGI"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1185">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1185"/>
                             <menuItem title="Unsubscribe" id="1408">
                                 <connections>
                                     <action selector="unsubscribeFeed:" target="-1" id="XJs-2M-kEa"/>
@@ -708,9 +672,7 @@ CA
                                     <action selector="useWebPageForArticles:" target="-1" id="nQY-bA-CAo"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1412">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1412"/>
                             <menuItem title="Skip Folder" keyEquivalent="S" id="1186">
                                 <connections>
                                     <action selector="skipFolder:" target="-1" id="Q0o-vd-qHh"/>
@@ -727,9 +689,7 @@ CA
                                     <action selector="markAllSubscriptionsRead:" target="-1" id="pFB-HD-Zss"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1190">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1190"/>
                             <menuItem title="Open Subscription Home Page" id="1191">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -778,9 +738,7 @@ CA
                                     <action selector="restoreMessage:" target="-1" id="Pvj-jE-Oiq"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="308">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="308"/>
                             <menuItem title="Open Article Page" id="1040">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -827,6 +785,7 @@ CA
                     </menu>
                 </menuItem>
                 <menuItem title="Window" id="19">
+                    <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Window" systemMenu="window" id="24">
                         <items>
                             <menuItem title="Minimize" keyEquivalent="m" id="23">
@@ -835,13 +794,12 @@ CA
                                 </connections>
                             </menuItem>
                             <menuItem title="Zoom" id="197">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="performZoom:" target="-1" id="198"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="92">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="92"/>
                             <menuItem title="Previous Tab" keyEquivalent="" id="1008">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
@@ -854,9 +812,7 @@ CA
                                     <action selector="nextTab:" target="-1" id="dkJ-sH-L2U"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1077">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="1077"/>
                             <menuItem title="Activity Window" keyEquivalent="0" id="402">
                                 <connections>
                                     <action selector="toggleActivityViewer:" target="-1" id="Q19-do-Grz"/>
@@ -872,10 +828,9 @@ CA
                                     <action selector="showDownloadsWindow:" target="-1" id="JdX-7A-Jxj"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="403">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="403"/>
                             <menuItem title="Bring All to Front" id="5">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="arrangeInFront:" target="-1" id="39"/>
                                 </connections>
@@ -896,9 +851,7 @@ CA
                                     <action selector="keyboardShortcutsHelp:" target="-1" id="3jK-u8-f0Y"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="931">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="931"/>
                             <menuItem title="Vienna Web Site" id="929">
                                 <connections>
                                     <action selector="openHomePage:" target="-1" id="QcX-Jg-MIJ"/>

--- a/Vienna/Interfaces/Base.lproj/MainMenu.xib
+++ b/Vienna/Interfaces/Base.lproj/MainMenu.xib
@@ -265,6 +265,13 @@ CA
                             <menuItem title="Find" id="168">
                                 <menu key="submenu" title="Find" id="159">
                                     <items>
+                                        <menuItem title="Search Articles" keyEquivalent="f" id="1327">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="setFocusToSearchField:" target="-1" id="1po-bJ-a0K"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="1328"/>
                                         <menuItem title="Find…" tag="1" keyEquivalent="f" id="154">
                                             <connections>
                                                 <action selector="localPerformFindPanelAction:" target="-1" id="NUj-Gm-lhM"/>
@@ -660,14 +667,6 @@ CA
                 <menuItem title="Folder" id="1177">
                     <menu key="submenu" title="Folder" id="1178">
                         <items>
-                            <menuItem title="Search Articles" id="1327">
-                                <connections>
-                                    <action selector="setFocusToSearchField:" target="-1" id="1po-bJ-a0K"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="1328">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
                             <menuItem title="Edit…" keyEquivalent="E" id="1180">
                                 <connections>
                                     <action selector="editFolder:" target="-1" id="2Im-E6-9HS"/>

--- a/Vienna/Interfaces/Base.lproj/MainMenu.xib
+++ b/Vienna/Interfaces/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ViennaApp">
@@ -245,13 +245,6 @@ CA
                             <menuItem title="Find" id="168">
                                 <menu key="submenu" title="Find" id="159">
                                     <items>
-                                        <menuItem title="Search Articles" keyEquivalent="f" id="1327">
-                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
-                                            <connections>
-                                                <action selector="setFocusToSearchField:" target="-1" id="1po-bJ-a0K"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem isSeparatorItem="YES" id="1328"/>
                                         <menuItem title="Find…" tag="1" keyEquivalent="f" id="154">
                                             <connections>
                                                 <action selector="localPerformFindPanelAction:" target="-1" id="NUj-Gm-lhM"/>

--- a/Vienna/Interfaces/Base.lproj/MainWindowController.xib
+++ b/Vienna/Interfaces/Base.lproj/MainWindowController.xib
@@ -32,167 +32,134 @@
             <rect key="contentRect" x="302" y="347" width="942" height="625"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <value key="minSize" type="size" width="700" height="350"/>
-            <view key="contentView" wantsLayer="YES" misplaced="YES" id="2">
+            <view key="contentView" wantsLayer="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="942" height="625"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <splitView autosaveName="" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="993">
-                        <rect key="frame" x="0.0" y="22" width="942" height="597"/>
+                        <rect key="frame" x="0.0" y="22" width="942" height="603"/>
                         <subviews>
-                            <view misplaced="YES" id="PG8-8Y-Lzt">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="597"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <subviews>
-                                    <visualEffectView blendingMode="behindWindow" material="sidebar" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="o3u-Zs-gsz">
-                                        <rect key="frame" x="0.0" y="567" width="288" height="29"/>
-                                        <subviews>
-                                            <searchField wantsLayer="YES" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CJo-vt-zIx">
-                                                <rect key="frame" x="5" y="5" width="278" height="19"/>
-                                                <searchFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" placeholderString="Search for folders" bezelStyle="round" sendsWholeSearchString="YES" recentsAutosaveName="filterStrings" id="lhy-4c-asJ">
-                                                    <font key="font" metaFont="smallSystem"/>
-                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    <connections>
-                                                        <action selector="searchUsingTreeFilter:" target="-1" id="pGo-ma-Cyc"/>
-                                                    </connections>
-                                                </searchFieldCell>
-                                            </searchField>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="CJo-vt-zIx" firstAttribute="top" secondItem="o3u-Zs-gsz" secondAttribute="top" constant="5" id="kTM-Re-UeS"/>
-                                            <constraint firstAttribute="bottom" secondItem="CJo-vt-zIx" secondAttribute="bottom" constant="5" id="nWB-gh-fLw"/>
-                                            <constraint firstItem="CJo-vt-zIx" firstAttribute="leading" secondItem="o3u-Zs-gsz" secondAttribute="leading" constant="5" id="ucW-1x-D1F"/>
-                                            <constraint firstAttribute="trailing" secondItem="CJo-vt-zIx" secondAttribute="trailing" constant="5" id="vAZ-Il-h0U"/>
-                                        </constraints>
-                                    </visualEffectView>
-                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8uX-2t-Ik7">
-                                        <rect key="frame" x="0.0" y="-1" width="288" height="568"/>
-                                        <clipView key="contentView" drawsBackground="NO" id="QAa-Gc-i1V">
-                                            <rect key="frame" x="0.0" y="0.0" width="288" height="568"/>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="8uX-2t-Ik7">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="603"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <clipView key="contentView" drawsBackground="NO" id="QAa-Gc-i1V">
+                                    <rect key="frame" x="0.0" y="0.0" width="288" height="603"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" autosaveName="outViewer" rowHeight="24" viewBased="YES" indentationPerLevel="13" outlineTableColumn="xXs-dn-GMc" id="Kk7-ax-B3r" customClass="FolderView">
+                                            <rect key="frame" x="0.0" y="0.0" width="288" height="603"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" autosaveName="outViewer" rowHeight="24" viewBased="YES" indentationPerLevel="13" outlineTableColumn="xXs-dn-GMc" id="Kk7-ax-B3r" customClass="FolderView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="288" height="568"/>
-                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                    <size key="intercellSpacing" width="3" height="0.0"/>
-                                                    <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                                    <tableColumns>
-                                                        <tableColumn identifier="folderColumns" width="256" minWidth="16" maxWidth="1000" id="xXs-dn-GMc">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" id="xSe-Hs-fQp">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <tableCellView identifier="FeedListCellView" id="SfX-xE-qxf" customClass="VNAFeedListCellView">
-                                                                    <rect key="frame" x="11" y="0.0" width="265" height="18"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <size key="intercellSpacing" width="3" height="0.0"/>
+                                            <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="folderColumns" width="256" minWidth="16" maxWidth="1000" id="xXs-dn-GMc">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" id="xSe-Hs-fQp">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView identifier="FeedListCellView" id="SfX-xE-qxf" customClass="VNAFeedListCellView">
+                                                            <rect key="frame" x="11" y="0.0" width="265" height="18"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <imageView wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="N4h-ph-608">
+                                                                    <rect key="frame" x="-1" y="0.0" width="20" height="20"/>
+                                                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="a3L-k0-Hh3"/>
+                                                                </imageView>
+                                                                <textField identifier="TextField" horizontalHuggingPriority="249" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JQW-he-OfP">
+                                                                    <rect key="frame" x="20" y="1" width="180" height="16"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" title="Folder Name" id="RHN-51-qgk">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ujq-2L-ZIq">
+                                                                    <rect key="frame" x="206" y="1" width="59" height="16"/>
                                                                     <subviews>
-                                                                        <imageView wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="N4h-ph-608">
-                                                                            <rect key="frame" x="-1" y="0.0" width="20" height="20"/>
-                                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="a3L-k0-Hh3"/>
+                                                                        <progressIndicator identifier="FolderProgressIndicator" wantsLayer="YES" horizontalHuggingPriority="252" verticalHuggingPriority="251" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Zii-IU-mH4">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                                                        </progressIndicator>
+                                                                        <imageView identifier="FolderAuxImageView" toolTip="An error occurred when this feed was last refreshed" wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Zar-1U-8CD">
+                                                                            <rect key="frame" x="20" y="-2.5" width="17.5" height="22"/>
+                                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="Efq-pL-jQo">
+                                                                                <imageReference key="image" image="exclamationmark.triangle.fill" catalog="system" symbolScale="default" renderingMode="original"/>
+                                                                            </imageCell>
                                                                         </imageView>
-                                                                        <textField identifier="TextField" horizontalHuggingPriority="249" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JQW-he-OfP">
-                                                                            <rect key="frame" x="20" y="1" width="180" height="16"/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" title="Folder Name" id="RHN-51-qgk">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ujq-2L-ZIq">
-                                                                            <rect key="frame" x="206" y="1" width="59" height="16"/>
-                                                                            <subviews>
-                                                                                <progressIndicator identifier="FolderProgressIndicator" wantsLayer="YES" horizontalHuggingPriority="252" verticalHuggingPriority="251" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Zii-IU-mH4">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
-                                                                                </progressIndicator>
-                                                                                <imageView identifier="FolderAuxImageView" toolTip="An error occurred when this feed was last refreshed" wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Zar-1U-8CD">
-                                                                                    <rect key="frame" x="20" y="-2.5" width="17.5" height="22"/>
-                                                                                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="Efq-pL-jQo">
-                                                                                        <imageReference key="image" image="exclamationmark.triangle.fill" catalog="system" symbolScale="default" renderingMode="original"/>
-                                                                                    </imageCell>
-                                                                                </imageView>
-                                                                                <button identifier="CountButton" horizontalHuggingPriority="252" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="J4i-Hs-cUg">
-                                                                                    <rect key="frame" x="41" y="0.0" width="18" height="16"/>
-                                                                                    <buttonCell key="cell" type="inline" title="0" bezelStyle="inline" alignment="center" refusesFirstResponder="YES" borderStyle="border" inset="2" id="RSJ-ph-xG6">
-                                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                        <font key="font" metaFont="smallSystemBold"/>
-                                                                                    </buttonCell>
-                                                                                </button>
-                                                                            </subviews>
-                                                                            <visibilityPriorities>
-                                                                                <integer value="1000"/>
-                                                                                <integer value="1000"/>
-                                                                                <integer value="1000"/>
-                                                                            </visibilityPriorities>
-                                                                            <customSpacing>
-                                                                                <real value="3.4028234663852886e+38"/>
-                                                                                <real value="3.4028234663852886e+38"/>
-                                                                                <real value="3.4028234663852886e+38"/>
-                                                                            </customSpacing>
-                                                                        </stackView>
+                                                                        <button identifier="CountButton" horizontalHuggingPriority="252" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="J4i-Hs-cUg">
+                                                                            <rect key="frame" x="41" y="0.0" width="18" height="16"/>
+                                                                            <buttonCell key="cell" type="inline" title="0" bezelStyle="inline" alignment="center" refusesFirstResponder="YES" borderStyle="border" inset="2" id="RSJ-ph-xG6">
+                                                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                                <font key="font" metaFont="smallSystemBold"/>
+                                                                            </buttonCell>
+                                                                        </button>
                                                                     </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstItem="JQW-he-OfP" firstAttribute="centerY" secondItem="SfX-xE-qxf" secondAttribute="centerY" id="BYj-ek-4RK"/>
-                                                                        <constraint firstItem="ujq-2L-ZIq" firstAttribute="centerY" secondItem="SfX-xE-qxf" secondAttribute="centerY" id="ELg-NU-EbG"/>
-                                                                        <constraint firstItem="J4i-Hs-cUg" firstAttribute="firstBaseline" secondItem="JQW-he-OfP" secondAttribute="firstBaseline" id="Nps-3X-1De"/>
-                                                                        <constraint firstAttribute="trailing" secondItem="ujq-2L-ZIq" secondAttribute="trailing" id="NsO-Aa-M0K"/>
-                                                                        <constraint firstItem="JQW-he-OfP" firstAttribute="leading" secondItem="SfX-xE-qxf" secondAttribute="leading" constant="22" id="Tuv-eU-9NA"/>
-                                                                        <constraint firstItem="ujq-2L-ZIq" firstAttribute="leading" secondItem="JQW-he-OfP" secondAttribute="trailing" constant="8" symbolic="YES" id="Xn8-3S-1qC"/>
-                                                                        <constraint firstItem="JQW-he-OfP" firstAttribute="leading" secondItem="N4h-ph-608" secondAttribute="centerX" priority="900" constant="13" id="cEs-gO-a0v"/>
-                                                                        <constraint firstItem="N4h-ph-608" firstAttribute="centerY" secondItem="SfX-xE-qxf" secondAttribute="centerY" id="h1c-LF-5QV"/>
-                                                                    </constraints>
-                                                                    <connections>
-                                                                        <outlet property="errorImageView" destination="Zar-1U-8CD" id="n6e-Cp-LCK"/>
-                                                                        <outlet property="iconHorizontalDistance" destination="cEs-gO-a0v" id="cI3-Ap-CLr"/>
-                                                                        <outlet property="imageView" destination="N4h-ph-608" id="xhO-cc-OoY"/>
-                                                                        <outlet property="progressIndicator" destination="Zii-IU-mH4" id="FFu-ji-rJa"/>
-                                                                        <outlet property="stackView" destination="ujq-2L-ZIq" id="Kpi-XH-dvD"/>
-                                                                        <outlet property="textField" destination="JQW-he-OfP" id="GMd-dy-KB5"/>
-                                                                        <outlet property="textFieldLeadingSpace" destination="Tuv-eU-9NA" id="YgG-Ez-cOt"/>
-                                                                        <outlet property="unreadCountBaseline" destination="Nps-3X-1De" id="JFh-RB-hPf"/>
-                                                                        <outlet property="unreadCountButton" destination="J4i-Hs-cUg" id="adA-1e-aAt"/>
-                                                                    </connections>
-                                                                </tableCellView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                    </tableColumns>
-                                                    <connections>
-                                                        <outlet property="menu" destination="uhR-6M-OgB" id="4rs-9J-nb7"/>
-                                                    </connections>
-                                                </outlineView>
-                                            </subviews>
-                                            <nil key="backgroundColor"/>
-                                        </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="u6a-gc-Hse">
-                                            <rect key="frame" x="0.0" y="558" width="288" height="16"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="m9n-zp-NnZ">
-                                            <rect key="frame" x="272" y="0.0" width="16" height="0.0"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                    </scrollView>
-                                </subviews>
+                                                                    <visibilityPriorities>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                    </visibilityPriorities>
+                                                                    <customSpacing>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                    </customSpacing>
+                                                                </stackView>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="JQW-he-OfP" firstAttribute="centerY" secondItem="SfX-xE-qxf" secondAttribute="centerY" id="BYj-ek-4RK"/>
+                                                                <constraint firstItem="ujq-2L-ZIq" firstAttribute="centerY" secondItem="SfX-xE-qxf" secondAttribute="centerY" id="ELg-NU-EbG"/>
+                                                                <constraint firstItem="J4i-Hs-cUg" firstAttribute="firstBaseline" secondItem="JQW-he-OfP" secondAttribute="firstBaseline" id="Nps-3X-1De"/>
+                                                                <constraint firstAttribute="trailing" secondItem="ujq-2L-ZIq" secondAttribute="trailing" id="NsO-Aa-M0K"/>
+                                                                <constraint firstItem="JQW-he-OfP" firstAttribute="leading" secondItem="SfX-xE-qxf" secondAttribute="leading" constant="22" id="Tuv-eU-9NA"/>
+                                                                <constraint firstItem="ujq-2L-ZIq" firstAttribute="leading" secondItem="JQW-he-OfP" secondAttribute="trailing" constant="8" symbolic="YES" id="Xn8-3S-1qC"/>
+                                                                <constraint firstItem="JQW-he-OfP" firstAttribute="leading" secondItem="N4h-ph-608" secondAttribute="centerX" priority="900" constant="13" id="cEs-gO-a0v"/>
+                                                                <constraint firstItem="N4h-ph-608" firstAttribute="centerY" secondItem="SfX-xE-qxf" secondAttribute="centerY" id="h1c-LF-5QV"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="errorImageView" destination="Zar-1U-8CD" id="n6e-Cp-LCK"/>
+                                                                <outlet property="iconHorizontalDistance" destination="cEs-gO-a0v" id="cI3-Ap-CLr"/>
+                                                                <outlet property="imageView" destination="N4h-ph-608" id="xhO-cc-OoY"/>
+                                                                <outlet property="progressIndicator" destination="Zii-IU-mH4" id="FFu-ji-rJa"/>
+                                                                <outlet property="stackView" destination="ujq-2L-ZIq" id="Kpi-XH-dvD"/>
+                                                                <outlet property="textField" destination="JQW-he-OfP" id="GMd-dy-KB5"/>
+                                                                <outlet property="textFieldLeadingSpace" destination="Tuv-eU-9NA" id="YgG-Ez-cOt"/>
+                                                                <outlet property="unreadCountBaseline" destination="Nps-3X-1De" id="JFh-RB-hPf"/>
+                                                                <outlet property="unreadCountButton" destination="J4i-Hs-cUg" id="adA-1e-aAt"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <outlet property="floatingResetButtonView" destination="ZRe-FS-qxT" id="JRl-LG-ntZ"/>
+                                                <outlet property="menu" destination="uhR-6M-OgB" id="4rs-9J-nb7"/>
+                                            </connections>
+                                        </outlineView>
+                                    </subviews>
+                                    <nil key="backgroundColor"/>
+                                </clipView>
                                 <constraints>
-                                    <constraint firstItem="8uX-2t-Ik7" firstAttribute="leading" secondItem="PG8-8Y-Lzt" secondAttribute="leading" id="KYR-SE-tnC"/>
-                                    <constraint firstAttribute="trailing" secondItem="o3u-Zs-gsz" secondAttribute="trailing" id="SsN-v0-dK4"/>
-                                    <constraint firstItem="o3u-Zs-gsz" firstAttribute="leading" secondItem="PG8-8Y-Lzt" secondAttribute="leading" id="YLh-QP-Vms"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="YwG-tG-A8p"/>
-                                    <constraint firstItem="8uX-2t-Ik7" firstAttribute="top" secondItem="o3u-Zs-gsz" secondAttribute="bottom" id="dTG-45-tti"/>
-                                    <constraint firstItem="o3u-Zs-gsz" firstAttribute="top" secondItem="PG8-8Y-Lzt" secondAttribute="top" id="dxe-yN-SUT"/>
-                                    <constraint firstAttribute="bottom" secondItem="8uX-2t-Ik7" secondAttribute="bottom" id="h84-sN-cLF"/>
-                                    <constraint firstAttribute="trailing" secondItem="8uX-2t-Ik7" secondAttribute="trailing" id="uAd-Tx-1yF"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="KFp-vR-Mda"/>
                                 </constraints>
-                            </view>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="u6a-gc-Hse">
+                                    <rect key="frame" x="0.0" y="558" width="288" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="m9n-zp-NnZ">
+                                    <rect key="frame" x="272" y="0.0" width="16" height="0.0"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
                             <customView fixedFrame="YES" id="9MG-Tu-1xT">
-                                <rect key="frame" x="289" y="0.0" width="653" height="597"/>
+                                <rect key="frame" x="289" y="0.0" width="653" height="603"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </customView>
                         </subviews>
@@ -1151,6 +1118,35 @@
             <point key="canvasLocation" x="72" y="-1173"/>
         </menu>
         <userDefaultsController representsSharedInstance="YES" id="fAX-Jg-YQ6"/>
+        <visualEffectView blendingMode="behindWindow" material="sidebar" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="ZRe-FS-qxT">
+            <rect key="frame" x="0.0" y="0.0" width="288" height="36"/>
+            <subviews>
+                <button wantsLayer="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="pAl-AW-rM9">
+                    <rect key="frame" x="90" y="3" width="108" height="27"/>
+                    <buttonCell key="cell" type="push" title="Show All Feeds" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Qqb-bF-tIg">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="searchUsingTreeFilter:" target="-1" id="x0g-20-NQh"/>
+                    </connections>
+                </button>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="5Fz-yB-GwX">
+                    <rect key="frame" x="0.0" y="-2" width="288" height="5"/>
+                </box>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="5Fz-yB-GwX" secondAttribute="bottom" id="0CJ-b8-D4N"/>
+                <constraint firstAttribute="bottom" secondItem="pAl-AW-rM9" secondAttribute="bottom" constant="10" id="3Hh-kM-U0q"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="pAl-AW-rM9" secondAttribute="trailing" constant="9" id="4qp-sf-j4j"/>
+                <constraint firstAttribute="trailing" secondItem="5Fz-yB-GwX" secondAttribute="trailing" id="DQX-0q-FzY"/>
+                <constraint firstItem="pAl-AW-rM9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ZRe-FS-qxT" secondAttribute="leading" constant="9" id="PBh-CQ-jvM"/>
+                <constraint firstItem="pAl-AW-rM9" firstAttribute="top" secondItem="ZRe-FS-qxT" secondAttribute="top" constant="10" id="arZ-nw-3Rp"/>
+                <constraint firstItem="5Fz-yB-GwX" firstAttribute="leading" secondItem="ZRe-FS-qxT" secondAttribute="leading" id="rwU-U9-4ly"/>
+                <constraint firstItem="pAl-AW-rM9" firstAttribute="centerX" secondItem="ZRe-FS-qxT" secondAttribute="centerX" id="thU-7y-6Z9"/>
+            </constraints>
+            <point key="canvasLocation" x="-5" y="-1066"/>
+        </visualEffectView>
     </objects>
     <resources>
         <image name="DeleteTemplate" width="18" height="14"/>

--- a/Vienna/Interfaces/da.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/da.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Ulæste artikler";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Søg efter mapper";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Omdøb…";
 

--- a/Vienna/Interfaces/de.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/de.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Ungelesene Artikel";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Suche nach Ordnern";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Umbenennen …";
 

--- a/Vienna/Interfaces/es.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/es.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Artículos no leídos";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Filtrar carpetas";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Renombrar…";
 

--- a/Vienna/Interfaces/fr.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/fr.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Articles non lus";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Rechercher dans les dossiers";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Renommer…";
 

--- a/Vienna/Interfaces/lt.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/lt.lproj/MainWindowController.strings
@@ -112,9 +112,6 @@
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "l14-tu-w7l"; */
 "l14-tu-w7l.title" = "Pervadinti…";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Ieškoti aplankų";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Pervadinti…";
 

--- a/Vienna/Interfaces/nl.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/nl.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Ongelezen artikelen";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Zoek naar mappen";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Wijzig naam…";
 

--- a/Vienna/Interfaces/ru.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/ru.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Непрочитанные статьи";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Поиск по подпискам";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Переименовать…";
 

--- a/Vienna/Interfaces/sv.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/sv.lproj/MainWindowController.strings
@@ -136,9 +136,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "Olästa artiklar";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Sök efter mappar";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Döp om…";
 

--- a/Vienna/Interfaces/uk.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/uk.lproj/MainWindowController.strings
@@ -103,9 +103,6 @@
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "l14-tu-w7l"; */
 "l14-tu-w7l.title" = "Переіменувати…";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "Знайти теки";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "Переіменувати…";
 

--- a/Vienna/Interfaces/zh-Hans.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/zh-Hans.lproj/MainWindowController.strings
@@ -112,9 +112,6 @@
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "l14-tu-w7l"; */
 "l14-tu-w7l.title" = "重命名…";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "搜索文件夹";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "重命名…";
 

--- a/Vienna/Interfaces/zh-Hant.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/MainWindowController.strings
@@ -145,9 +145,6 @@
 /* Class = "NSMenuItem"; title = "Unread Articles"; ObjectID = "lDl-nn-yvL"; */
 "lDl-nn-yvL.title" = "未讀的文章";
 
-/* Class = "NSSearchFieldCell"; placeholderString = "Search for folders"; ObjectID = "lhy-4c-asJ"; */
-"lhy-4c-asJ.placeholderString" = "查詢所有資料夾";
-
 /* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "lxY-yo-Hjh"; */
 "lxY-yo-Hjh.title" = "重新命名⋯";
 

--- a/Vienna/Resources/da.lproj/Localizable.strings
+++ b/Vienna/Resources/da.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Søg nuværende hjemmeside";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Søg efter mapper";
+
 /* No comment provided by engineer. */
 "Search Results" = "Søg i resultater";
 

--- a/Vienna/Resources/de.lproj/Localizable.strings
+++ b/Vienna/Resources/de.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Webseite durchsuchen";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Suche nach Ordnern";
+
 /* No comment provided by engineer. */
 "Search Results" = "Suchergebnisse";
 

--- a/Vienna/Resources/es.lproj/Localizable.strings
+++ b/Vienna/Resources/es.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Buscar en página web actual";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Filtrar carpetas";
+
 /* No comment provided by engineer. */
 "Search Results" = "Resultados de la búsqueda";
 

--- a/Vienna/Resources/fr.lproj/Localizable.strings
+++ b/Vienna/Resources/fr.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Chercher dans la page actuelle";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Rechercher dans les dossiers";
+
 /* No comment provided by engineer. */
 "Search Results" = "Chercher dans les résultats";
 

--- a/Vienna/Resources/lt.lproj/Localizable.strings
+++ b/Vienna/Resources/lt.lproj/Localizable.strings
@@ -441,6 +441,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Ieškoti šiame puslapyje";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Ieškoti aplankų";
+
 /* No comment provided by engineer. */
 "Search Results" = "Paieškos rezultatai";
 

--- a/Vienna/Resources/nl.lproj/Localizable.strings
+++ b/Vienna/Resources/nl.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Doorzoek huidige webpagina";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Zoek naar mappen";
+
 /* No comment provided by engineer. */
 "Search Results" = "Zoekresultaten";
 

--- a/Vienna/Resources/ru.lproj/Localizable.strings
+++ b/Vienna/Resources/ru.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "Поиск по текущей веб-странице";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Поиск по подпискам";
+
 /* No comment provided by engineer. */
 "Search Results" = "Результаты поиска";
 

--- a/Vienna/Resources/sv.lproj/Localizable.strings
+++ b/Vienna/Resources/sv.lproj/Localizable.strings
@@ -429,6 +429,9 @@
    Toolbar item tooltip */
 "Search Articles" = "Sök i artiklar";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Sök efter mappar";
+
 /* No comment provided by engineer. */
 "Search Results" = "Sökresultat";
 

--- a/Vienna/Resources/uk.lproj/Localizable.strings
+++ b/Vienna/Resources/uk.lproj/Localizable.strings
@@ -387,6 +387,9 @@
    Toolbar item tooltip */
 "Search Articles" = "Шукати статті";
 
+/* Placeholder title of a search field */
+"Search for folders" = "Знайти теки";
+
 /* No comment provided by engineer. */
 "Search Results" = "Результати пошуку";
 

--- a/Vienna/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hans.lproj/Localizable.strings
@@ -417,6 +417,9 @@
    Toolbar item tooltip */
 "Search Articles" = "搜索文章";
 
+/* Placeholder title of a search field */
+"Search for folders" = "搜索文件夹";
+
 /* No comment provided by engineer. */
 "Search Results" = "搜索结果";
 

--- a/Vienna/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hant.lproj/Localizable.strings
@@ -483,6 +483,9 @@
 /* Placeholder title of a search field */
 "Search current web page" = "查詢當前網頁";
 
+/* Placeholder title of a search field */
+"Search for folders" = "查詢所有資料夾";
+
 /* No comment provided by engineer. */
 "Search Results" = "搜尋結果";
 

--- a/Vienna/Sources/Alerts/SearchPanel.m
+++ b/Vienna/Sources/Alerts/SearchPanel.m
@@ -38,7 +38,7 @@
 		self.topObjects = objects;
 		((NSSearchFieldCell *)searchField.cell).searchMenuTemplate = APPCONTROLLER.searchFieldMenu;
 	}
-	[searchLabel setStringValue:NSLocalizedString(@"Search all articles or the current web page", nil)];
+	[searchLabel setStringValue:NSLocalizedString(@"Search", @"Search panel title")];
     [window beginSheet:searchPanelWindow completionHandler:nil];
 }
 

--- a/Vienna/Sources/Alerts/SearchPanel.m
+++ b/Vienna/Sources/Alerts/SearchPanel.m
@@ -39,6 +39,7 @@
 		((NSSearchFieldCell *)searchField.cell).searchMenuTemplate = APPCONTROLLER.searchFieldMenu;
 	}
 	[searchLabel setStringValue:NSLocalizedString(@"Search", @"Search panel title")];
+	searchField.stringValue = APPCONTROLLER.searchString ? APPCONTROLLER.searchString : @"";
     [window beginSheet:searchPanelWindow completionHandler:nil];
 }
 

--- a/Vienna/Sources/Alerts/SearchPanel.m
+++ b/Vienna/Sources/Alerts/SearchPanel.m
@@ -22,6 +22,7 @@
 #import "BrowserPane.h"
 #import "AppController.h"
 #import "Vienna-Swift.h"
+#import "SearchMethod.h"
 
 @implementation SearchPanel
 
@@ -50,23 +51,17 @@
 }
 
 /* searchStringChanged
- * This function is called when the user hits the Enter or Cancel key in the search
- * field. (Cancel blanks the searchField string value so searchArticlesWithString ends
- * up doing nothing.)
+ * This function is called when the user hits the Enter or Cancel key in the search field.
+ * (Cancel blanks the searchField string value so search ends up doing nothing.)
  */
 -(IBAction)searchStringChanged:(id)sender
 {
 	APPCONTROLLER.searchString = searchField.stringValue;
-
-    id<Tab> activeBrowserTab = APPCONTROLLER.browser.activeTab;
-    if (activeBrowserTab) {
-        [activeBrowserTab searchFor:APPCONTROLLER.searchString
-                             action:NSFindPanelActionSetFindString];
-        [APPCONTROLLER setFocusToSearchField:self];
-    } else {
-        [APPCONTROLLER searchArticlesWithString:searchField.stringValue];
-    }
-
+    SearchMethod * currentSearchMethod = [Preferences standardPreferences].searchMethod;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [APPCONTROLLER performSelector:currentSearchMethod.handler withObject:currentSearchMethod];
+#pragma clang diagnostic pop
 	[searchPanelWindow.sheetParent endSheet:searchPanelWindow];
 	[searchPanelWindow orderOut:self];
 }

--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -144,7 +144,7 @@
 -(IBAction)keepFoldersArranged:(id)sender;
 -(IBAction)exportSubscriptions:(id)sender;
 -(IBAction)importSubscriptions:(id)sender;
-
+- (IBAction)searchUsingTreeFilter:(id)sender;
 
 // Public functions
 -(NSArray *)contextMenuItemsForElement:(NSDictionary *)element defaultMenuItems:(NSArray *)defaultMenuItems;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -630,9 +630,14 @@
 
 	[cellMenu addItem: [NSMenuItem separatorItem]];
 
+    NSArray *builtInSearchMethods = @[
+        SearchMethod.allArticlesSearchMethod,
+        SearchMethod.currentWebPageSearchMethod,
+        SearchMethod.searchForFoldersMethod
+    ];
+
 	// Add all built-in search methods to the menu. 
-	for (searchMethod in [SearchMethod builtInSearchMethods])
-	{
+	for (searchMethod in builtInSearchMethods) {
 		friendlyName = searchMethod.displayName;
 		item = [[NSMenuItem alloc] initWithTitle:friendlyName
                                           action:@selector(setSearchMethod:)
@@ -643,7 +648,11 @@
 		if ( [friendlyName isEqualToString:[Preferences standardPreferences].searchMethod.displayName] )
 			item.state = NSControlStateValueOn;
 		
-		[cellMenu addItem:item];
+        if ([searchMethod isEqualTo:SearchMethod.searchForFoldersMethod]) {
+            [cellMenu addItem:[NSMenuItem separatorItem]];
+        }
+
+        [cellMenu addItem:item];
 	}
 	
 	// Add all available plugged-in search methods to the menu.
@@ -3047,10 +3056,14 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     [articleListView performFindPanelAction:NSFindPanelActionNext];
 }
 
-- (IBAction)searchUsingTreeFilter:(NSSearchField* )field
+- (IBAction)searchUsingTreeFilter:(id)sender
 {
-    NSString* f = field.stringValue;
-    [self.foldersTree setSearch:f];
+    if ([sender isKindOfClass:[NSSearchField class]]) {
+        NSString *searchString = ((NSSearchField *)sender).stringValue;
+        [self.foldersTree setSearch:searchString];
+    } else if ([sender isKindOfClass:[SearchMethod class]]) {
+        [self.foldersTree setSearch:self.toolbarSearchField.stringValue];
+    }
 }
 
 /* searchUsingToolbarTextField

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3019,6 +3019,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)setSearchString:(NSString *)newSearchString
 {
 	searchString = [newSearchString copy];
+	self.toolbarSearchField.stringValue = searchString;
 }
 
 /* searchString

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2126,9 +2126,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	switch (action)
 	{
 		case NSFindPanelActionSetFindString:
-			self.toolbarSearchField.stringValue = APP.currentTextSelection;
-			[searchPanel setSearchString:APP.currentTextSelection];
-            [self setFocusToSearchField:self];
+			self.searchString = APP.currentTextSelection;
 			break;
 			
 		case NSFindPanelActionShowFindPanel:

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3063,6 +3063,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         [self.foldersTree setSearch:searchString];
     } else if ([sender isKindOfClass:[SearchMethod class]]) {
         [self.foldersTree setSearch:self.toolbarSearchField.stringValue];
+    } else if ([sender isKindOfClass:[NSButton class]]) {
+        // Send an empty string to cancel the search.
+        [self.foldersTree setSearch:[NSString string]];
+        self.mainWindowController.toolbarSearchField.stringValue = @"";
     }
 }
 

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -325,7 +325,6 @@
 	// The menu title doesn't appear anywhere so we don't localise it. The titles of each
 	// item is localised though.	
 	((NSSearchFieldCell *)self.toolbarSearchField.cell).searchMenuTemplate = self.searchFieldMenu;
-	((NSSearchFieldCell *)self.filterSearchField.cell).searchMenuTemplate = self.searchFieldMenu;
 	
 	// Set the placeholder string for the global search field
 	SearchMethod * currentSearchMethod = [Preferences standardPreferences].searchMethod;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3061,7 +3061,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         NSString *searchString = ((NSSearchField *)sender).stringValue;
         [self.foldersTree setSearch:searchString];
     } else if ([sender isKindOfClass:[SearchMethod class]]) {
-        [self.foldersTree setSearch:self.toolbarSearchField.stringValue];
+        [self.foldersTree setSearch:self.searchString];
     } else if ([sender isKindOfClass:[NSButton class]]) {
         // Send an empty string to cancel the search.
         [self.foldersTree setSearch:[NSString string]];
@@ -3093,7 +3093,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)performAllArticlesSearch
 {
-	[self searchArticlesWithString:self.toolbarSearchField.stringValue];
+	[self searchArticlesWithString:self.searchString];
 }
 
 /* performAllArticlesSearch
@@ -3111,7 +3111,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	id<Tab> activeBrowserTab = self.browser.activeTab;
 	if (activeBrowserTab) {
-		[self setFocusToSearchField:self];
         [activeBrowserTab searchFor:self.searchString
                              action:NSFindPanelActionSetFindString];
 	}

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -3067,6 +3067,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         [self.foldersTree setSearch:[NSString string]];
         self.mainWindowController.toolbarSearchField.stringValue = @"";
     }
+    [self.mainWindow makeFirstResponder:self.foldersTree.mainView];
 }
 
 /* searchUsingToolbarTextField
@@ -3131,6 +3132,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         } else {
 			[self.articleController reloadArrayOfArticles];
         }
+        [self.browser switchToPrimaryTab];
 	}
 }
 

--- a/Vienna/Sources/Main window/FolderView.h
+++ b/Vienna/Sources/Main window/FolderView.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)reloadDataWhilePreservingSelection;
 - (void)reloadDataForRowIndexWhilePreservingSelection:(NSInteger)rowIndex;
+- (void)showResetButton:(BOOL)enabled;
 
 // This property overrides a superclass property.
 @property (nullable, weak) id<FolderViewDelegate> delegate;

--- a/Vienna/Sources/Main window/FolderView.m
+++ b/Vienna/Sources/Main window/FolderView.m
@@ -35,6 +35,12 @@ VNAFeedListRowHeight const VNAFeedListRowHeightMedium = 28.0;
 
 static void *ObserverContext = &ObserverContext;
 
+@interface FolderView ()
+
+@property (weak, nonatomic) IBOutlet NSView *floatingResetButtonView;
+
+@end
+
 @implementation FolderView {
     NSPredicate *_filterPredicate;
     FoldersFilterableDataSourceImpl *_filterDataSource;
@@ -178,6 +184,34 @@ static void *ObserverContext = &ObserverContext;
     NSIndexSet *rowIndexes = [NSIndexSet indexSetWithIndex:rowIndex];
     NSIndexSet *columnIndexes = [NSIndexSet indexSetWithIndexesInRange:range];
     [self reloadDataForRowIndexes:rowIndexes columnIndexes:columnIndexes];
+}
+
+- (void)showResetButton:(BOOL)flag
+{
+    NSView *floatingView = self.floatingResetButtonView;
+    NSScrollView *scrollView = self.enclosingScrollView;
+    NSClipView *contentView = scrollView.contentView;
+    if (flag) {
+        [scrollView addFloatingSubview:floatingView
+                               forAxis:NSEventGestureAxisVertical];
+        CGFloat height = floatingView.frame.size.height;
+        NSEdgeInsets insets = NSEdgeInsetsMake(height, 0.0, 0.0, 0.0);
+        contentView.automaticallyAdjustsContentInsets = NO;
+        contentView.contentInsets = insets;
+        scrollView.scrollerInsets = insets;
+        NSView *superView = floatingView.superview;
+        NSArray<NSLayoutConstraint *> *constraints = @[
+            [floatingView.topAnchor constraintEqualToAnchor:superView.topAnchor],
+            [floatingView.leadingAnchor constraintEqualToAnchor:superView.leadingAnchor],
+            [floatingView.trailingAnchor constraintEqualToAnchor:superView.trailingAnchor]
+        ];
+        [NSLayoutConstraint activateConstraints:constraints];
+    } else {
+        [floatingView removeFromSuperview];
+        scrollView.scrollerInsets = NSEdgeInsetsZero;
+        contentView.contentInsets = NSEdgeInsetsZero;
+        contentView.automaticallyAdjustsContentInsets = YES;
+    }
 }
 
 // MARK: Actions

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1083,6 +1083,7 @@ static void *ObserverContext = &ObserverContext;
 
     if (tf.length == 0) {
         self.outlineView.filterPredicate = nil;
+        [self.outlineView showResetButton:NO];
         return;
     }
 
@@ -1093,6 +1094,7 @@ static void *ObserverContext = &ObserverContext;
         return;
     }
 
+    [self.outlineView showResetButton:YES];
     self.outlineView.filterPredicate = predicate;
 }
 

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -353,9 +353,9 @@ extension MainWindowController: NSToolbarDelegate {
                 toolbarSearchField = item.view as? NSSearchField
             }
 
-            item.label = NSLocalizedString("Search Articles", comment: "Toolbar item label")
-            item.paletteLabel = NSLocalizedString("Search Articles", comment: "Toolbar item palette label")
-            item.toolTip = NSLocalizedString("Search Articles", comment: "Toolbar item tooltip")
+            item.label = NSLocalizedString("Search", comment: "Toolbar item label")
+            item.paletteLabel = NSLocalizedString("Search", comment: "Toolbar item palette label")
+            item.toolTip = NSLocalizedString("Search", comment: "Toolbar item tooltip")
 
             item.action = #selector(AppController.searchUsingToolbarTextField(_:))
             item.menuFormRepresentation = NSMenuItem(title: item.label, action: item.action, keyEquivalent: "")

--- a/Vienna/Sources/Plug-ins/SearchMethod.h
+++ b/Vienna/Sources/Plug-ins/SearchMethod.h
@@ -27,15 +27,14 @@
 /// At the moment, however, we only ever do a normal web search.
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 
-/// Class method that returns the standard SearchMethod "Search all Articles".
-+ (SearchMethod *)allArticlesSearchMethod;
+/// The standard SearchMethod "Search all Articles".
+@property (class, readonly, nonatomic) SearchMethod *allArticlesSearchMethod;
 
-/// Class method that Returns a SearchMethod that only works when the active
-/// view is a web pane.
-+ (SearchMethod *)currentWebPageSearchMethod;
+/// SearchMethod that only works when the active view is a web pane.
+@property (class, readonly, nonatomic) SearchMethod *currentWebPageSearchMethod;
 
-/// Class method that returns all built-in SearchMethods.
-+ (NSArray *)builtInSearchMethods;
+/// The standard SearchMethod "Search For Folders".
+@property (class, readonly, nonatomic) SearchMethod *searchForFoldersMethod;
 
 @property (copy, nonatomic) NSString *displayName;
 @property (copy, nonatomic) NSString *queryString;

--- a/Vienna/Sources/Plug-ins/SearchMethod.m
+++ b/Vienna/Sources/Plug-ins/SearchMethod.m
@@ -23,8 +23,8 @@
 #import "AppController.h"
 #import "HelperFunctions.h"
 
-static NSString *const VNACodingKeyDisplayName = @"friendlyName";
-static NSString *const VNACodingKeyQueryString = @"searchQueryString";
+static NSString * const VNACodingKeyDisplayName = @"friendlyName";
+static NSString * const VNACodingKeyQueryString = @"searchQueryString";
 
 @implementation SearchMethod
 
@@ -33,13 +33,11 @@ static NSString *const VNACodingKeyQueryString = @"searchQueryString";
 - (instancetype)initWithDictionary:(NSDictionary *)dict
 {
     self = [self init];
-
     if (self) {
         _displayName = [[dict valueForKey:@"FriendlyName"] copy];
         _queryString = [[dict valueForKey:@"SearchQueryString"] copy];
         _handler = @selector(performWebSearch:);
     }
-
     return self;
 }
 
@@ -47,34 +45,41 @@ static NSString *const VNACodingKeyQueryString = @"searchQueryString";
 
 + (SearchMethod *)allArticlesSearchMethod
 {
-    SearchMethod *method = [[SearchMethod alloc] init];
-    method.displayName = NSLocalizedString(@"Search all articles",
-                                           @"Placeholder title of a search "
-                                            "field");
-    method.handler = @selector(performAllArticlesSearch);
-
+    static SearchMethod *method;
+    if (!method) {
+        method = [SearchMethod new];
+        method.displayName = NSLocalizedString(@"Search all articles",
+                                               @"Placeholder title of a search "
+                                               "field");
+        method.handler = @selector(performAllArticlesSearch);
+    }
     return method;
 }
 
 + (SearchMethod *)currentWebPageSearchMethod
 {
-    SearchMethod *method = [[SearchMethod alloc] init];
-    method.displayName = NSLocalizedString(@"Search current web page",
-                                           @"Placeholder title of a search "
-                                            "field");
-    method.handler = @selector(performWebPageSearch);
-
+    static SearchMethod *method;
+    if (!method) {
+        method = [SearchMethod new];
+        method.displayName = NSLocalizedString(@"Search current web page",
+                                               @"Placeholder title of a search "
+                                                "field");
+        method.handler = @selector(performWebPageSearch);
+    }
     return method;
 }
 
-// If you add a new one, add it to the array. Remember: arrayWithObjects needs
-// a "nil" termination.
-+ (NSArray *)builtInSearchMethods
++ (SearchMethod *)searchForFoldersMethod
 {
-    return @[
-        [SearchMethod allArticlesSearchMethod],
-        [SearchMethod currentWebPageSearchMethod]
-    ];
+    static SearchMethod *method;
+    if (!method) {
+        method = [SearchMethod new];
+        method.displayName = NSLocalizedString(@"Search for folders",
+                                               @"Placeholder title of a search "
+                                               "field");
+        method.handler = @selector(searchUsingTreeFilter:);
+    }
+    return method;
 }
 
 - (NSURL *)queryURLforSearchString:(NSString *)searchString

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -230,7 +230,7 @@ static Preferences * _standardPreferences = nil;
                                                                       requiringSecureCoding:YES];
     defaultValues[MAPref_ArticleListSortOrders] = [NSKeyedArchiver vna_archivedDataWithRootObject:@[sortDescriptor]
                                                                             requiringSecureCoding:YES];
-    defaultValues[MAPref_SearchMethod] = [NSKeyedArchiver vna_archivedDataWithRootObject:[SearchMethod allArticlesSearchMethod]
+    defaultValues[MAPref_SearchMethod] = [NSKeyedArchiver vna_archivedDataWithRootObject:SearchMethod.allArticlesSearchMethod
                                                                    requiringSecureCoding:YES];
 
     defaultValues[MAPref_ConcurrentDownloads] = @(MA_Default_ConcurrentDownloads);


### PR DESCRIPTION
This merges the folder search field in the sidebar with the search field in the toolbar.

<img width="238" alt="Screenshot 2022-10-01 at 11 04 51" src="https://user-images.githubusercontent.com/15073177/193402015-77f252f8-197d-4369-90a5-397945517479.png">
<img width="259" alt="Screenshot 2022-06-01 at 03 37 22" src="https://user-images.githubusercontent.com/15073177/171310734-3d7ea3e8-22ac-44a5-ab5f-beaff4eec164.png">

Since the folder search might return zero results, I have added a reset button at the top of the sidebar, to make it easier for the user to go back. This button only shows up when a folder search is active; otherwise it is hidden.

I have also made some improvements to the handling of the toolbar search field. Searches now only start when the user presses the enter/return key.

Resolves #582
Resolves #1401