### PR TITLE
Adopt UniformTypeIdentifiers framework and replace deprecated methods

### DIFF
--- a/Vienna/Info.plist
+++ b/Vienna/Info.plist
@@ -195,6 +195,28 @@
 			</dict>
 		</dict>
 	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>OPML document</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>org.opml.opml</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>opml</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 	<key>VCSLongHash</key>
 	<string>VCS_FULL_HASH</string>
 	<key>VCSShortHash</key>

--- a/Vienna/Resources/Base.lproj/InfoPlist.strings
+++ b/Vienna/Resources/Base.lproj/InfoPlist.strings
@@ -1,6 +1,9 @@
 /* A message that tells the user why Vienna is requesting the ability to send Apple events. */
 "NSAppleEventsUsageDescription" = "";
 
+/* A label for OPML (Outline Processor Markup Language) documents. This is shown in Finder's Get Info window, for example. */
+"OPML document" = "OPML document";
+
 /* A label for plug-in bundles. This is shown in Finder's Get Info window, for example. */
 "Vienna plug-in" = "Vienna plug-in";
 

--- a/Vienna/Sources/Download window/DownloadItem.m
+++ b/Vienna/Sources/Download window/DownloadItem.m
@@ -20,6 +20,8 @@
 
 #import "DownloadItem.h"
 
+@import UniformTypeIdentifiers;
+
 static NSString *const VNACodingKeyFilename = @"filename";
 static NSString *const VNACodingKeySize = @"size";
 
@@ -43,7 +45,12 @@ static NSString *const VNACodingKeySize = @"size";
 {
     if (!_image) {
         NSString *extension = self.filename.pathExtension;
-        _image = [NSWorkspace.sharedWorkspace iconForFileType:extension];
+        if (@available(macOS 11, *)) {
+            UTType *contentType = [UTType typeWithFilenameExtension:extension];
+            _image = [NSWorkspace.sharedWorkspace iconForContentType:contentType];
+        } else {
+            _image = [NSWorkspace.sharedWorkspace iconForFileType:extension];
+        }
         if (!_image.valid) {
             _image = nil;
         } else {

--- a/Vienna/Sources/Download window/DownloadWindow.m
+++ b/Vienna/Sources/Download window/DownloadWindow.m
@@ -146,10 +146,13 @@
 	if (index != -1)
 	{
 		DownloadItem * item = list[index];
-		if (item)
-		{
-			if ([[NSWorkspace sharedWorkspace] openFile:item.filename] == NO)
-				runOKAlertSheet(NSLocalizedString(@"Vienna cannot open the file.", nil), NSLocalizedString(@"Vienna cannot open the file \"%@\" because it moved since you downloaded it.", nil), item.filename.lastPathComponent);
+		if (item) {
+            NSURL *url = [NSURL fileURLWithPath:item.filename];
+            if (url && ![NSWorkspace.sharedWorkspace openURL:url]) {
+                runOKAlertSheet(NSLocalizedString(@"Vienna cannot open the file.", nil),
+                                NSLocalizedString(@"Vienna cannot open the file \"%@\" because it moved since you downloaded it.", nil),
+                                item.filename.lastPathComponent);
+            }
 		}
 	}
 }

--- a/Vienna/Sources/Download window/NSWorkspace+OpenWithMenu.m
+++ b/Vienna/Sources/Download window/NSWorkspace+OpenWithMenu.m
@@ -30,6 +30,8 @@
 
 #import "NSWorkspace+OpenWithMenu.h"
 
+@import UniformTypeIdentifiers;
+
 @implementation NSWorkspace (OpenWithMenu)
 
 #pragma mark - Handler apps
@@ -140,8 +142,12 @@
         NSOpenPanel *oPanel = [NSOpenPanel openPanel];
         [oPanel setAllowsMultipleSelection:NO];
         [oPanel setCanChooseDirectories:NO];
-        [oPanel setAllowedFileTypes:@[(NSString *)kUTTypeApplicationBundle]];
-        
+        if (@available(macOS 11, *)) {
+            oPanel.allowedContentTypes = @[UTTypeApplicationBundle];
+        } else {
+            oPanel.allowedFileTypes = @[(__bridge NSString *)kUTTypeApplicationBundle];
+        };
+
         // Set Applications folder as default directory
         NSArray *applicationFolderPaths = [[NSFileManager defaultManager] URLsForDirectory:NSApplicationDirectory inDomains:NSLocalDomainMask];
         if ([applicationFolderPaths count]) {

--- a/Vienna/Sources/Info panel/InfoPanelController.m
+++ b/Vienna/Sources/Info panel/InfoPanelController.m
@@ -243,8 +243,9 @@
  Opens the cached file of the feed using the default application associated
  with its type.
  */
-- (IBAction)openCachedFile:(id)sender {
-    [[NSWorkspace sharedWorkspace] openFile:self.cachedFile];
+- (IBAction)openCachedFile:(id)sender
+{
+    [NSWorkspace.sharedWorkspace openURL:[NSURL fileURLWithPath:self.cachedFile]];
 }
 
 @end

--- a/Vienna/Sources/Main window/EnclosureView.m
+++ b/Vienna/Sources/Main window/EnclosureView.m
@@ -19,6 +19,9 @@
 //
 
 #import "EnclosureView.h"
+
+@import UniformTypeIdentifiers;
+
 #import "DownloadManager.h"
 #import "DSClickableURLTextField.h"
 #import "NSWorkspace+OpenWithMenu.h"
@@ -82,8 +85,6 @@
 	{
 		return;
 	}
-	
-	NSString * ext = basename.pathExtension;
 
 	// Find the file's likely location in Finder and see if it is already there.
 	// We'll set the options in the pane based on whether the file is there or not.
@@ -104,9 +105,14 @@
         downloadButton.action = @selector(openFile:);
         [filenameLabel setStringValue:NSLocalizedString(@"Click the Open button to open this file.", nil)];
 	}
-	
-	NSImage * iconImage = [[NSWorkspace sharedWorkspace] iconForFileType:ext];
-	fileImage.image = iconImage;
+
+    NSString *extension = basename.pathExtension;
+    if (@available(macOS 11, *)) {
+        UTType *type = [UTType typeWithFilenameExtension:extension];
+        fileImage.image = [NSWorkspace.sharedWorkspace iconForContentType:type];
+    } else {
+        fileImage.image = [NSWorkspace.sharedWorkspace iconForFileType:extension];
+    }
 	NSDictionary *linkAttributes = @{
 									 NSLinkAttributeName: enclosureURLString,
 									 NSForegroundColorAttributeName: [NSColor colorWithCalibratedHue:240.0f/360.0f saturation:1.0f brightness:0.75f alpha:1.0f],
@@ -132,7 +138,8 @@
 	NSString * basename = [NSURL URLWithString:enclosureURLString].lastPathComponent;
 	NSString * destPath = [DownloadManager fullDownloadPath:basename];
 
-	[[NSWorkspace sharedWorkspace] openFile:destPath];
+    NSURL *url = [NSURL fileURLWithPath:destPath];
+    [NSWorkspace.sharedWorkspace openURL:url];
 }
 
 /* drawRect


### PR DESCRIPTION
No change in functionality.

The UniformTypeIdentifiers framework replaces some old CoreFoundation APIs in macOS 11. I also replaced some deprecated NSWorkspace methods to open urls in external apps (for the most part, these are backwards compatible, except a few cases).