### PR TITLE
Update localisations

### DIFF
--- a/Vienna/Interfaces/cs.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/cs.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Poslat odkaz e-mailem";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Zvětšit text";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Zmenšit text";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/da.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/da.lproj/FeedCredentials.strings
@@ -16,3 +16,12 @@
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Brugernavnet og kodeordet du skal angive vil blive husket til næste gang du opdaterer dette abonnement.";
 
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "Lvs-Rd-GZy"; */
+"Lvs-Rd-GZy.title" = "Henvisning:";
+
+/* Class = "NSTextFieldCell"; title = "Details"; ObjectID = "VkU-PT-7wf"; */
+"VkU-PT-7wf.title" = "Detaljer";
+
+/* Class = "NSTextFieldCell"; title = "Feed:"; ObjectID = "yIO-aF-1Qg"; */
+"yIO-aF-1Qg.title" = "Feed:";
+

--- a/Vienna/Interfaces/da.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/da.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Send henvisning via email";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Gør tekst større";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Gør tekst mindre";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/de.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/de.lproj/FeedCredentials.strings
@@ -16,3 +16,12 @@
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Die Benutzerdaten werden für die nächsten Aktualisierungen des Abonnements gespeichert.";
 
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "Lvs-Rd-GZy"; */
+"Lvs-Rd-GZy.title" = "URL:";
+
+/* Class = "NSTextFieldCell"; title = "Details"; ObjectID = "VkU-PT-7wf"; */
+"VkU-PT-7wf.title" = "Details";
+
+/* Class = "NSTextFieldCell"; title = "Feed:"; ObjectID = "yIO-aF-1Qg"; */
+"yIO-aF-1Qg.title" = "Feed:";
+

--- a/Vienna/Interfaces/de.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/de.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Link per E-Mail senden";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Schrift größer";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Schrift kleiner";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */
@@ -341,7 +341,7 @@
 "1338.title" = "Manuell";
 
 /* Class = "NSMenuItem"; title = "Name"; ObjectID = "1339"; */
-"1339.title" = "Name (alphabetisch)";
+"1339.title" = "Name";
 
 /* Class = "NSMenuItem"; title = "Unsubscribe"; ObjectID = "1408"; */
 "1408.title" = "Abonnement entfernen";

--- a/Vienna/Interfaces/de.lproj/Preferences.strings
+++ b/Vienna/Interfaces/de.lproj/Preferences.strings
@@ -44,7 +44,7 @@
 "DDY-fS-V5T.title" = "Neuen Browser ausprobieren";
 
 /* Class = "NSButtonCell"; title = "Show feeds icons in folder list"; ObjectID = "dkm-xW-4If"; */
-"dkm-xW-4If.title" = "Abonnementenicons anzeigen";
+"dkm-xW-4If.title" = "Feedsymbole in der Feedleiste anzeigen";
 
 /* Class = "NSMenuItem"; title = "After two weeks"; ObjectID = "Dw9-en-4Zu"; */
 "Dw9-en-4Zu.title" = "Nach zwei Wochen";

--- a/Vienna/Interfaces/de.lproj/SearchFolder.strings
+++ b/Vienna/Interfaces/de.lproj/SearchFolder.strings
@@ -14,7 +14,7 @@
 "98.title" = "Enthält Artikel mit";
 
 /* Class = "NSTextFieldCell"; title = "of the following conditions:"; ObjectID = "100"; */
-"100.title" = "der folgenden Eigenschaften";
+"100.title" = "der folgenden Eigenschaften:";
 
 /* Class = "NSMenuItem"; title = "any"; ObjectID = "j0v-xF-tpl"; */
 "j0v-xF-tpl.title" = "einer";

--- a/Vienna/Interfaces/en-AU.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/en-AU.lproj/FeedCredentials.strings
@@ -1,3 +1,6 @@
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
+"34.title" = "Access to %@ requires you to provide login credentials";
+
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "The username and password you provide will be remembered for the next time you refresh this subscription.";
 

--- a/Vienna/Interfaces/en-GB.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/en-GB.lproj/FeedCredentials.strings
@@ -1,3 +1,6 @@
+/* Class = "NSTextFieldCell"; title = "Access to %@ requires you to provide log in credentials"; ObjectID = "34"; */
+"34.title" = "Access to %@ requires you to provide login credentials";
+
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "The username and password you provide will be remembered for the next time you refresh this subscription.";
 

--- a/Vienna/Interfaces/en-GB.lproj/Preferences.strings
+++ b/Vienna/Interfaces/en-GB.lproj/Preferences.strings
@@ -1,3 +1,6 @@
 /* Class = "NSTextFieldCell"; title = "Move articles to Trash:"; ObjectID = "bom-nB-4zx"; */
 "bom-nB-4zx.title" = "Move articles to Bin:";
 
+/* Class = "NSButtonCell"; title = "After \"Next Unread\" command"; ObjectID = "jkb-TT-wPC"; */
+"jkb-TT-wPC.title" = "After “Next Unread” command";
+

--- a/Vienna/Interfaces/es.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/es.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Enviar enlace por correo electrónico";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Aumentar tamaño del texto";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Reducir tamaño del texto";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/eu.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/eu.lproj/MainMenu.strings
@@ -226,10 +226,10 @@
 /* Class = "NSMenuItem"; title = "Open Article Page in External Browser"; ObjectID = "1067"; */
 "1067.title" = "Ireki Artikuluaren Orria Kanpo Nabegatzailean";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Testu Haundiagoa";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Testu Txikiagoa";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/fr.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/fr.lproj/FeedCredentials.strings
@@ -16,3 +16,12 @@
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Le nom d'utilisateur et le mot de passe fournis seront conservés pour le prochain accès à ce flux.";
 
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "Lvs-Rd-GZy"; */
+"Lvs-Rd-GZy.title" = "URL :";
+
+/* Class = "NSTextFieldCell"; title = "Details"; ObjectID = "VkU-PT-7wf"; */
+"VkU-PT-7wf.title" = "Détails";
+
+/* Class = "NSTextFieldCell"; title = "Feed:"; ObjectID = "yIO-aF-1Qg"; */
+"yIO-aF-1Qg.title" = "Flux :";
+

--- a/Vienna/Interfaces/fr.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/fr.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Partager le lien par e-mail";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Agrandir le texte";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Réduire le texte";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/gl.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/gl.lproj/MainMenu.strings
@@ -226,10 +226,10 @@
 /* Class = "NSMenuItem"; title = "Open Article Page in External Browser"; ObjectID = "1067"; */
 "1067.title" = "Abrir páxina do artigo nun navegador externo";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Aumentar o tamaño do texto";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Reducir o tamaño do texto";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/it.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/it.lproj/MainMenu.strings
@@ -232,10 +232,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Invia link via email";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Testo Più Grande";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Testo Più Piccolo";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/ko.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/ko.lproj/MainMenu.strings
@@ -229,10 +229,10 @@
 /* Class = "NSMenuItem"; title = "Open Article Page in External Browser"; ObjectID = "1067"; */
 "1067.title" = "외부 브라우져에서 기사 페이지 열기";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "텍스트 크게";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "텍스트 작게";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/lt.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/lt.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Siųsti nuorodą el. paštu";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Didesnis tekstas";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Mažesnis tekstas";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/nl.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/nl.lproj/FeedCredentials.strings
@@ -16,3 +16,12 @@
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "De opgegeven gebruikersnaam en wachtwoord zullen worden opgeslagen, zodat je deze niet nog eens hoeft op te geven.";
 
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "Lvs-Rd-GZy"; */
+"Lvs-Rd-GZy.title" = "URL:";
+
+/* Class = "NSTextFieldCell"; title = "Details"; ObjectID = "VkU-PT-7wf"; */
+"VkU-PT-7wf.title" = "Details";
+
+/* Class = "NSTextFieldCell"; title = "Feed:"; ObjectID = "yIO-aF-1Qg"; */
+"yIO-aF-1Qg.title" = "Feed:";
+

--- a/Vienna/Interfaces/nl.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/nl.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Verstuur link via e-mail";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Maak tekst groter";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Maak tekst kleiner";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/pt-BR.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/pt-BR.lproj/MainMenu.strings
@@ -226,10 +226,10 @@
 /* Class = "NSMenuItem"; title = "Open Article Page in External Browser"; ObjectID = "1067"; */
 "1067.title" = "Abrir Página do Artigo no Navegador Externo";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Texto Maior";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Texto Menor";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/pt.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/pt.lproj/MainMenu.strings
@@ -223,10 +223,10 @@
 /* Class = "NSMenuItem"; title = "Open Article Page in External Browser"; ObjectID = "1067"; */
 "1067.title" = "Abrir página do Artigo no Browser Externo";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Texto Maior";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Texto Menor";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/ru.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/ru.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Отправить ссылку электронной почтой";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Увеличить текст";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Уменьшить текст";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/sv.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/sv.lproj/FeedCredentials.strings
@@ -16,3 +16,12 @@
 /* Class = "NSTextFieldCell"; title = "The user name and password you provide will be remembered for the next time you refresh this subscription."; ObjectID = "39"; */
 "39.title" = "Användarnamnet och lösenordet du anger kommer att kommas ihåg till nästa gång du uppdaterar den här prenumerationen.";
 
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "Lvs-Rd-GZy"; */
+"Lvs-Rd-GZy.title" = "URL:";
+
+/* Class = "NSTextFieldCell"; title = "Details"; ObjectID = "VkU-PT-7wf"; */
+"VkU-PT-7wf.title" = "Detaljer";
+
+/* Class = "NSTextFieldCell"; title = "Feed:"; ObjectID = "yIO-aF-1Qg"; */
+"yIO-aF-1Qg.title" = "Flöde:";
+

--- a/Vienna/Interfaces/sv.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/sv.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Skicka länk via e-post";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Öka textstorleken";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Minska textstorleken";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/sv.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/sv.lproj/MainWindowController.strings
@@ -223,6 +223,9 @@
 /* Class = "NSToolbarItem"; toolTip = "Delete the current article"; ObjectID = "Y22-Ul-q6w"; */
 "Y22-Ul-q6w.toolTip" = "Radera den markerade artikeln";
 
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Filter articles"; ObjectID = "Ymd-v7-5ML"; */
+"Ymd-v7-5ML.ibShadowedToolTip" = "Filtrera artiklar";
+
 /* Class = "NSMenuItem"; title = "Last 48 Hours"; ObjectID = "yqJ-tO-HNW"; */
 "yqJ-tO-HNW.title" = "Senaste 48 timmarna";
 

--- a/Vienna/Interfaces/tr.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/tr.lproj/MainMenu.strings
@@ -229,10 +229,10 @@
 /* Class = "NSMenuItem"; title = "Open Article Page in External Browser"; ObjectID = "1067"; */
 "1067.title" = "Makale Sayfasını Harici Tarayıcıda Aç";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Daha Büyük Metin";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Daha Küçük Metin";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/uk.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/uk.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "Надіслати посилання на ел. пошту";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "Більший текст";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "Менший текст";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/zh-Hans.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/zh-Hans.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "通过邮件方式发送";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "发大文章字体";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "缩小文章字体";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Interfaces/zh-Hant.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/MainMenu.strings
@@ -238,10 +238,10 @@
 /* Class = "NSMenuItem"; title = "Send Link by Email"; ObjectID = "1073"; */
 "1073.title" = "以電子郵件傳送";
 
-/* Class = "NSMenuItem"; title = "Make Text Bigger"; ObjectID = "1084"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Bigger Text"; ObjectID = "1084"; */
 "1084.title" = "將文字放大";
 
-/* Class = "NSMenuItem"; title = "Make Text Smaller"; ObjectID = "1085"; Note = "This string is also used in Safari"; */
+/* Class = "NSMenuItem"; title = "Smaller Text"; ObjectID = "1085"; */
 "1085.title" = "將文字縮小";
 
 /* Class = "NSMenuItem"; title = "Open Web Location…"; ObjectID = "1101"; */

--- a/Vienna/Resources/Base.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/Base.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d new articles retrieved</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d new unread articles retrieved</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/cs.lproj/Localizable.strings
+++ b/Vienna/Resources/cs.lproj/Localizable.strings
@@ -10,9 +10,6 @@
 /* Progress in bytes, e.g. 1 KB of 1 MB */
 "%@ of %@" = "%1$@ z %2$@";
 
-/* Notification body */
-"%d new unread articles retrieved" = "Přijato nových nepřečtených příspěvků: %d";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Složka s tímto jménem již existuje.";
 

--- a/Vienna/Resources/cs.lproj/Localizable.strings
+++ b/Vienna/Resources/cs.lproj/Localizable.strings
@@ -10,26 +10,8 @@
 /* Progress in bytes, e.g. 1 KB of 1 MB */
 "%@ of %@" = "%1$@ z %2$@";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "Nově přijato příspěvků: %d";
-
 /* Notification body */
 "%d new unread articles retrieved" = "Přijato nových nepřečtených příspěvků: %d";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "Bylo úspěšně exportováno celkem odebírání: %d";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "Bylo úspěšně importováno celkem odebírání: %d";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "Nečtených příspěvků: %d";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u příspěvků";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u nečtených";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Složka s tímto jménem již existuje.";

--- a/Vienna/Resources/cs.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/cs.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>Nově přijato příspěvků: %d</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d new unread articles retrieved</string>
+			<key>many</key>
+			<string>%d new unread articles retrieved</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>Přijato nových nepřečtených příspěvků: %d</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/da.lproj/Localizable.strings
+++ b/Vienna/Resources/da.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ ulæste";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d nye artikler hentet";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d nye ulæste artikler hentet";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d abonnementer successfuldt eksportert";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d abonnementer successfuldt importeret";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d ulæste artikler";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artikler";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u ulæste";
 
 /* Title in popup submenu */
 "<None>" = "<Ingen>";
@@ -206,9 +188,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "Tøm Papirkurven";
-
-/* Title of a menu item */
-"Empty Trash…" = "Tøm papirkurv…";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Indpakning";
@@ -683,6 +662,9 @@
 
 /* No comment provided by engineer. */
 "Unsubscribe from Feed" = "Af-abonner feedet";
+
+/* No comment provided by engineer. */
+"Unsubscribing from an Open Reader RSS feed will also remove your locally cached articles." = "Hvis du afabonnerer fra et Open Reader RSS feed vil det også automatisk fjerne de lokalt cachede artikler.";
 
 /* Title of a button on an alert */
 "Upgrade Database" = "Opgrader databasen";

--- a/Vienna/Resources/da.lproj/Localizable.strings
+++ b/Vienna/Resources/da.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ ulæste";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d nye ulæste artikler hentet";
-
 /* Title in popup submenu */
 "<None>" = "<Ingen>";
 

--- a/Vienna/Resources/da.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/da.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d nye artikler hentet</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ny ulæst artikel hentet</string>
+			<key>other</key>
+			<string>%d nye ulæste artikler hentet</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/de.lproj/Localizable.strings
+++ b/Vienna/Resources/de.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ ungelesen";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d neue Artikel abgerufen";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d neue ungelesene Artikel abgerufen";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d Abonnements erfolgreich exportiert";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d Abonnements erfolgreich importiert";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d ungelesene Artikel";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u Artikel";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u ungelesen";
 
 /* Title in popup submenu */
 "<None>" = "<Nichts>";
@@ -102,7 +84,7 @@
 "Cannot create the Vienna database" = "Vienna konnte die Datenbank nicht erstellen";
 
 /* No comment provided by engineer. */
-"Cannot import the specified file. The file contents are not valid OPML XML format." = "Die ausgewählte Datei konnte nicht importiert werden. Der Dateiinhalt ist nicht valides OPML";
+"Cannot import the specified file. The file contents are not valid OPML XML format." = "Die ausgewählte Datei kann nicht importiert werden, da sie kein gültiges OPML-Format beinhaltet.";
 
 /* No comment provided by engineer. */
 "Cannot rename folder" = "Konnte den Ordner nicht umbenennen";
@@ -207,9 +189,6 @@
 /* Title of a button on an alert */
 "Empty Trash" = "Papierkorb entleeren";
 
-/* Title of a menu item */
-"Empty Trash…" = "Papierkorb entleeren …";
-
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Anhang";
 
@@ -244,7 +223,7 @@
 "External Browser" = "Externer Browser";
 
 /* No comment provided by engineer. */
-"Feed URL updated to %@" = "Die Feed URL wurd auf %@ aktualisiert";
+"Feed URL updated to %@" = "Feed-URL geändert in %@";
 
 /* No comment provided by engineer. */
 "Fetching Open Reader Subscriptions…" = "Rufe Open Reader Abonnements ab …";
@@ -310,7 +289,7 @@
 "HTTP code %d reported from server" = "Der Server lieferte den HTTP-Code %d";
 
 /* Message text of an alert */
-"If you quit Vienna now, all downloads will stop." = "Möchtest du die laufenden Downloads unterbrechen und Vienna jetzt schließen?";
+"If you quit Vienna now, all downloads will stop." = "Wenn du Vienna jetzt beendest, werden alle Downloads abgebrochen.";
 
 /* Title of a button on an alert */
 "Import" = "Importieren";
@@ -427,7 +406,7 @@
 "OK" = "OK";
 
 /* Message text of an alert */
-"One or more downloads are in progress" = "Eine oder mehrere Dateien werden heruntergeladen.";
+"One or more downloads are in progress" = "Eine oder mehrere Dateien werden heruntergeladen";
 
 /* Title of a popup menu item */
 "Open" = "Öffnen";
@@ -515,7 +494,7 @@
 "Refresh All Subscriptions" = "Alle Abonnements aktualisieren";
 
 /* No comment provided by engineer. */
-"Refresh completed" = "Aktualisierung durchgeführt.";
+"Refresh completed" = "Aktualisierung abgeschlossen";
 
 /* Title of a menu item */
 "Refresh Selected Subscriptions" = "Ausgewähltes Abonnement aktualisieren";

--- a/Vienna/Resources/de.lproj/Localizable.strings
+++ b/Vienna/Resources/de.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ ungelesen";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d neue ungelesene Artikel abgerufen";
-
 /* Title in popup submenu */
 "<None>" = "<Nichts>";
 

--- a/Vienna/Resources/de.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/de.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d neue Artikel abgerufen</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d neuer ungelesener Artikel abgerufen</string>
+			<key>other</key>
+			<string>%d neue ungelesene Artikel abgerufen</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/en-AU.lproj/Localizable.strings
+++ b/Vienna/Resources/en-AU.lproj/Localizable.strings
@@ -1,4 +1,7 @@
 /* No comment provided by engineer. */
+"A new plugin has been installed. It is now available from the menu and you can add it to the toolbar." = "A new plug-in has been installed. It is now available from the menu and you can add it to the toolbar.";
+
+/* No comment provided by engineer. */
 "Are you sure you want to delete the messages in the Trash folder permanently?" = "Are you sure you want to delete the messages in the Bin folder permanently?";
 
 /* Title of a button on an alert */
@@ -7,8 +10,8 @@
 /* Title of a button on an alert */
 "Empty Trash" = "Empty Bin";
 
-/* Title of a menu item */
-"Empty Trash…" = "Empty Bin…";
+/* No comment provided by engineer. */
+"Plugin installed" = "Plug-in installed";
 
 /* No comment provided by engineer. */
 "The subscription for \"%@\" requires a user name and password for access." = "The subscription for “%@” requires a username and password for access.";

--- a/Vienna/Resources/en-GB.lproj/Localizable.strings
+++ b/Vienna/Resources/en-GB.lproj/Localizable.strings
@@ -1,5 +1,23 @@
 /* No comment provided by engineer. */
+"A new plugin has been installed. It is now available from the menu and you can add it to the toolbar." = "A new plug-in has been installed. It is now available from the menu and you can add it to the toolbar.";
+
+/* No comment provided by engineer. */
+"A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine." = "A new Vienna database cannot be created at “%@” because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine.";
+
+/* No comment provided by engineer. */
+"Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone." = "Are you sure you want to delete group folder “%@” and all sub folders? This operation cannot be undone.";
+
+/* No comment provided by engineer. */
+"Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search." = "Are you sure you want to delete smart folder “%@”? This will not delete the actual articles matched by the search.";
+
+/* No comment provided by engineer. */
 "Are you sure you want to delete the messages in the Trash folder permanently?" = "Are you sure you want to delete the messages in the Bin folder permanently?";
+
+/* No comment provided by engineer. */
+"Are you sure you want to unsubscribe from \"%@\"? This operation will delete all cached articles." = "Are you sure you want to unsubscribe from “%@”? This operation will delete all cached articles.";
+
+/* No comment provided by engineer. */
+"Deleting folder \"%@\"…" = "Deleting folder “%@”…";
 
 /* Title of a button on an alert */
 "Don’t Empty Trash" = "Don’t Empty Bin";
@@ -7,8 +25,17 @@
 /* Title of a button on an alert */
 "Empty Trash" = "Empty Bin";
 
-/* Title of a menu item */
-"Empty Trash…" = "Empty Bin…";
+/* No comment provided by engineer. */
+"Error loading script '%@'" = "Error loading script “%@”";
+
+/* No comment provided by engineer. */
+"Plugin installed" = "Plug-in installed";
+
+/* No comment provided by engineer. */
+"The \"%@\" folder cannot be created." = "The “%@” folder cannot be created.";
+
+/* No comment provided by engineer. */
+"The style \"%@\" has been installed to your Styles folder and added to the Style menu." = "The style “%@” has been installed to your Styles folder and added to the Style menu.";
 
 /* No comment provided by engineer. */
 "The subscription for \"%@\" requires a user name and password for access." = "The subscription for “%@” requires a username and password for access.";
@@ -17,7 +44,16 @@
 "There are deleted articles in the trash. Would you like to empty the trash before quitting?" = "There are deleted articles in the bin. Would you like to empty the bin before quitting?";
 
 /* No comment provided by engineer. */
+"Today's Articles" = "Today’s Articles";
+
+/* No comment provided by engineer. */
 "Trash" = "Bin";
+
+/* No comment provided by engineer. */
+"Vienna cannot open the file \"%@\" because it moved since you downloaded it." = "Vienna cannot open the file “%@” because it moved since you downloaded it.";
+
+/* No comment provided by engineer. */
+"Vienna cannot show the file \"%@\" because it moved since you downloaded it." = "Vienna cannot show the file “%@” because it moved since you downloaded it.";
 
 /* No comment provided by engineer. */
 "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologize for the inconvenience." = "Vienna must upgrade its database to the latest version. This may take a minute or so. We apologise for the inconvenience.";

--- a/Vienna/Resources/es.lproj/Localizable.strings
+++ b/Vienna/Resources/es.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ no leídos";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d nuevos artículos recuperados";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d nuevos artículos no leídos recuperados";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d suscripciones exportadas correctamente";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d suscripciones importadas correctamente";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d artículos no leídos";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artículos";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u no leídos";
 
 /* Title in popup submenu */
 "<None>" = "<Ninguna>";
@@ -206,9 +188,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "Vaciar papelera";
-
-/* Title of a menu item */
-"Empty Trash…" = "Vaciar papelera…";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Archivo adjunto";

--- a/Vienna/Resources/es.lproj/Localizable.strings
+++ b/Vienna/Resources/es.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ no leídos";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d nuevos artículos no leídos recuperados";
-
 /* Title in popup submenu */
 "<None>" = "<Ninguna>";
 

--- a/Vienna/Resources/es.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/es.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d nuevos artículos recuperados</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d nuevos artículos no leídos recuperados</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/eu.lproj/Localizable.strings
+++ b/Vienna/Resources/eu.lproj/Localizable.strings
@@ -7,9 +7,6 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ Informazioa";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d artikulu berri irakurri gabe jasota";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Izen berdineko direktorioa existitzen da";
 

--- a/Vienna/Resources/eu.lproj/Localizable.strings
+++ b/Vienna/Resources/eu.lproj/Localizable.strings
@@ -7,26 +7,8 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ Informazioa";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d artikulu berri jasota";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d artikulu berri irakurri gabe jasota";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d harpidetzak zuzen esportatu dira";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d harpidetzak zuzen inportatu dira";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d artikulu irakurri gabe";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artikulu";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u irakurri gabeak";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Izen berdineko direktorioa existitzen da";

--- a/Vienna/Resources/eu.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/eu.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d artikulu berri jasota</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d artikulu berri irakurri gabe jasota</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/fr.lproj/Localizable.strings
+++ b/Vienna/Resources/fr.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ non lus";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d nouveaux articles non lus récupérés";
-
 /* Title in popup submenu */
 "<None>" = "<Aucun>";
 

--- a/Vienna/Resources/fr.lproj/Localizable.strings
+++ b/Vienna/Resources/fr.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ non lus";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d nouveaux articles récupérés";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d nouveaux articles non lus récupérés";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d abonnements exportés avec succès";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d abonnements importés avec succès";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d articles non lus";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u articles";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u non lus";
 
 /* Title in popup submenu */
 "<None>" = "<Aucun>";
@@ -206,9 +188,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "Vider la corbeille";
-
-/* Title of a menu item */
-"Empty Trash…" = "Vider la corbeille…";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Fichier joint";

--- a/Vienna/Resources/fr.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/fr.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d nouveaux articles récupérés</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d nouvel article non lu récupéré</string>
+			<key>other</key>
+			<string>%d nouveaux articles non lus récupérés</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/gl.lproj/Localizable.strings
+++ b/Vienna/Resources/gl.lproj/Localizable.strings
@@ -7,26 +7,8 @@
 /* No comment provided by engineer. */
 "%@ Info" = "Información de %@";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "Recuperados %d novos artigos";
-
 /* Notification body */
 "%d new unread articles retrieved" = "Recuperados novos artigos sen ler";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d subscricións correctamente exportadas";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d subscricións importadas correctamente";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d artigos sen ler";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artigos";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u sen ler";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Xa existe un cartafol con ese nome";

--- a/Vienna/Resources/gl.lproj/Localizable.strings
+++ b/Vienna/Resources/gl.lproj/Localizable.strings
@@ -7,9 +7,6 @@
 /* No comment provided by engineer. */
 "%@ Info" = "Información de %@";
 
-/* Notification body */
-"%d new unread articles retrieved" = "Recuperados novos artigos sen ler";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Xa existe un cartafol con ese nome";
 

--- a/Vienna/Resources/gl.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/gl.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>Recuperados %d novos artigos</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>Recuperados novos artigos sen ler</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/it.lproj/Localizable.strings
+++ b/Vienna/Resources/it.lproj/Localizable.strings
@@ -4,26 +4,8 @@
 /* No comment provided by engineer. */
 "(Untitled Feed)" = "(Feed Senza Titolo)";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d nuovi articoli ricevuti";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d nuovi articoli non letti ricevuti";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d iscrizioni esportate correttamente";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d iscrizioni importate correttamente";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d articoli non letti";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u articoli";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u non letti";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Una cartella con lo stesso nome esiste di già";

--- a/Vienna/Resources/it.lproj/Localizable.strings
+++ b/Vienna/Resources/it.lproj/Localizable.strings
@@ -4,9 +4,6 @@
 /* No comment provided by engineer. */
 "(Untitled Feed)" = "(Feed Senza Titolo)";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d nuovi articoli non letti ricevuti";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Una cartella con lo stesso nome esiste di già";
 

--- a/Vienna/Resources/it.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/it.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d nuovi articoli ricevuti</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d nuovi articoli non letti ricevuti</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/ja.lproj/Localizable.strings
+++ b/Vienna/Resources/ja.lproj/Localizable.strings
@@ -7,26 +7,8 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ 情報";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d の新着記事があります";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d の未読記事があります。";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d の購読の書き出しに成功しました。";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d の購読の読み込みに成功しました。";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d の未読記事";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u 記事";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u 未読";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "この名前のフォルダがすでに存在します。";
@@ -135,6 +117,9 @@
 /* Title of a button on an alert */
 "Empty" = "空にする";
 
+/* Title of a button on an alert */
+"Empty Trash" = "ゴミ箱を空にする";
+
 /* No comment provided by engineer. */
 "Enter the URL here" = "URL をここに入力";
 
@@ -183,7 +168,7 @@
 /* No comment provided by engineer. */
 "HTTP code %d reported from server" = "HTTP コード %d がサーバから送られました。";
 
-/* No comment provided by engineer. */
+/* Message text of an alert */
 "If you quit Vienna now, all downloads will stop." = "すべてのダウンロードを中止して、Vienna を終了しますか？";
 
 /* No comment provided by engineer. */
@@ -270,7 +255,7 @@
 /* No comment provided by engineer. */
 "No new articles available" = "新着記事はありません";
 
-/* No comment provided by engineer. */
+/* Message text of an alert */
 "One or more downloads are in progress" = "ダウンロード中です";
 
 /* Title of a popup menu item */
@@ -462,7 +447,4 @@
 
 /* No comment provided by engineer. */
 "You cannot undo this action" = "この操作は取り消せません。";
-
-/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
-"Empty Trash" = "ゴミ箱を空にする";
 

--- a/Vienna/Resources/ja.lproj/Localizable.strings
+++ b/Vienna/Resources/ja.lproj/Localizable.strings
@@ -7,9 +7,6 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ 情報";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d の未読記事があります。";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "この名前のフォルダがすでに存在します。";
 

--- a/Vienna/Resources/ja.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/ja.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%d の新着記事があります</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d の未読記事があります。</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/ko.lproj/Localizable.strings
+++ b/Vienna/Resources/ko.lproj/Localizable.strings
@@ -7,9 +7,6 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ 정보";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d 항목의 읽지 않은 새 기사가 추가되었습니다.";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "지정한 이름의 항목이 이미 존재합니다.";
 

--- a/Vienna/Resources/ko.lproj/Localizable.strings
+++ b/Vienna/Resources/ko.lproj/Localizable.strings
@@ -7,26 +7,8 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ 정보";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d 항목의 새 기사를 등록";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d 항목의 읽지 않은 새 기사가 추가되었습니다.";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d 항목의 구독을 성공적으로 저장했습니다.";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d 항목의 구독을 성공적으로 가져왔습니다.";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d 항목의 읽지 않은 기사";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u 기사";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u 읽지 않음";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "지정한 이름의 항목이 이미 존재합니다.";

--- a/Vienna/Resources/ko.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/ko.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%d 항목의 새 기사를 등록</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 항목의 읽지 않은 새 기사가 추가되었습니다.</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/lt.lproj/Localizable.strings
+++ b/Vienna/Resources/lt.lproj/Localizable.strings
@@ -13,9 +13,6 @@
 /* Number of bytes received, e.g. 1 MB received */
 "%@ received" = "Gauta %@";
 
-/* Notification body */
-"%d new unread articles retrieved" = "Parsiųsta naujų neperskaitytų straipsnių";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Aplankas su tokiu pavadinimu jau yra";
 

--- a/Vienna/Resources/lt.lproj/Localizable.strings
+++ b/Vienna/Resources/lt.lproj/Localizable.strings
@@ -13,26 +13,8 @@
 /* Number of bytes received, e.g. 1 MB received */
 "%@ received" = "Gauta %@";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "Parsiųsta %d naujų straipsnių";
-
 /* Notification body */
 "%d new unread articles retrieved" = "Parsiųsta naujų neperskaitytų straipsnių";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "Sėkmingai importuota %d naujų prenumeratų";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "Sėkmingai importuota %d naujų prenumeratų";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d neskaitytų straipsnių";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u straipsniai";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u neperskaityta";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Aplankas su tokiu pavadinimu jau yra";

--- a/Vienna/Resources/lt.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/lt.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>Parsiųsta %d naujų straipsnių</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d new unread articles retrieved</string>
+			<key>many</key>
+			<string>%d new unread articles retrieved</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>Parsiųsta naujų neperskaitytų straipsnių</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/nl.lproj/Localizable.strings
+++ b/Vienna/Resources/nl.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ ongelezen";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d nieuwe ongelezen artikelen opgehaald";
-
 /* Title in popup submenu */
 "<None>" = "<Geen>";
 

--- a/Vienna/Resources/nl.lproj/Localizable.strings
+++ b/Vienna/Resources/nl.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ ongelezen";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d nieuwe artikelen opgehaald";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d nieuwe ongelezen artikelen opgehaald";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d abonnementen geëxporteerd";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d abonnementen geïmporteerd";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d ongelezen artikelen";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artikelen";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u ongelezen";
 
 /* Title in popup submenu */
 "<None>" = "<Geen>";
@@ -206,9 +188,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "Leeg prullenmand";
-
-/* Title of a menu item */
-"Empty Trash…" = "Leeg prullenmand…";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Bijlage";

--- a/Vienna/Resources/nl.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/nl.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d nieuwe artikelen opgehaald</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d nieuw ongelezen artikel opgehaald</string>
+			<key>other</key>
+			<string>%d nieuwe ongelezen artikelen opgehaald</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/pt-BR.lproj/Localizable.strings
+++ b/Vienna/Resources/pt-BR.lproj/Localizable.strings
@@ -4,26 +4,8 @@
 /* No comment provided by engineer. */
 "(Untitled Feed)" = "(Notícias Sem Título)";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d novos artigos descarregados";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d novos artigos recebidos";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d assinaturas exportadas com sucesso";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d assinaturas importadas com sucesso";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d artigos não lidos";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artigos";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u não lidos";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Uma pasta com este nome já existe";
@@ -578,16 +560,4 @@
 
 /* No comment provided by engineer. */
 "You cannot undo this action" = "Você não poderá desfazer essa ação";
-
-/* Class = "NSButtonCell"; title = "Empty Trash"; ObjectID = "17"; */
-"Empty Trash" = "Esvaziar Lixeira";
-
-/* Class = "NSButtonCell"; title = "Don't Empty Trash"; ObjectID = "18"; */
-"Don’t Empty Trash" = "Não Esvaziar Lixeira";
-
-/* Class = "NSTextFieldCell"; title = "There are deleted articles in the trash. Would you like to empty the trash before quitting?"; ObjectID = "19"; */
-"There are deleted articles in the trash. Would you like to empty the trash before quitting?" = "Existem artigos apagados na lixeira. Você deseja esvaziar a lixeira antes de encerrar?";
-
-/* Class = "NSButtonCell"; title = "Do not show this warning again"; ObjectID = "20"; */
-"Do not show this warning again" = "Não mostrar este aviso novamente";
 

--- a/Vienna/Resources/pt-BR.lproj/Localizable.strings
+++ b/Vienna/Resources/pt-BR.lproj/Localizable.strings
@@ -4,9 +4,6 @@
 /* No comment provided by engineer. */
 "(Untitled Feed)" = "(Notícias Sem Título)";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d novos artigos recebidos";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Uma pasta com este nome já existe";
 

--- a/Vienna/Resources/pt-BR.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/pt-BR.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d novos artigos descarregados</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d novos artigos recebidos</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/pt.lproj/Localizable.strings
+++ b/Vienna/Resources/pt.lproj/Localizable.strings
@@ -7,9 +7,6 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ Informação";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d novos artigos recebidos";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Já existe uma pasta com esse nome";
 

--- a/Vienna/Resources/pt.lproj/Localizable.strings
+++ b/Vienna/Resources/pt.lproj/Localizable.strings
@@ -7,26 +7,8 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ Informação";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d novos artigos recebidos";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d novos artigos recebidos";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d subscrições exportadas com sucesso";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d subscrições importadas com sucesso";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d artigos não lidos";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artigos";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u não lidos";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Já existe uma pasta com esse nome";

--- a/Vienna/Resources/pt.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/pt.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d novos artigos recebidos</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d novos artigos recebidos</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/ru.lproj/Localizable.strings
+++ b/Vienna/Resources/ru.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ непрочитано";
 
-/* Notification body */
-"%d new unread articles retrieved" = "Получено %d новых статей";
-
 /* Title in popup submenu */
 "<None>" = "<Нет>";
 

--- a/Vienna/Resources/ru.lproj/Localizable.strings
+++ b/Vienna/Resources/ru.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ непрочитано";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "Получено %d новых статей";
-
 /* Notification body */
 "%d new unread articles retrieved" = "Получено %d новых статей";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "Успешно экспортировано %d каналов";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "Успешно импортировано %d каналов";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d непрочитанных статей";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u статей";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u непрочитано";
 
 /* Title in popup submenu */
 "<None>" = "<Нет>";
@@ -206,9 +188,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "Очистить Корзину";
-
-/* Title of a menu item */
-"Empty Trash…" = "Очистить Корзину…";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Вложения";

--- a/Vienna/Resources/ru.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/ru.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>Получено %d новых статей</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d new unread articles retrieved</string>
+			<key>many</key>
+			<string>%d new unread articles retrieved</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>Получено %d новых статей</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/sv.lproj/Localizable.strings
+++ b/Vienna/Resources/sv.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ olästa";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d nya artiklar mottagna";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d nya olästa artiklar mottagna";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d prenumerationer exporterades felfritt";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d prenumerationer importerades felfritt";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d olästa artiklar";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u artiklar";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u olästa";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "En mapp med det namnet finns redan";
@@ -188,9 +170,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "Töm papperskorgen";
-
-/* Title of a menu item */
-"Empty Trash…" = "Töm papperskorgen…";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "Bilaga";

--- a/Vienna/Resources/sv.lproj/Localizable.strings
+++ b/Vienna/Resources/sv.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ olästa";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d nya olästa artiklar mottagna";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "En mapp med det namnet finns redan";
 

--- a/Vienna/Resources/sv.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/sv.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d nya artiklar mottagna</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ny oläst artikel mottagen</string>
+			<key>other</key>
+			<string>%d nya olästa artiklar mottagna</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/tr.lproj/Localizable.strings
+++ b/Vienna/Resources/tr.lproj/Localizable.strings
@@ -7,9 +7,6 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ Bilgi";
 
-/* Notification body */
-"%d new unread articles retrieved" = "%d yeni okunmayan makale alındı";
-
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Bu isimde başka bir klasör var";
 

--- a/Vienna/Resources/tr.lproj/Localizable.strings
+++ b/Vienna/Resources/tr.lproj/Localizable.strings
@@ -7,26 +7,8 @@
 /* No comment provided by engineer. */
 "%@ Info" = "%@ Bilgi";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "%d yeni makale alındı";
-
 /* Notification body */
 "%d new unread articles retrieved" = "%d yeni okunmayan makale alındı";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "%d abonelikleri başarılı bir şekilde çıkarıldı";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "%d abonelikleri başarılı bir şekilde dahil edildi";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d okunmamış makale";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u makale";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u okunmayan";
 
 /* No comment provided by engineer. */
 "A folder with that name already exists" = "Bu isimde başka bir klasör var";

--- a/Vienna/Resources/tr.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/tr.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d yeni makale alındı</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d yeni okunmayan makale alındı</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/uk.lproj/Localizable.strings
+++ b/Vienna/Resources/uk.lproj/Localizable.strings
@@ -14,24 +14,6 @@
 "%@ received" = "одержано %@";
 
 /* No comment provided by engineer. */
-"%d new articles retrieved" = "Отримано %d нових статей";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "Успішно експортовано %d підписок";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "Успішно імпортовано %d підписок";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d непрочитаних статей";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u статей";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u непрочитаних";
-
-/* No comment provided by engineer. */
 "A folder with that name already exists" = "Папка з таким іменем уже існує";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/uk.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/uk.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>Отримано %d нових статей</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>few</key>
+			<string>%d new unread articles retrieved</string>
+			<key>many</key>
+			<string>%d new unread articles retrieved</string>
+			<key>one</key>
+			<string>%d new unread article retrieved</string>
+			<key>other</key>
+			<string>%d new unread articles retrieved</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hans.lproj/Localizable.strings
@@ -10,9 +10,6 @@
 /* Number of bytes received, e.g. 1 MB received */
 "%@ received" = "收到 %@";
 
-/* Notification body */
-"%d new unread articles retrieved" = "收到了 %d 篇新文章";
-
 /* Title in popup submenu */
 "<None>" = "<无>";
 

--- a/Vienna/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hans.lproj/Localizable.strings
@@ -10,26 +10,8 @@
 /* Number of bytes received, e.g. 1 MB received */
 "%@ received" = "收到 %@";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "有 %d 篇新文章";
-
 /* Notification body */
 "%d new unread articles retrieved" = "收到了 %d 篇新文章";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "已经成功输出了 %d 个频道";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "已经成功导入了 %d 个频道";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d 篇未读文章";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u 文章";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u 未读";
 
 /* Title in popup submenu */
 "<None>" = "<无>";

--- a/Vienna/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>有 %d 篇新文章</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>收到了 %d 篇新文章</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Vienna/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hant.lproj/Localizable.strings
@@ -19,26 +19,8 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ 篇未讀的";
 
-/* No comment provided by engineer. */
-"%d new articles retrieved" = "已取得 %d 則新文章";
-
 /* Notification body */
 "%d new unread articles retrieved" = "已順利取得 %d 則未閱讀的新文章";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully exported" = "已順利匯出 %d 個訂閱頻道";
-
-/* No comment provided by engineer. */
-"%d subscriptions successfully imported" = "已順利匯入 %d 個訂閱頻道";
-
-/* No comment provided by engineer. */
-"%d unread articles" = "%d 則未閱讀的文章";
-
-/* No comment provided by engineer. */
-"%u articles" = "%u 則文章";
-
-/* No comment provided by engineer. */
-"%u unread" = "%u 則未閱讀";
 
 /* Title in popup submenu */
 "<None>" = "<无>";
@@ -206,9 +188,6 @@
 
 /* Title of a button on an alert */
 "Empty Trash" = "清空垃圾桶";
-
-/* Title of a menu item */
-"Empty Trash…" = "清空垃圾桶...";
 
 /* Data field name (Y/N) visible in menu/smart folder definition */
 "Enclosure" = "隨附項目";

--- a/Vienna/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hant.lproj/Localizable.strings
@@ -19,9 +19,6 @@
 /* No comment provided by engineer. */
 "%@ unread" = "%@ 篇未讀的";
 
-/* Notification body */
-"%d new unread articles retrieved" = "已順利取得 %d 則未閱讀的新文章";
-
 /* Title in popup submenu */
 "<None>" = "<无>";
 

--- a/Vienna/Resources/zh-Hant.lproj/Localizable.stringsdict
+++ b/Vienna/Resources/zh-Hant.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>已取得 %d 則新文章</string>
 		</dict>
 	</dict>
+	<key>%d new unread articles retrieved</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@articles@</string>
+		<key>articles</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>已順利取得 %d 則未閱讀的新文章</string>
+		</dict>
+	</dict>
 	<key>%d subscriptions successfully exported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
Note that the removed plural keys from Localizable.strings is done automatically by Xcode, because these are already present in the Localizable.stringsdict files.