### PR TITLE
Add ClangFormat configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+# ClangFormat 14.0
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+AlignConsecutiveMacros:                         AcrossEmptyLinesAndComments
+AlignOperands:                                  DontAlign
+AlignTrailingComments:                          false
+AllowShortFunctionsOnASingleLine:               Empty
+AllowShortLoopsOnASingleLine:                   false
+BraceWrapping:
+  AfterFunction:                                true
+BreakBeforeBraces:                              Custom
+ColumnLimit:                                    0
+IncludeBlocks:                                  Preserve
+IncludeCategories:
+  - Regex:                                      '^<'
+    Priority:                                   1
+    SortPriority:                               0
+    CaseSensitive:                              false
+  - Regex:                                      '.*'
+    Priority:                                   2
+    SortPriority:                               0
+    CaseSensitive:                              false
+IncludeIsMainRegex:                             (\+?.*)?$
+IncludeIsMainSourceRegex:                       (\+?.*\.h)$
+IndentWidth:                                    4
+IndentWrappedFunctionNames:                     true
+KeepEmptyLinesAtTheStartOfBlocks:               false
+ObjCBlockIndentWidth:                           4
+ObjCSpaceAfterProperty:                         true
+SeparateDefinitionBlocks:                       Always
+SortIncludes:                                   CaseInsensitive
+SpaceAroundPointerQualifiers:                   Before
+SpacesInContainerLiterals:                      false


### PR DESCRIPTION
We have discussed this a bunch of times (based on [this gist](https://gist.github.com/Eitot/08b1dda5333f40930ef983943cb0c8f3)). I am adding a configuration now, because I am frequently using it with `git-clang-format` to reformat some of the PRs.

ClangFormat 15 actually adds an option to add braces to control statements automatically, so there probably is no need for ClangTidy anymore once LLVM 15 is released.