### PR TITLE
Re-enable WKWebView background drawing and add alternative

### DIFF
--- a/Vienna/Sources/Main window/WKWebViewConfiguration+Private.h
+++ b/Vienna/Sources/Main window/WKWebViewConfiguration+Private.h
@@ -2,7 +2,7 @@
 //  WKWebViewConfiguration+Private.h
 //  Vienna
 //
-//  Copyright 2021-2022 Eitot
+//  Copyright 2021 Eitot
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -24,7 +24,5 @@
 // This is implemented by WKWebpagePreferences.allowsContentJavaScript as of
 // macOS 11.
 @property (setter=_setAllowsJavaScriptMarkup:, nonatomic) BOOL _allowsJavaScriptMarkup NS_DEPRECATED_MAC(10.12, 11);
-
-@property (setter=_setDrawsBackground:, nonatomic) BOOL _drawsBackground NS_AVAILABLE_MAC(10.14);
 
 @end

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -47,11 +47,7 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
 
     @objc
     init(frame: NSRect) {
-        let configuration = WKWebViewConfiguration()
-        if #available(macOS 10.14, *), configuration.responds(to: #selector(setter: WKWebViewConfiguration._drawsBackground)) {
-            configuration._drawsBackground = false
-        }
-        super.init(frame: frame, configuration: configuration)
+        super.init(frame: frame, configuration: WKWebViewConfiguration())
         if responds(to: #selector(setter: _textZoomFactor)) {
             _textZoomFactor = Preferences.standard.textSizeMultiplier
         }

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -27,6 +27,7 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
     var articles: [Article] = [] {
         didSet {
             guard !articles.isEmpty else {
+                isHidden = true
                 self.clearHTML()
                 return
             }
@@ -36,6 +37,7 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
             self.htmlPath = htmlPath
 
             self.loadFileURL(htmlPath, allowingReadAccessTo: htmlPath.deletingLastPathComponent())
+            isHidden = false
         }
     }
 


### PR DESCRIPTION
The previous solution leads to problems when the HTML page has no defined background colour. Web developers might not do this if the background colour is white (which is the browser default). This is something beyond our control, since users can choose to display the HTML version of an article.

Hiding the web view entirely seems to provide a similar solution, but it is not ideal either. For a split second, the white background might be visible. This could be remedied by waiting until the webpage has finished loading.