### PR TITLE
Fix "Use Web Page for Articles" option

### DIFF
--- a/Vienna/Sources/Main window/ArticleView.m
+++ b/Vienna/Sources/Main window/ArticleView.m
@@ -77,22 +77,11 @@ self.converter = [[WebViewArticleConverter alloc] init];
 	return NO;
 }
 
-/* clearHTML
- * Make the web view behave like a blank page.
- */
--(void)clearHTML
-{
-    self.hidden = YES;
-    self.tabUrl = [NSURL URLWithString:@"about:blank"];
-    [self loadTab];
-    html = @"";
-}
-
 -(void)setArticles:(NSArray<Article *> *)articles {
     if (articles.count > 0) {
         [self setHtml:[self.converter articleTextFromArray:articles]];
     } else {
-        [self clearHTML];
+        self.hidden = YES;
     }
 }
 
@@ -266,7 +255,8 @@ self.converter = [[WebViewArticleConverter alloc] init];
 }
 
 - (void)loadTab {
-    [[self mainFrame] loadRequest:[NSURLRequest requestWithURL: self.tabUrl]];
+    [self.mainFrame loadRequest:[NSURLRequest requestWithURL: self.tabUrl]];
+    self.hidden = NO;
 }
 
 - (BOOL)canScrollDown {

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -28,7 +28,6 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
         didSet {
             guard !articles.isEmpty else {
                 isHidden = true
-                self.clearHTML()
                 return
             }
 
@@ -67,6 +66,13 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
         }
     }
 
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        var navig: WKNavigation?
+        navig = super.load(request)
+        isHidden = false
+        return navig
+    }
+
     /// handle special keys when the article view has the focus
     override func keyDown(with event: NSEvent) {
         if let pressedKeys = event.characters, pressedKeys.count == 1 {
@@ -78,11 +84,6 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
         }
         super.keyDown(with: event)
     }
-
-    func clearHTML() {
-        deleteHtmlFile()
-        load(URLRequest(url: URL.blank))
-     }
 
     func resetTextSize() {
         makeTextStandardSize(self)


### PR DESCRIPTION
Articles did not appear in the article view pane when the "Use Web Page
for Articles" / "Load Full HTML Articles" option was enabled for the
folder.

Issue #1592