### PR TITLE
Make transitions in article view pane smoother

### DIFF
--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1118,13 +1118,15 @@
 		Folder * folder = [[Database sharedManager] folderFromID:firstArticle.folderId];
 		if (folder.loadsFullHTML && msgArray.count == 1)
 		{
+			if (!self.currentPageFullHTML) {
+			    // Clear out the text so the user knows something happened in response to the
+			    // click on the article.
+			    [articleText setArticles:@[]];
+			}
+
 			// Remember we have a full HTML page so we can setup the context menus
 			// appropriately.
 			self.currentPageFullHTML = YES;
-			
-			// Clear out the text so the user knows something happened in response to the
-			// click on the article.
-			[articleText setArticles:@[]];
 			
 			// Now set the article to the URL in the RSS feed's article. NOTE: We use
 			// performSelector:withObject:afterDelay: here so that this link load gets

--- a/Vienna/Sources/Main window/ArticleView.m
+++ b/Vienna/Sources/Main window/ArticleView.m
@@ -81,6 +81,7 @@ self.converter = [[WebViewArticleConverter alloc] init];
     if (articles.count > 0) {
         [self setHtml:[self.converter articleTextFromArray:articles]];
     } else {
+        [self setHtml:@"<html><meta name=\"color-scheme\" content=\"light dark\"><body></body></html>"];
         self.hidden = YES;
     }
 }
@@ -89,7 +90,6 @@ self.converter = [[WebViewArticleConverter alloc] init];
  * Loads the web view with the specified HTML text.
  */
 - (void)setHtml:(NSString *)htmlText {
-	self.hidden = NO;
 	// If the current HTML is the same as the new HTML then we don't need to
 	// do anything here. This will stop the view from spurious redraws of the same
 	// article after a refresh.
@@ -101,6 +101,7 @@ self.converter = [[WebViewArticleConverter alloc] init];
 	
 	[self.mainFrame loadHTMLString:html
 							  baseURL:[NSURL URLWithString:@"/"]];
+	self.hidden = NO;
 }
 
 /* keyDown

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -27,6 +27,7 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
     var articles: [Article] = [] {
         didSet {
             guard !articles.isEmpty else {
+                self.loadHTMLString("<html><meta name=\"color-scheme\" content=\"light dark\"><body></body></html>", baseURL: URL.blank)
                 isHidden = true
                 return
             }


### PR DESCRIPTION
Limit redraws
Make transition pages respect dark mode

Especially useful for users frenetically using arrow keys to navigate
in article list, while "Use Web Page for Articles" / "Load Full HTML
Articles" is enabled.

Follow-up of #1592