### PR TITLE
Restore folder list width between app relaunches

### DIFF
--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -46,6 +46,9 @@ final class MainWindowController: NSWindowController {
 
     override func windowDidLoad() {
         super.windowDidLoad()
+        // workaround for autosave not working when name is set in Interface Builder
+        // cf. https://stackoverflow.com/q/16587058
+        splitView.autosaveName = "VNASplitView"
 
         (self.browser as? RSSSource)?.rssSubscriber = self
 


### PR DESCRIPTION
AutosaveName needs to be set programmatically after the view has been
added.

Issue #1595