### PR TITLE
Modify some keyboard navigation to be like Vienna 3.7

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2261,6 +2261,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			
             if (activeBrowserTab == nil) {
                 //we are in the article view
+                [self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
                 if (flags & NSEventModifierFlagShift) {
                     [self.articleController.mainArticleView scrollUpDetailsOrGoBack];
 				} else {


### PR DESCRIPTION
When Space (or Shift-Space) keyboard shortcut is used, set focus on the
article list so that Space followed by Enter will open the article page
instead of the homepage.

Issue #1609