### PR TITLE
Fix article list sometimes not appearing on start

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -254,11 +254,6 @@
 
 	self.toolbarSearchField = self.mainWindowController.toolbarSearchField;
 
-	Preferences * prefs = [Preferences standardPreferences];
-
-    // Restore the most recent layout
-    [self setLayout:prefs.layout withRefresh:NO];
-
     // Set the delegates
     [NSApplication sharedApplication].delegate = self;
 	
@@ -285,6 +280,11 @@
 		[NSApp terminate:nil];
 		return;
 	}
+
+	Preferences * prefs = [Preferences standardPreferences];
+
+    // Restore the most recent layout
+    [self setLayout:prefs.layout withRefresh:NO];
 
 	// Initialize the Sort By and Columns menu
 	[self initSortMenu];

--- a/Vienna/Sources/Main window/WebViewBrowser.m
+++ b/Vienna/Sources/Main window/WebViewBrowser.m
@@ -130,19 +130,15 @@
     if (_primaryTab) {
         [self.tabBarControl.tabView removeTabViewItem:_primaryTab];
     }
+    _primaryTab = newPrimaryTab;
 
     [self.tabBarControl.tabView insertTabViewItem:newPrimaryTab atIndex:0];
 
 	[newPrimaryTab setHasCloseButton:NO];
 	newPrimaryTab.identifier = newPrimaryTab.view;
 
-	_primaryTab = newPrimaryTab;
-	
 	[self.primaryTab.view setNeedsDisplay:YES];
 	[self switchToPrimaryTab];
-	//this call seems to be necessary manually here, no delegate call
-	//maybe setPrimaryTab is called earlier than the delegate IBOutlet setup.
-	[self tabView:self.tabBarControl.tabView didSelectTabViewItem:newPrimaryTab];
 }
 
 /* activeTab


### PR DESCRIPTION
Under certain circumstances, the article list would be empty after app launch.
We make sure the app is ready to handle notifications before setting up the display of article list.

Issue #1623