### PR TITLE
Add printing support to the new browser

### DIFF
--- a/Vienna/Interfaces/Base.lproj/MainMenu.xib
+++ b/Vienna/Interfaces/Base.lproj/MainMenu.xib
@@ -207,6 +207,7 @@ CA
                             <menuItem title="Page Setup…" keyEquivalent="P" id="77">
                                 <connections>
                                     <action selector="runPageLayout:" target="-1" id="87"/>
+                                    <binding destination="EBo-gz-68t" name="hidden" keyPath="values.UseNewBrowser" id="Dki-E4-XNg"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Print…" keyEquivalent="p" id="78">

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1591,7 +1591,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     id<Tab> activeBrowserTab = self.browser.activeTab;
 
     if (activeBrowserTab) {
-        [activeBrowserTab printPage];
+        [activeBrowserTab printDocument:sender];
     }
 }
 

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -769,7 +769,7 @@ static void *ObserverContext = &ObserverContext;
 -(void)printDocument:(id)sender
 {
     if (self.useNewBrowser) {
-        [articleText printPage];
+        [articleText printDocument:sender];
     } else {
         [((TabbedWebView *)articleText) printDocument:sender];
     }

--- a/Vienna/Sources/Main window/ArticleView.m
+++ b/Vienna/Sources/Main window/ArticleView.m
@@ -277,10 +277,6 @@ self.converter = [[WebViewArticleConverter alloc] init];
     return (visibleRect.origin.y > 2);
 }
 
-- (void)printPage {
-	//TODO
-}
-
 - (void)reloadTab {
 	//TODO
 }

--- a/Vienna/Sources/Main window/BrowserPane.m
+++ b/Vienna/Sources/Main window/BrowserPane.m
@@ -722,11 +722,6 @@
 	return canGoForward;
 }
 
-- (void)printPage {
-	[self.webPane printDocument:self];
-}
-
-
 - (void)reloadTab {
     [self handleReload:nil];
 }

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -325,10 +325,8 @@ extension BrowserTab: Tab {
         webView.makeTextLarger(self)
     }
 
-    func printPage() {
-        // TODO: neither Javascript nor the native print methods work here. This is a webkit bug:
-        // rdar://problem/36557179
-        self.webView.printView(nil)
+    func printDocument(_ sender: Any?) {
+        webView.printView(sender)
     }
 
     func activateAddressBar() {

--- a/Vienna/Sources/Main window/Tab.swift
+++ b/Vienna/Sources/Main window/Tab.swift
@@ -53,7 +53,7 @@ protocol Tab {
 
     // MARK: other actions
 
-    func printPage()
+    func printDocument(_ sender: Any?)
     func activateAddressBar()
     func activateWebView()
 }

--- a/Vienna/Sources/Main window/TabbedWebView.m
+++ b/Vienna/Sources/Main window/TabbedWebView.m
@@ -474,7 +474,7 @@ static NSString * _userAgent ;
 	dict[NSPrintBottomMargin] = @36.0;
 	
 	[printInfo setVerticallyCentered:NO];
-	[printView print:self];
+	[printView print:sender];
 }
 
 /* maintainsInactiveSelection

--- a/Vienna/Sources/Main window/WKWebView+Private.h
+++ b/Vienna/Sources/Main window/WKWebView+Private.h
@@ -17,7 +17,8 @@
 //  limitations under the License.
 //
 
-@import Foundation;
+@import Cocoa;
+@import WebKit;
 
 @interface WKWebView (Private)
 
@@ -26,5 +27,8 @@
 
 @property (readonly, nonatomic) BOOL _supportsTextZoom;
 @property (setter=_setTextZoomFactor:, nonatomic) double _textZoomFactor;
+
+// This is implemented by WKWebView.printOperationWithPrintInfo as of macOS 11.
+- (NSPrintOperation *)_printOperationWithPrintInfo:(NSPrintInfo *)printInfo NS_DEPRECATED_MAC(10.12, 11);
 
 @end

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -69,10 +69,6 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
         hideAddressBar(true)
     }
 
-    func printDocument(_ sender: Any) {
-        // TODO
-    }
-
     // MARK: gui
 
     override func activateAddressBar() {

--- a/Vienna/Sources/Shared/BaseView.h
+++ b/Vienna/Sources/Shared/BaseView.h
@@ -24,7 +24,6 @@
 @protocol BaseView
 @required
 	-(void)performFindPanelAction:(NSInteger)tag;
-	-(void)printDocument:(id)sender;
 	@property (readonly, nonatomic) NSString *viewLink;
 	@property (nonatomic, readonly) NSView *mainView;
 	-(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags;


### PR DESCRIPTION
This uses private WebKit APIs on systems before macOS 11.

I have not tested this on any older systems (I have no access to those anymore, since I am using an M1 Mac). Can someone test this on macOS 10.12 or macOS 10.13?