### PR TITLE
Fix status text in window's status bar

### DIFF
--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -216,25 +216,30 @@ extension MainWindowController: NSWindowDelegate {
 
     func windowDidBecomeMain(_ notification: Notification) {
         statusLabel.textColor = .windowFrameTextColor
+    }
+
+    func windowDidResignMain(_ notification: Notification) {
+        statusLabel.textColor = .disabledControlTextColor
+    }
+
+    func windowDidChangeOcclusionState(_ notification: Notification) {
+        guard let window, window.occlusionState.contains(.visible) else {
+            observationTokens.removeAll()
+            return
+        }
 
         observationTokens = [
-            OpenReader.shared.observe(\.statusMessage, options: .new) { [weak self] manager, change in
+            OpenReader.shared.observe(\.statusMessage, options: [.initial, .new]) { [weak self] manager, change in
                 if change.newValue is String {
                     self?.statusLabel.stringValue = manager.statusMessage
                 }
             },
-            RefreshManager.shared.observe(\.statusMessage, options: .new) { [weak self] manager, change in
+            RefreshManager.shared.observe(\.statusMessage, options: [.initial, .new]) { [weak self] manager, change in
                 if change.newValue is String {
                     self?.statusLabel.stringValue = manager.statusMessage
                 }
             }
         ]
-    }
-
-    func windowDidResignMain(_ notification: Notification) {
-        statusLabel.textColor = .disabledControlTextColor
-
-        observationTokens.removeAll()
     }
 
 }


### PR DESCRIPTION
This fixes a latent bug that causes the status text in the main window's "status bar" (the bottom bar) to display outdated information. This happens, e.g., when the user starts a fetch, switches to a different app and comes back to Vienna later.