### PR TITLE
Fix Round Robin of tabs

### DIFF
--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -212,11 +212,19 @@ extension TabbedBrowserViewController: Browser {
     }
 
     func showPreviousTab() {
-        self.tabView?.selectPreviousTabViewItem(nil)
+        if self.tabView?.selectedTabViewItem == primaryTab {
+            self.tabView?.selectLastTabViewItem(nil)
+        } else {
+            self.tabView?.selectPreviousTabViewItem(nil)
+        }
     }
 
     func showNextTab() {
-        self.tabView?.selectNextTabViewItem(nil)
+        if getIndexAfterSelected() == browserTabCount {
+            self.tabView?.selectFirstTabViewItem(nil)
+        } else {
+            self.tabView?.selectNextTabViewItem(nil)
+        }
     }
 
     func closeActiveTab() {


### PR DESCRIPTION
"Previous Tab / Next Tab" menu commands should cycle between open tabs, handling transitions between last tab and first tab when respective ends are reached.

https://forums.cocoaforge.com/viewtopic.php?f=18&t=27266&p=141046
Fix issue #1655