### PR TITLE
Fix toolbar search field behaviour

### DIFF
--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -274,7 +274,7 @@ extension MainWindowController: NSToolbarDelegate {
             item.menuFormRepresentation = NSMenuItem(title: item.label, action: item.action, keyEquivalent: "")
 
             toolbarSearchField?.sendsWholeSearchString = true
-            toolbarSearchField?.sendsSearchStringImmediately = false
+            toolbarSearchField?.cell?.sendsActionOnEndEditing = false
 
             return item
         }


### PR DESCRIPTION
I have taken this out of #1566, since this is a bug fix.

This fixes the issue that causes a search to start when the user presses the search button. This restores the functionality up to c4738f0.

When NSCell's `sendsActionOnEndEditing` is set to `false` (`true` by default),  the search field only sends the action when the user presses the enter/return key. When set to `true` it also sends the action when the user clicks on the search button or the search field loses its first responder status, such as when the user deselects the search field or clicks on the search button to select a scope.