### PR TITLE
Adopt new WebKit API

### DIFF
--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -13,9 +13,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-13]
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     timeout-minutes: 15
 
     steps:

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -48,8 +48,10 @@ class CustomWKWebView: WKWebView {
         let prefs = configuration.preferences
         prefs.javaScriptCanOpenWindowsAutomatically = true
 
-        if prefs.responds(to: #selector(setter: WKPreferences._fullScreenEnabled)) {
-            prefs._fullScreenEnabled = true
+        if #available(macOS 12.3, *) {
+            prefs.isElementFullscreenEnabled = true
+        } else if prefs.responds(to: #selector(setter: WKPreferences._isFullScreenEnabled)) {
+            prefs._isFullScreenEnabled = true
         }
 
         #if DEBUG
@@ -97,6 +99,9 @@ class CustomWKWebView: WKWebView {
         self.allowsMagnification = true
         self.allowsBackForwardNavigationGestures = true
         self.allowsLinkPreview = true
+        if #available(macOS 13.3, *) {
+            isInspectable = true
+        }
     }
 
     @available(*, unavailable)

--- a/Vienna/Sources/Main window/WKPreferences+Private.h
+++ b/Vienna/Sources/Main window/WKPreferences+Private.h
@@ -1,5 +1,5 @@
 //
-//  WKPreferences_Private.h
+//  WKPreferences+Private.h
 //  Vienna
 //
 //  Copyright 2020 Tassilo Karge
@@ -25,6 +25,9 @@
 @property (setter=_setDeveloperExtrasEnabled:, nonatomic) BOOL _developerExtrasEnabled;
 #endif
 
-@property (setter=_setFullScreenEnabled:, nonatomic) BOOL _fullScreenEnabled;
+// This is implemented by WKPreferences.elementFullscreenEnabled as of
+// macOS 12.3.
+@property (setter=_setFullScreenEnabled:, nonatomic) BOOL _fullScreenEnabled
+    NS_SWIFT_NAME(_isFullScreenEnabled) NS_DEPRECATED_MAC(10.12, 12.3);
 
 @end


### PR DESCRIPTION
WKWebView `isInspectable` allows users to use Safari's developer mode to inspect Vienna's web views in release builds. Before this commit, only developer/debug builds were inspectable. `_developerExtrasEnabled` is not equivalent, it adds menu items to the context menu when invoked from one of Vienna's web views. I have left it there for ease of developing.

WKPreferences `isElementFullscreenEnabled` is equivalent to `_fullScreenEnabled` (in the WebKit source code, they invoke the same methods), despite the different name.