### PR TITLE
Perform Xcode 14.3 compatibility check

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1848,9 +1848,10 @@
 		2A37F4A9FDCFA73011CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = VNA;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "Vienna project";
 				TargetAttributes = {
 					035B703419E0E4AE00197334 = {

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/CombinePredicateTranslations.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/CombinePredicateTranslations.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/ComparePredicateTranslations.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/ComparePredicateTranslations.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/Deployment.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/Deployment.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/ExpandPredicateTranslations.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/ExpandPredicateTranslations.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This suppresses the nagging warning about using the "recommended" deployment target.