### PR TITLE
Add braces to all statements and reformat them

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -92,7 +92,7 @@
 		37C650801816EBAD3C0D9DBF /* NSURL+CaminoExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37C65C3C01B0F8EE0C0E5A52 /* NSURL+CaminoExtensions.m */; };
 		3A0F2A55258FBB8B0036397F /* TabbedBrowserViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2FDF6FBD218A266A002F77E9 /* TabbedBrowserViewController.xib */; };
 		3A0F2A9E258FCB780036397F /* BrowserTab.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2FDF6FBE218A266A002F77E9 /* BrowserTab.xib */; };
-		3A171C00210B551B00B80FBB /* TRVSURLSessionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A171BF1210B551B00B80FBB /* TRVSURLSessionOperation.m */; settings = {COMPILER_FLAGS = "-Wno-completion-handler -Wno-idiomatic-parentheses"; }; };
+		3A171C00210B551B00B80FBB /* TRVSURLSessionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A171BF1210B551B00B80FBB /* TRVSURLSessionOperation.m */; settings = {COMPILER_FLAGS = "-Wno-completion-handler -Wno-idiomatic-parentheses -Xclang -analyzer-tidy-checker=-readability-braces-around-statements"; }; };
 		3A4DBEC71733C207006DD2AB /* ArticleCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A4DBEC61733C206006DD2AB /* ArticleCellView.m */; };
 		3A500122259A63CB00AA6AAD /* ArticleConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC4A1BE25852C0E005FF227 /* ArticleConverter.swift */; };
 		3A500129259A640D00AA6AAD /* ArticleStyleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2280372271B18A005D1023 /* ArticleStyleLoader.swift */; };
@@ -133,7 +133,7 @@
 		435028B7165DE9E00018EDB7 /* UnifiedDisplayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350288E165DE9DF0018EDB7 /* UnifiedDisplayView.m */; };
 		435028B8165DE9E00018EDB7 /* URLHandlerCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 43502890165DE9DF0018EDB7 /* URLHandlerCommand.m */; };
 		435028B9165DE9E00018EDB7 /* ViennaApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 43502892165DE9DF0018EDB7 /* ViennaApp.m */; };
-		43BA97FE1664804E00B95F35 /* DSClickableURLTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E09F2C111192B7003B530A /* DSClickableURLTextField.m */; };
+		43BA97FE1664804E00B95F35 /* DSClickableURLTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E09F2C111192B7003B530A /* DSClickableURLTextField.m */; settings = {COMPILER_FLAGS = "-Xclang -analyzer-tidy-checker=-readability-braces-around-statements"; }; };
 		4D36B44B1D37F91E009736C1 /* VNAArticleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D36B44A1D37F91E009736C1 /* VNAArticleTests.m */; };
 		664F87C713C62DFE00E266DE /* OpenReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 664F87C613C62DFE00E266DE /* OpenReader.m */; };
 		793C95331C42A0DD00984D4E /* FoldersFilterable.m in Sources */ = {isa = PBXBuildFile; fileRef = 793C95321C42A0DD00984D4E /* FoldersFilterable.m */; };
@@ -3136,6 +3136,8 @@
 					"-Wunreachable-code-break",
 					"-Wunreachable-code-return",
 					"-Wunused-macros",
+					"-Xclang",
+					"-analyzer-tidy-checker=readability-braces-around-statements,readability-misleading-indentation",
 				);
 			};
 			name = Development;
@@ -3174,6 +3176,8 @@
 					"-Wunreachable-code-break",
 					"-Wunreachable-code-return",
 					"-Wunused-macros",
+					"-Xclang",
+					"-analyzer-tidy-checker=readability-braces-around-statements,readability-misleading-indentation",
 				);
 			};
 			name = Deployment;

--- a/Vienna/Sources/Alerts/NewGroupFolder.m
+++ b/Vienna/Sources/Alerts/NewGroupFolder.m
@@ -37,8 +37,7 @@
  */
 -(void)newGroupFolder:(NSWindow *)window underParent:(NSInteger)itemId
 {
-	if (!newGroupFolderWindow)
-	{
+	if (!newGroupFolderWindow) {
 		NSArray * objects;
 		[[NSBundle bundleForClass:[self class]] loadNibNamed:@"GroupFolder" owner:self topLevelObjects:&objects];
 		self.topObjects = objects;
@@ -70,8 +69,9 @@
 	[newGroupFolderWindow.sheetParent endSheet:newGroupFolderWindow];
 	[newGroupFolderWindow orderOut:self];
 	
-	if (newFolderId != -1)
+	if (newFolderId != -1) {
 		[APPCONTROLLER selectFolder:newFolderId];
+	}
 }
 
 /* doCancel

--- a/Vienna/Sources/Alerts/NewSubscription.m
+++ b/Vienna/Sources/Alerts/NewSubscription.m
@@ -42,8 +42,7 @@
  */
 -(instancetype)initWithDatabase:(Database *)newDb
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		db = newDb;
 		sourcesDict = nil;
 		editFolderId = -1;
@@ -140,8 +139,7 @@
 	[self loadRSSFeedBundle];
 
 	Folder * folder = [db folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
 		editFeedURL.stringValue = folder.feedURL;
 		[self enableSaveButton];
 		editFolderId = folderId;
@@ -156,8 +154,7 @@
  */
 -(void)loadRSSFeedBundle
 {
-	if (!editRSSFeedWindow || !newRSSFeedWindow)
-	{
+	if (!editRSSFeedWindow || !newRSSFeedWindow) {
 		NSArray * objects;
 		[[NSBundle bundleForClass:[self class]] loadNibNamed:@"RSSFeed" owner:self topLevelObjects:&objects];
 		self.topObjects = objects;
@@ -174,19 +171,18 @@
 	NSURL * rssFeedURL;
 	NSString * feedURLString = (feedURL.stringValue).vna_trimmed;
 	// Replace feed:// with http:// if necessary
-	if ([feedURLString hasPrefix:@"feed://"])
+	if ([feedURLString hasPrefix:@"feed://"]) {
 		feedURLString = [NSString stringWithFormat:@"http://%@", [feedURLString substringFromIndex:7]];
+	}
 
 	// Format the URL based on the selected feed source.
-	if (sourcesDict != nil)
-	{
+	if (sourcesDict != nil) {
 		NSString * selectedSource = (NSString *)feedSource.selectedItem.representedObject;
 		NSDictionary * feedSourceType = [sourcesDict valueForKey:selectedSource];
 		NSString * linkTemplate = [feedSourceType valueForKey:@"LinkTemplate"];
         if ([selectedSource.lowercaseString isEqualToString:@"local file"]) {
             rssFeedURL = [NSURL fileURLWithPath:feedURLString.stringByExpandingTildeInPath];
-        }
-        else if (linkTemplate.length > 0) {
+        } else if (linkTemplate.length > 0) {
             rssFeedURL = [NSURL URLWithString:[NSString stringWithFormat:linkTemplate, feedURLString]];
         }
 	}
@@ -197,8 +193,7 @@
 	NSAssert(rssFeedURL != nil, @"No valid URL verified to attempt subscription !");
 
  	// Check if we have already subscribed to this feed by seeing if a folder exists in the db
-	if ([db folderFromFeedURL:rssFeedURL.absoluteString] != nil)
-	{
+	if ([db folderFromFeedURL:rssFeedURL.absoluteString] != nil) {
         NSAlert *alert = [NSAlert new];
         alert.messageText = NSLocalizedString(@"Error", @"Already subscribed title");
         alert.informativeText = NSLocalizedString(@"You are already subscribed to that feed", @"You are already subscribed to that feed");
@@ -294,17 +289,16 @@
 	NSMenuItem * feedSourceItem = feedSource.selectedItem;
 	NSString * linkTitleString = nil;
 	BOOL showButton = NO;
-	if (feedSourceItem != nil)
-	{
+	if (feedSourceItem != nil) {
 		NSDictionary * itemDict = [sourcesDict valueForKey:feedSourceItem.title];
-		if (itemDict != nil)
-		{
+		if (itemDict != nil) {
 			linkTitleString = [itemDict valueForKey:@"LinkName"];
 			showButton = [itemDict valueForKey:@"SiteHomePage"] != nil;
 		}
 	}
-	if (linkTitleString == nil)
+	if (linkTitleString == nil) {
 		linkTitleString = @"Link";
+	}
 	linkTitle.stringValue = [NSString stringWithFormat:@"%@:", linkTitleString];
 	siteHomePageButton.hidden = !showButton;
 }
@@ -314,11 +308,9 @@
 -(void)doShowSiteHomePage:(id)sender
 {
 	NSMenuItem * feedSourceItem = feedSource.selectedItem;
-	if (feedSourceItem != nil)
-	{
+	if (feedSourceItem != nil) {
 		NSDictionary * itemDict = [sourcesDict valueForKey:feedSourceItem.title];
-		if (itemDict != nil)
-		{
+		if (itemDict != nil) {
 			NSString * siteHomePageURL = [itemDict valueForKey:@"SiteHomePage"];
 			NSURL * url = [[NSURL alloc] initWithString:siteHomePageURL];
 			[[NSWorkspace sharedWorkspace] openURL:url];

--- a/Vienna/Sources/Alerts/SearchPanel.m
+++ b/Vienna/Sources/Alerts/SearchPanel.m
@@ -30,8 +30,7 @@
  */
 -(void)runSearchPanel:(NSWindow *)window
 {
-	if (!searchPanelWindow)
-	{
+	if (!searchPanelWindow) {
 		NSArray * objects;
 		[[NSBundle bundleForClass:[self class]] loadNibNamed:@"SearchPanel" owner:self topLevelObjects:&objects];
 		self.topObjects = objects;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -114,8 +114,7 @@
  */
 -(instancetype)init
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		scriptPathMappings = [[NSMutableDictionary alloc] init];
 		lastCountOfUnread = 0;
 		appStatusItem = nil;
@@ -160,8 +159,7 @@
 -(void)doSafeInitialisation
 {
 	static BOOL doneSafeInit = NO;
-	if (!doneSafeInit)
-	{
+	if (!doneSafeInit) {
 		[self.foldersTree initialiseFoldersTree];
 
 		Preferences * prefs = [Preferences standardPreferences];
@@ -171,14 +169,16 @@
 		// Select the folder and article from the last session
 		NSInteger previousFolderId = [prefs integerForKey:MAPref_CachedFolderID];
 		NSString * previousArticleGuid = [prefs stringForKey:MAPref_CachedArticleGUID];
-		if (previousArticleGuid.vna_isBlank)
+		if (previousArticleGuid.vna_isBlank) {
 			previousArticleGuid = nil;
+		}
 		[self.articleController selectFolderAndArticle:previousFolderId guid:previousArticleGuid];
 
 		[self.mainWindow makeFirstResponder:(previousArticleGuid != nil) ? ((NSView<BaseView> *)self.browser.primaryTab.view).mainView : self.foldersTree.mainView];
 
-		if (prefs.refreshOnStartup)
+		if (prefs.refreshOnStartup) {
 			[self refreshAllSubscriptions:self];
+		}
 
 		doneSafeInit = YES;
 		
@@ -189,8 +189,9 @@
 #pragma mark Accessor Methods
 
 - (NewSubscription *)rssFeed {
-    if (!_rssFeed)
+    if (!_rssFeed) {
         _rssFeed = [[NewSubscription alloc] initWithDatabase:db];
+    }
     return _rssFeed;
 }
 
@@ -219,8 +220,9 @@
 {
 	static NSLayoutManager * theManager = nil;
 	
-	if (theManager == nil)
+	if (theManager == nil) {
 		theManager = [[NSLayoutManager alloc] init];
+	}
 	return theManager;
 }
 
@@ -273,8 +275,7 @@
     [nc addObserver:self selector:@selector(handleGoogleAuthFailed:) name:@"MA_Notify_GoogleAuthFailed" object:nil];
 
 	// Initialize the database
-	if ((db = [Database sharedManager]) == nil)
-	{
+	if ((db = [Database sharedManager]) == nil) {
 		[NSApp terminate:nil];
 		return;
 	}
@@ -306,14 +307,12 @@
 	// Set alternate in main menu for opening pages, and check for correct title of menu item
 	// This is a hack, because Interface Builder refuses to set alternates with only the shift key as modifier.
 	NSMenuItem * alternateItem = menuItemWithAction(@selector(viewSourceHomePageInAlternateBrowser:));
-	if (alternateItem != nil)
-	{
+	if (alternateItem != nil) {
         alternateItem.keyEquivalentModifierMask = NSEventModifierFlagOption;
 		[alternateItem setAlternate:YES];
 	}
 	alternateItem = menuItemWithAction(@selector(viewArticlePagesInAlternateBrowser:));
-	if (alternateItem != nil)
-	{
+	if (alternateItem != nil) {
         alternateItem.keyEquivalentModifierMask = NSEventModifierFlagOption;
 		[alternateItem setAlternate:YES];
 	}
@@ -329,8 +328,9 @@
     self.toolbarSearchField.placeholderString = currentSearchMethod.displayName;
 	
 	// Add Scripts menu if we have any scripts
-	if (!hasOSScriptsMenu())
+	if (!hasOSScriptsMenu()) {
 		[self initScriptsMenu];
+	}
 
 	// Add the app to the status bar if needed.
 	[self showAppInStatusBar];
@@ -342,8 +342,9 @@
     [self scheduleBackgroundRefresh];
 
 	// Register to be notified when the scripts folder changes.
-	if (!hasOSScriptsMenu())
+	if (!hasOSScriptsMenu()) {
 		[self installScriptsFolderWatcher];
+	}
 	
 	// Fix up the Close commands
 	[self updateCloseCommands];
@@ -446,9 +447,8 @@
                 if (alertResponse == NSAlertFirstButtonReturn) {
                     [preferences setInteger:VNAEmptyTrashWithoutWarning
                                      forKey:MAPref_EmptyTrashNotification];
-                }
                 // The user pressed the "Don’t Empty Trash" button
-                else if (alertResponse == NSAlertSecondButtonReturn) {
+                } else if (alertResponse == NSAlertSecondButtonReturn) {
                     [preferences setInteger:VNAEmptyTrashNone
                                      forKey:MAPref_EmptyTrashNotification];
                 }
@@ -476,8 +476,7 @@
 {
     [self unregisterEventHandlers];
     
-	if (didCompleteInitialisation)
-	{
+	if (didCompleteInitialisation) {
 		// Close the activity window explicitly to force it to
 		// save its split bar position to the preferences.
 		NSWindow *activityPanel = self.activityPanelController.window;
@@ -510,43 +509,37 @@
 -(BOOL)application:(NSApplication *)theApplication openFile:(NSString *)filename
 {
 	Preferences * prefs = [Preferences standardPreferences];
-	if ([filename.pathExtension isEqualToString:@"viennastyle"])
-	{
+	if ([filename.pathExtension isEqualToString:@"viennastyle"]) {
 		NSString * styleName = filename.lastPathComponent.stringByDeletingPathExtension;
-		if (![self installFilename:filename toPath:ArticleStyleLoader.stylesDirectoryURL.path])
+		if (![self installFilename:filename toPath:ArticleStyleLoader.stylesDirectoryURL.path]) {
 			prefs.displayStyle = styleName;
-		else
-		{
+		} else {
             [self populateStyleMenu];
 			prefs.displayStyle = styleName;
             runOKAlertPanel(NSLocalizedString(@"Vienna has installed a new style", nil), NSLocalizedString(@"The style \"%@\" has been installed to your Styles folder and added to the Style menu.", nil), styleName);
 		}
 		return YES;
 	}
-	if ([filename.pathExtension isEqualToString:@"viennaplugin"])
-	{
+	if ([filename.pathExtension isEqualToString:@"viennaplugin"]) {
 		NSString * path = PluginManager.plugInsDirectoryURL.path;
-		if ([self installFilename:filename toPath:path])
-		{
+		if ([self installFilename:filename toPath:path]) {
 			runOKAlertPanel(NSLocalizedString(@"Plugin installed", nil), NSLocalizedString(@"A new plugin has been installed. It is now available from the menu and you can add it to the toolbar.", nil));			
 			NSString * fullPath = [path stringByAppendingPathComponent:filename.lastPathComponent];
             [self.pluginManager loadPlugin:fullPath];
 		}
 		return YES;
 	}
-	if ([filename.pathExtension isEqualToString:@"scpt"])
-	{
+	if ([filename.pathExtension isEqualToString:@"scpt"]) {
 		NSFileManager *fileManager = NSFileManager.defaultManager;
 		NSURL *scriptsURL = fileManager.vna_applicationScriptsDirectory;
-		if ([self installFilename:filename toPath:scriptsURL.path])
-		{
-			if (!hasOSScriptsMenu())
+		if ([self installFilename:filename toPath:scriptsURL.path]) {
+			if (!hasOSScriptsMenu()) {
 				[self initScriptsMenu];
+			}
 		}
 		return YES;
 	}
-	if ([filename.pathExtension isEqualToString:@"opml"])
-	{
+	if ([filename.pathExtension isEqualToString:@"opml"]) {
         NSAlert *alert = [NSAlert new];
         alert.messageText = NSLocalizedString(@"Import subscriptions from OPML file?", nil);
         alert.informativeText = NSLocalizedString(@"Do you really want to import the subscriptions from the specified OPML file?", nil);
@@ -561,18 +554,17 @@
             return NO;
         }
 	}
-    if ([filename.pathExtension isEqualToString:@"webloc"])
-    {
+    if ([filename.pathExtension isEqualToString:@"webloc"]) {
         NSURL* url = [NSURL URLFromInetloc:filename];
-        if (!self.mainWindow.visible)
-        	[self.mainWindow makeKeyAndOrderFront:self];
-        if (url != nil && !db.readOnly)
-        {
+        if (!self.mainWindow.visible) {
+            [self.mainWindow makeKeyAndOrderFront:self];
+        }
+        if (url != nil && !db.readOnly) {
             [self.rssFeed newSubscription:self.mainWindow initialURL:url.absoluteString];
 		    return YES;
+        } else {
+            return NO;
         }
-        else
-        	return NO;
     }
 	return NO;
 }
@@ -590,10 +582,8 @@
 	NSFileManager * fileManager = [NSFileManager defaultManager];
 	BOOL isDir = NO;
 	
-	if (![fileManager fileExistsAtPath:path isDirectory:&isDir])
-	{
-		if (![fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:NULL error:NULL])
-		{
+	if (![fileManager fileExistsAtPath:path isDirectory:&isDir]) {
+		if (![fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:NULL error:NULL]) {
 			runOKAlertPanel(NSLocalizedString(@"Cannot create folder", nil), NSLocalizedString(@"The \"%@\" folder cannot be created.", nil), path);
 			return NO;
 		}
@@ -642,8 +632,9 @@
 		item.representedObject = searchMethod;
 		
 		// Is this the currently set search method? If yes, mark it as such.
-		if ( [friendlyName isEqualToString:[Preferences standardPreferences].searchMethod.displayName] )
+		if ( [friendlyName isEqualToString:[Preferences standardPreferences].searchMethod.displayName] ) {
 			item.state = NSControlStateValueOn;
+		}
 		
         if ([searchMethod isEqualTo:SearchMethod.searchForFoldersMethod]) {
             [cellMenu addItem:[NSMenuItem separatorItem]];
@@ -654,19 +645,19 @@
 	
 	// Add all available plugged-in search methods to the menu.
 	NSMutableArray * searchMethods = [NSMutableArray arrayWithArray:self.pluginManager.searchMethods];
-	if (searchMethods.count > 0)
-	{	
+	if (searchMethods.count > 0) {
 		[cellMenu addItem: [NSMenuItem separatorItem]];
 		
-		for (searchMethod in searchMethods)
-		{
-			if (!searchMethod.displayName) 
+		for (searchMethod in searchMethods) {
+			if (!searchMethod.displayName) { 
 				continue;
+			}
 			item = [[NSMenuItem alloc] initWithTitle:searchMethod.displayName action:@selector(setSearchMethod:) keyEquivalent:@""];
 			item.representedObject = searchMethod;
 			// Is this the currently set search method? If yes, mark it as such.
-			if ( [searchMethod.displayName isEqualToString: [Preferences standardPreferences].searchMethod.displayName] )
+			if ( [searchMethod.displayName isEqualToString: [Preferences standardPreferences].searchMethod.displayName] ) {
 				item.state = NSControlStateValueOn;
+			}
 			[cellMenu addItem:item];
 		}
 	} 
@@ -728,14 +719,14 @@
 
 	[self.browser setPrimaryTab:primaryTab];
 	self.foldersTree.mainView.nextKeyView = ((NSView<BaseView> *)self.browser.primaryTab.view).mainView;
-    if (self.selectedArticle == nil)
+    if (self.selectedArticle == nil) {
         [self.mainWindow makeFirstResponder:self.foldersTree.mainView];
-    else
+    } else {
         [self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
+    }
 
 	BOOL isFilterBarVisible = self.isFilterBarVisible;
-	switch (newLayout)
-	{
+	switch (newLayout) {
 		case VNALayoutReport:
 		case VNALayoutCondensed:
 			self.filterDisclosureView = self.mainWindowController.filterDisclosureView;
@@ -759,8 +750,9 @@
 withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
     NSString *urlStr = [event paramDescriptorForKeyword:keyDirectObject].stringValue;
-    if(urlStr)
+    if (urlStr) {
         [self.rssFeed newSubscription:self.mainWindow initialURL:urlStr];
+    }
 }
 
 /** openURLsInDefaultBrowser
@@ -832,8 +824,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	id<Tab> activeBrowserTab = self.browser.activeTab;
 
     [self showMainWindow:self];
-	if (!activeBrowserTab)
-	{
+	if (!activeBrowserTab) {
 		(void)[self.browser createNewTab:nil inBackground:NO load:NO];
     } else {
         [self.browser.activeTab activateAddressBar];
@@ -847,8 +838,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)openURLFromString:(NSString *)urlString inPreferredBrowser:(BOOL)openInPreferredBrowserFlag
 {
 	NSURL * theURL = [NSURL URLWithString:urlString];
-	if (theURL == nil)
-	{
+	if (theURL == nil) {
 		theURL = cleanedUpUrlFromString(urlString);
 	}
 	[self openURL:theURL inPreferredBrowser:openInPreferredBrowserFlag];
@@ -862,10 +852,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	Preferences * prefs = [Preferences standardPreferences];
 	BOOL openURLInVienna = prefs.openLinksInVienna;
-	if (!openInPreferredBrowserFlag)
+	if (!openInPreferredBrowserFlag) {
 		openURLInVienna = (!openURLInVienna);
-	if (openURLInVienna)
-	{
+	}
+	if (openURLInVienna) {
 		BOOL openInBackground = prefs.openLinksInBackground;
         if ([NSEvent modifierFlags] & NSEventModifierFlagShift) {
             openInBackground = !openInBackground;
@@ -874,9 +864,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         for (NSURL * url in urls) {
 			(void)[self.browser createNewTab:url inBackground:openInBackground load:true];
         }
-	}
-	else
+	} else {
 		[self openURLsInDefaultBrowser:urls];
+	}
 }
 
 /* openURL
@@ -885,8 +875,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)openURL:(NSURL *)url inPreferredBrowser:(BOOL)openInPreferredBrowserFlag
 {
-	if (url == nil)
-	{
+	if (url == nil) {
 		NSLog(@"Called openURL:inPreferredBrowser: with nil url.");
 		return;
 	}
@@ -898,10 +887,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)downloadEnclosure:(id)sender
 {
-	for (Article * currentArticle in self.articleController.markedArticleRange)
-	{
-		if (currentArticle.hasEnclosure)
-		{
+	for (Article * currentArticle in self.articleController.markedArticleRange) {
+		if (currentArticle.hasEnclosure) {
 			[[DownloadManager sharedInstance] downloadFileFromURL:currentArticle.enclosure];
 		}
 	}
@@ -959,8 +946,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         panel.allowedFileTypes = @[@"opml"];
     }
     [panel beginSheetModalForWindow:self.mainWindow completionHandler:^(NSInteger returnCode) {
-        if (returnCode == NSModalResponseOK)
-        {
+        if (returnCode == NSModalResponseOK) {
             [panel orderOut:self];
             
             NSInteger countExported = [Export exportToFile:panel.URL.path
@@ -968,15 +954,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
                                                  selection:accessoryController.mode == ExportModeSelectedFeeds
                                                 withGroups:accessoryController.preserveFolders];
             
-            if (countExported < 0)
-            {
+            if (countExported < 0) {
                 NSAlert *alert = [NSAlert new];
                 alert.messageText = NSLocalizedString(@"Cannot create export output file", nil);
                 alert.informativeText = NSLocalizedString(@"The specified export output file could not be created. Check that it is not locked and no other application is using it.", nil);
                 [alert beginSheetModalForWindow:self.mainWindow completionHandler:nil];
-            }
-            else
-            {
+            } else {
                 // Announce how many we successfully imported
                 NSAlert *alert = [NSAlert new];
                 alert.alertStyle = NSAlertStyleInformational;
@@ -998,8 +981,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     [panel beginSheetModalForWindow:self.mainWindow
                   completionHandler: ^(NSInteger returnCode) {
                       
-                      if (returnCode == NSModalResponseOK)
-                      {
+                      if (returnCode == NSModalResponseOK) {
                           [panel orderOut:self];
                           [Import importFromFile:panel.URL.path];
                       }
@@ -1018,17 +1000,13 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	NSURL * scriptURL = [NSURL fileURLWithPath:scriptName];
 	NSAppleScript * appleScript = [[NSAppleScript alloc] initWithContentsOfURL:scriptURL error:&errorDictionary];
-	if (appleScript == nil)
-	{
+	if (appleScript == nil) {
 		NSString * baseScriptName = scriptName.lastPathComponent.stringByDeletingPathExtension;
 		runOKAlertPanel([NSString stringWithFormat:NSLocalizedString(@"Error loading script '%@'", nil), baseScriptName],
 						[errorDictionary valueForKey:NSAppleScriptErrorMessage]);
-	}
-	else
-	{
+	} else {
 		NSAppleEventDescriptor * resultEvent = [appleScript executeAndReturnError:&errorDictionary];
-		if (resultEvent == nil)
-		{
+		if (resultEvent == nil) {
 			NSString * baseScriptName = scriptName.lastPathComponent.stringByDeletingPathExtension;
 			runOKAlertPanel([NSString stringWithFormat:NSLocalizedString(@"AppleScript Error in '%@' script", nil), baseScriptName],
 							[errorDictionary valueForKey:NSAppleScriptErrorMessage]);
@@ -1102,8 +1080,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)setFilterBarState:(BOOL)isVisible withAnimation:(BOOL)doAnimate
 {
-	if (isVisible && !self.filterBarVisible)
-	{
+	if (isVisible && !self.filterBarVisible) {
         [self.filterDisclosureView disclose:doAnimate];
 
 		// Hook up the Tab ordering so Tab from the search field goes to the
@@ -1116,8 +1093,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			[self.mainWindow makeFirstResponder:self.filterSearchField];
         }
 	}
-	if (!isVisible && self.filterBarVisible)
-	{
+	if (!isVisible && self.filterBarVisible) {
         [self.filterDisclosureView collapse:doAnimate];
 
 		// Fix up the tab ordering
@@ -1125,14 +1101,14 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		
 		// Clear the filter, otherwise we end up with no way remove it!
 		self.filterString = @"";
-		if (doAnimate)
-		{
+		if (doAnimate) {
 			[self searchUsingFilterField:self];
 			
 			// If the focus was originally on the filter bar then we should
 			// move it to the message list
-			if (self.mainWindow.firstResponder == self.mainWindow)
+			if (self.mainWindow.firstResponder == self.mainWindow) {
 				[self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
+			}
 		}
 	}
 }
@@ -1145,8 +1121,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSMenu * sortSubmenu = [NSMenu new];
 	
 	// Add the fields which are sortable to the menu.
-	for (Field * field in [db arrayOfFields])
-	{
+	for (Field * field in [db arrayOfFields]) {
 		// Filter out columns we don't sort on. Later we should have an attribute in the
 		// field object itself based on which columns we can sort on.
 		if (field.tag != ArticleFieldIDParent &&
@@ -1188,8 +1163,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	NSMenu * columnsSubMenu = [NSMenu new];
 	
-	for (Field * field in [db arrayOfFields])
-	{
+	for (Field * field in [db arrayOfFields]) {
 		// Filter out columns we don't view in the article list. Later we should have an attribute in the
 		// field object based on which columns are visible in the tableview.
 		if (field.tag != ArticleFieldIDText && 
@@ -1280,8 +1254,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         NSMenu *scriptsMenu = [[NSMenu alloc] initWithTitle:@""];
 
 		NSInteger index;
-		for (index = 0; index < count; ++index)
-		{
+		for (index = 0; index < count; ++index) {
 			NSMenuItem * menuItem = [[NSMenuItem alloc] initWithTitle:sortedMenuItems[index]
 															   action:@selector(doSelectScript:)
 														keyEquivalent:@""];
@@ -1299,8 +1272,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		
 		// If this is the first call to initScriptsMenu, create the scripts menu. Otherwise we just
 		// update the one we have.
-		if (scriptsMenuItem != nil)
-		{
+		if (scriptsMenuItem != nil) {
 			[NSApp.mainMenu removeItem:scriptsMenuItem];
 		}
 
@@ -1460,15 +1432,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)updateCloseCommands
 {
-	if (self.browser.browserTabCount <= 1 || !self.mainWindow.keyWindow)
-	{
+	if (self.browser.browserTabCount <= 1 || !self.mainWindow.keyWindow) {
 		closeTabItem.keyEquivalent = @"";
 		closeAllTabsItem.keyEquivalent = @"";
 		closeWindowItem.keyEquivalent = @"w";
         closeWindowItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-	}
-	else
-	{
+	} else {
 		closeTabItem.keyEquivalent = @"w";
         closeTabItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
 		closeAllTabsItem.keyEquivalent = @"w";
@@ -1484,8 +1453,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)showAppInStatusBar
 {
 	Preferences * prefs = [Preferences standardPreferences];
-	if (prefs.showAppInStatusBar && appStatusItem == nil)
-	{
+	if (prefs.showAppInStatusBar && appStatusItem == nil) {
 		appStatusItem = [NSStatusBar.systemStatusBar statusItemWithLength:NSVariableStatusItemLength];
         [self setAppStatusBarIcon];
 		
@@ -1505,9 +1473,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
                                  action:@selector(terminate:)
                           keyEquivalent:@""];
 		appStatusItem.menu = statusBarMenu;
-	}
-	else if (!prefs.showAppInStatusBar && appStatusItem != nil)
-	{
+	} else if (!prefs.showAppInStatusBar && appStatusItem != nil) {
 		[NSStatusBar.systemStatusBar removeStatusItem:appStatusItem];
 		appStatusItem = nil;
 	}
@@ -1519,18 +1485,14 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)setAppStatusBarIcon
 {
-	if (appStatusItem != nil)
-	{
-		if (lastCountOfUnread == 0)
-		{
+	if (appStatusItem != nil) {
+		if (lastCountOfUnread == 0) {
             NSImage *statusBarImage = [NSImage imageNamed:@"statusBarIcon"];
             statusBarImage.template = YES;
             appStatusItem.button.image = statusBarImage;
             appStatusItem.button.title = @"";
             appStatusItem.button.imagePosition = NSImageOnly;
-		}
-		else
-		{
+		} else {
             NSImage *statusBarImage = [NSImage imageNamed:@"statusBarIconUnread"];
             statusBarImage.template = YES;
             appStatusItem.button.image = statusBarImage;
@@ -1573,12 +1535,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)doEditFolder:(Folder *)folder
 {
-	if (folder.type == VNAFolderTypeRSS)
-	{
+	if (folder.type == VNAFolderTypeRSS) {
 		[self.rssFeed editSubscription:self.mainWindow folderId:folder.itemId];
-	}
-	else if (folder.type == VNAFolderTypeSmart)
-	{
+	} else if (folder.type == VNAFolderTypeSmart) {
         if (!smartFolder) {
 			smartFolder = [[SmartFolder alloc] initWithDatabase:db];
         }
@@ -1739,8 +1698,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	NSMenuItem * menuItem = (NSMenuItem *)sender;
 	NSString * scriptPath = [scriptPathMappings valueForKey:menuItem.title];
-	if (scriptPath != nil)
+	if (scriptPath != nil) {
 		[self runAppleScript:scriptPath];
+	}
 }
 
 /* doSelectStyle
@@ -1758,16 +1718,14 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)handleTabChange:(NSNotification *)nc
 {
 	id<Tab> activeBrowserTab = self.browser.activeTab;
-	if (activeBrowserTab == nil)
-	{
+	if (activeBrowserTab == nil) {
 		//we are in the article view
-		if (self.selectedArticle == nil)
+		if (self.selectedArticle == nil) {
 			[self.mainWindow makeFirstResponder:self.foldersTree.mainView];
-		else
+		} else {
 			[self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
-	}
-	else
-	{
+		}
+	} else {
 		[activeBrowserTab activateWebView];
 	}
 	[self updateStatusBarFilterButtonVisibility];
@@ -1788,8 +1746,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)handleFolderNameChange:(NSNotification *)nc
 {
 	NSInteger folderId = ((NSNumber *)nc.object).integerValue;
-	if (folderId == self.articleController.currentFolderId)
+	if (folderId == self.articleController.currentFolderId) {
 		[self updateSearchPlaceholderAndSearchMethod];
+	}
 }
 
 /* handleRefreshStatusChange
@@ -1797,8 +1756,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)handleRefreshStatusChange:(NSNotification *)nc
 {
-	if (self.connecting)
-	{
+	if (self.connecting) {
 		// Save the date/time of this refresh so we do the right thing when
 		// we apply the filter.
 		[[Preferences standardPreferences] setObject:[NSDate date] forKey:MAPref_LastRefreshDate];
@@ -1807,9 +1765,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		NSToolbarItem *item = [self toolbarItemWithIdentifier:@"Refresh"];
 		item.action = @selector(cancelAllRefreshesToolbar:);
         item.image = [NSImage imageNamed:@"CancelTemplate"];
-	}
-	else
-	{
+	} else {
 		// Run the auto-expire now
 		Preferences * prefs = [Preferences standardPreferences];
 		[db purgeArticlesOlderThanTag:prefs.autoExpireDuration];
@@ -1823,8 +1779,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		
 		// Bounce the dock icon for 1 second if the bounce method has been selected.
 		NSInteger newUnread = [RefreshManager sharedManager].countOfNewArticles + [OpenReader sharedManager].countOfNewArticles;
-		if (newUnread > 0 && ((prefs.newArticlesNotification & VNANewArticlesNotificationBounce) != 0))
+		if (newUnread > 0 && ((prefs.newArticlesNotification & VNANewArticlesNotificationBounce) != 0)) {
 			[NSApp requestUserAttention:NSInformationalRequest];
+		}
 
         // User notification
         if (newUnread > 0) {
@@ -1870,20 +1827,16 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSArray * articleArray = self.articleController.markedArticleRange;
 	Article * currentArticle;
 	
-	if (articleArray.count > 0) 
-	{
+	if (articleArray.count > 0) {
 		
         NSMutableArray * articlesWithLinks = [NSMutableArray arrayWithCapacity:articleArray.count];
         NSMutableArray * urls = [NSMutableArray arrayWithCapacity:articleArray.count];
 		
-		for (currentArticle in articleArray)
-		{
-			if (currentArticle && !currentArticle.link.vna_isBlank)
-            {
+		for (currentArticle in articleArray) {
+			if (currentArticle && !currentArticle.link.vna_isBlank) {
                 [articlesWithLinks addObject:currentArticle];
                 NSURL * theURL = [NSURL URLWithString:currentArticle.link];
-                if (theURL == nil)
-                {
+                if (theURL == nil) {
 					theURL = cleanedUpUrlFromString(currentArticle.link);
                 }
                 [urls addObject:theURL];
@@ -1941,8 +1894,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)localPerformFindPanelAction:(id)sender
 {
     NSInteger action = [sender tag];
-	switch (action)
-	{
+	switch (action) {
 		case NSFindPanelActionSetFindString:
 			self.searchString = APP.currentTextSelection;
 			break;
@@ -1966,21 +1918,17 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags
 {
-    if (keyChar >= '0' && keyChar <= '9' && (flags & NSEventModifierFlagControl))
-	{
+    if (keyChar >= '0' && keyChar <= '9' && (flags & NSEventModifierFlagControl)) {
 		NSInteger layoutStyle = VNALayoutReport + (keyChar - '0');
 		[self setLayout:layoutStyle withRefresh:YES];
 		return YES;
 	}
-	switch (keyChar)
-	{
+	switch (keyChar) {
 		case NSLeftArrowFunctionKey:
-            if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption))
+            if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) {
 				return NO;
-			else
-			{
-				if (self.mainWindow.firstResponder == ((NSView<BaseView> *)self.browser.primaryTab.view).mainView)
-				{
+			} else {
+				if (self.mainWindow.firstResponder == ((NSView<BaseView> *)self.browser.primaryTab.view).mainView) {
 					[self.mainWindow makeFirstResponder:self.foldersTree.mainView];
 					return YES;
 				}
@@ -1988,15 +1936,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			return NO;
 			
 		case NSRightArrowFunctionKey:
-            if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption))
+            if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) {
 				return NO;
-			else
-			{
-				if (self.mainWindow.firstResponder == self.foldersTree.mainView)
-				{
+			} else {
+				if (self.mainWindow.firstResponder == self.foldersTree.mainView) {
 					[self.browser switchToPrimaryTab];
-					if (self.selectedArticle == nil)
-					{
+					if (self.selectedArticle == nil) {
 						[self.articleController ensureSelectedArticle];
 					}
 					[self.mainWindow makeFirstResponder:(self.selectedArticle != nil) ? ((NSView<BaseView> *)self.browser.primaryTab.view).mainView : self.foldersTree.mainView];
@@ -2007,13 +1952,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			
 		case NSDeleteFunctionKey:
 		case NSDeleteCharacter:
-			if (self.mainWindow.firstResponder == self.foldersTree.mainView)
-			{
+			if (self.mainWindow.firstResponder == self.foldersTree.mainView) {
 				[self deleteFolder:self];
 				return YES;
-			}
-			else if (self.mainWindow.firstResponder == (self.articleController.mainArticleView).mainView)
-			{
+			} else if (self.mainWindow.firstResponder == (self.articleController.mainArticleView).mainView) {
 				[self deleteMessage:self];
 				return YES;
 			}
@@ -2026,10 +1968,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			
 		case 'f':
 		case 'F':
-			if (!self.filterBarVisible)
+			if (!self.filterBarVisible) {
 				[self setPersistedFilterBarState:YES withAnimation:YES];
-			else
+			} else {
 				[self.mainWindow makeFirstResponder:self.filterSearchField];
+			}
 			return YES;
 			
 		case '>':
@@ -2080,20 +2023,19 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			
 		case NSEnterCharacter:
 		case NSCarriageReturnCharacter:
-			if (self.mainWindow.firstResponder == self.foldersTree.mainView)
-			{
-                if (flags & NSEventModifierFlagOption)
+			if (self.mainWindow.firstResponder == self.foldersTree.mainView) {
+                if (flags & NSEventModifierFlagOption) {
 					[self viewSourceHomePageInAlternateBrowser:self];
-				else
+				} else {
 					[self viewSourceHomePage:self];
+				}
 				return YES;
-			}
-			else
-			{
-                if (flags & NSEventModifierFlagOption)
+			} else {
+                if (flags & NSEventModifierFlagOption) {
 					[self viewArticlePagesInAlternateBrowser:self];
-				else
+				} else {
 					[self viewArticlePages:self];
+				}
 				return YES;
 			}
 			return NO;
@@ -2122,10 +2064,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(NSToolbarItem *)toolbarItemWithIdentifier:(NSString *)theIdentifier
 {
-	for (NSToolbarItem * theItem in self.mainWindow.toolbar.visibleItems)
-	{
-		if ([theItem.itemIdentifier isEqualToString:theIdentifier])
+	for (NSToolbarItem * theItem in self.mainWindow.toolbar.visibleItems) {
+		if ([theItem.itemIdentifier isEqualToString:theIdentifier]) {
 			return theItem;
+		}
 	}
 	return nil;
 }
@@ -2166,37 +2108,32 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)createNewSubscription:(NSString *)urlString underFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId
 {
 	// Replace feed:// with http:// if necessary
-	if ([urlString hasPrefix:@"feed://"])
+	if ([urlString hasPrefix:@"feed://"]) {
 		urlString = [NSString stringWithFormat:@"http://%@", [urlString substringFromIndex:7]];
+	}
 
 	urlString = cleanedUpUrlFromString(urlString).absoluteString;
 	
 	// If the folder already exists, just select it.
 	Folder * folder = [db folderFromFeedURL:urlString];
-	if (folder != nil)
-	{
+	if (folder != nil) {
 		[self.browser switchToPrimaryTab];
 		[self.foldersTree selectFolder:folder.itemId];
 		return;
 	}
 	
 	// Create the new folder.
-	if ([Preferences standardPreferences].syncGoogleReader && [Preferences standardPreferences].prefersGoogleNewSubscription)
-	{	//creates in OpenReader
+	if ([Preferences standardPreferences].syncGoogleReader && [Preferences standardPreferences].prefersGoogleNewSubscription) {	//creates in OpenReader
 		NSString * folderName = [db folderFromID:parentId].name;
 		[[OpenReader sharedManager] subscribeToFeed:urlString withLabel:folderName];
-	}
-	else
-	{ //creates locally
+	} else { //creates locally
 		NSInteger folderId = [db addRSSFolder:[Database untitledFeedFolderName]
                                   underParent:parentId
                                    afterChild:predecessorId
                               subscriptionURL:urlString];
 
-		if (folderId != -1)
-		{
-            if (isAccessible(urlString) || [urlString hasPrefix:@"file"])
-            {
+		if (folderId != -1) {
+            if (isAccessible(urlString) || [urlString hasPrefix:@"file"]) {
                 Folder * folder = [db folderFromID:folderId];
                 [[RefreshManager sharedManager] refreshSubscriptions:@[folder] ignoringSubscriptionStatus:NO];
             }
@@ -2217,8 +2154,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)newSmartFolder:(id)sender
 {
-	if (!smartFolder)
+	if (!smartFolder) {
 		smartFolder = [[SmartFolder alloc] initWithDatabase:db];
+	}
 	[smartFolder newCriteria:self.mainWindow underParent:self.foldersTree.groupParentSelection];
 }
 
@@ -2227,8 +2165,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)newGroupFolder:(id)sender
 {
-	if (!groupFolder)
+	if (!groupFolder) {
 		groupFolder = [[NewGroupFolder alloc] init];
+	}
 	[groupFolder newGroupFolder:self.mainWindow underParent:self.foldersTree.groupParentSelection];
 }
 
@@ -2238,8 +2177,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)restoreMessage:(id)sender
 {
 	Folder * folder = [db folderFromID:self.articleController.currentFolderId];
-	if (folder.type == VNAFolderTypeTrash && self.selectedArticle != nil && !db.readOnly)
-	{
+	if (folder.type == VNAFolderTypeTrash && self.selectedArticle != nil && !db.readOnly) {
 		NSArray * articleArray = self.articleController.markedArticleRange;
 		[self.articleController markDeletedByArray:articleArray deleteFlag:NO];
 		[self clearUndoStack];
@@ -2252,8 +2190,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)deleteMessage:(id)sender
 {
-	if (self.selectedArticle != nil && !db.readOnly)
-	{
+	if (self.selectedArticle != nil && !db.readOnly) {
 		Folder * folder = [db folderFromID:self.articleController.currentFolderId];
 		if (folder.type != VNAFolderTypeTrash) {
 			NSArray * articleArray = self.articleController.markedArticleRange;
@@ -2284,8 +2221,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)showDownloadsWindow:(id)sender
 {
-	if (downloadWindow == nil)
+	if (downloadWindow == nil) {
 		downloadWindow = [[DownloadWindow alloc] init];
+	}
 	[downloadWindow.window makeKeyAndOrderFront:sender];
 }
 
@@ -2294,10 +2232,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)conditionalShowDownloadsWindow:(id)sender
 {
-	if (downloadWindow == nil)
+	if (downloadWindow == nil) {
 		downloadWindow = [[DownloadWindow alloc] init];
-	if (!downloadWindow.window.visible)
+	}
+	if (!downloadWindow.window.visible) {
 		[downloadWindow.window makeKeyAndOrderFront:sender];
+	}
 }
 
 /* viewFirstUnread
@@ -2306,13 +2246,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)viewFirstUnread:(id)sender
 {
 	[self.browser switchToPrimaryTab];
-	if (db.countOfUnread > 0)
-	{
+	if (db.countOfUnread > 0) {
 		[self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
 		[self.articleController displayFirstUnread];
-	}
-	else
-	{
+	} else {
 		[self.mainWindow makeFirstResponder:(self.selectedArticle != nil) ? ((NSView<BaseView> *)self.browser.primaryTab.view).mainView : self.foldersTree.mainView];
 	}
 }
@@ -2323,13 +2260,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)viewNextUnread:(id)sender
 {
 	[self.browser switchToPrimaryTab];
-	if (db.countOfUnread > 0)
-	{
+	if (db.countOfUnread > 0) {
 		[self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
 		[self.articleController displayNextUnread];
-	}
-	else
-	{
+	} else {
 		[self.mainWindow makeFirstResponder:(self.selectedArticle != nil) ? ((NSView<BaseView> *)self.browser.primaryTab.view).mainView : self.foldersTree.mainView];
 	}
 }
@@ -2349,11 +2283,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)skipFolder:(id)sender
 {
-	if (!db.readOnly)
-	{
+	if (!db.readOnly) {
 		[self.articleController markAllFoldersReadByArray:self.foldersTree.selectedFolders];
-		if (db.countOfUnread > 0)
-		{
+		if (db.countOfUnread > 0) {
 			[self.articleController displayNextFolderWithUnread];
 		}
 	}
@@ -2376,8 +2308,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)markAllSubscriptionsRead:(id)sender
 {
-	if (!db.readOnly)
-	{
+	if (!db.readOnly) {
 		[self.articleController markAllFoldersReadByArray:[self.foldersTree folders:0]];
 	}
 }
@@ -2388,8 +2319,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)markReadToggle:(id)sender
 {
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !db.readOnly)
-	{
+	if (theArticle != nil && !db.readOnly) {
 		NSArray * articleArray = self.articleController.markedArticleRange;
 		[self.articleController markReadByArray:articleArray readFlag:!theArticle.read];
 	}
@@ -2401,8 +2331,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)markRead:(id)sender
 {
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !db.readOnly)
-	{
+	if (theArticle != nil && !db.readOnly) {
 		NSArray * articleArray = self.articleController.markedArticleRange;
 		[self.articleController markReadByArray:articleArray readFlag:YES];
 	}
@@ -2414,8 +2343,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)markUnread:(id)sender
 {
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !db.readOnly)
-	{
+	if (theArticle != nil && !db.readOnly) {
 		NSArray * articleArray = self.articleController.markedArticleRange;
 		[self.articleController markReadByArray:articleArray readFlag:NO];
 	}
@@ -2427,8 +2355,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)markFlagged:(id)sender
 {
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !db.readOnly)
-	{
+	if (theArticle != nil && !db.readOnly) {
 		NSArray * articleArray = self.articleController.markedArticleRange;
 		[self.articleController markFlaggedByArray:articleArray flagged:!theArticle.flagged];
 	}
@@ -2457,45 +2384,34 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSString * alertTitle = nil;
 	BOOL needPrompt = YES;
 	
-	if (count == 1)
-	{
+	if (count == 1) {
 		Folder * folder = selectedFolders[0];
-		if (folder.type == VNAFolderTypeSmart)
-		{
+		if (folder.type == VNAFolderTypeSmart) {
 			alertBody = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to delete smart folder \"%@\"? This will not delete the actual articles matched by the search.", nil), folder.name];
 			alertTitle = NSLocalizedString(@"Delete smart folder", nil);
-		}
-		else if (folder.type == VNAFolderTypeSearch)
+		} else if (folder.type == VNAFolderTypeSearch) {
 			needPrompt = NO;
-		else if (folder.type == VNAFolderTypeRSS)
-		{
+		} else if (folder.type == VNAFolderTypeRSS) {
 			alertBody = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to unsubscribe from \"%@\"? This operation will delete all cached articles.", nil), folder.name];
 			alertTitle = NSLocalizedString(@"Delete subscription", nil);
-		}
-		else if (folder.type == VNAFolderTypeOpenReader)
-		{
+		} else if (folder.type == VNAFolderTypeOpenReader) {
 			alertBody = [NSString stringWithFormat:NSLocalizedString(@"Unsubscribing from an Open Reader RSS feed will also remove your locally cached articles.", nil), folder.name];
 			alertTitle = NSLocalizedString(@"Delete Open Reader RSS feed", nil);
-		}
-		else if (folder.type == VNAFolderTypeGroup)
-		{
+		} else if (folder.type == VNAFolderTypeGroup) {
 			alertBody = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to delete group folder \"%@\" and all sub folders? This operation cannot be undone.", nil), folder.name];
 			alertTitle = NSLocalizedString(@"Delete group folder", nil);
-		}
-		else if (folder.type == VNAFolderTypeTrash)
+		} else if (folder.type == VNAFolderTypeTrash) {
 			return;
-		else
+		} else {
 			NSAssert1(false, @"Unhandled folder type in deleteFolder: %@", [folder name]);
-	}
-	else
-	{
+		}
+	} else {
 		alertBody = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to delete all %d selected folders? This operation cannot be undone.", nil), (unsigned int)count];
 		alertTitle = NSLocalizedString(@"Delete multiple folders", nil);
 	}
 	
 	// Get confirmation first
-	if (needPrompt)
-	{
+	if (needPrompt) {
         NSAlert *alert = [NSAlert new];
         alert.messageText = alertTitle;
         alert.informativeText = alertBody;
@@ -2503,31 +2419,32 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         [alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Title of a button on an alert")];
         NSModalResponse alertResponse = [alert runModal];
 
-		if (alertResponse == NSAlertSecondButtonReturn)
+		if (alertResponse == NSAlertSecondButtonReturn) {
 			return;
+		}
 	}
 	
 
-	if (smartFolder != nil)
+	if (smartFolder != nil) {
 		[smartFolder doCancel:nil];
-	if ([(NSControl *)self.foldersTree.mainView abortEditing])
+	}
+	if ([(NSControl *)self.foldersTree.mainView abortEditing]) {
 		[self.mainWindow makeFirstResponder:self.foldersTree.mainView];
+	}
 	
 	
 	// Clear undo stack for this action
 	[self clearUndoStack];
 	
 	// Prompt for each folder for now
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		Folder * folder = selectedFolders[index];
 		
 		// This little hack is so if we're deleting the folder currently being displayed
 		// and there's more than one folder being deleted, we delete the folder currently
 		// being displayed last so that the MA_Notify_FolderDeleted handlers that only
 		// refresh the display if the current folder is being deleted only trips once.
-		if (folder.itemId == self.articleController.currentFolderId && index < count - 1)
-		{
+		if (folder.itemId == self.articleController.currentFolderId && index < count - 1) {
 			[selectedFolders insertObject:folder atIndex:count];
 			++count;
 			continue;
@@ -2576,8 +2493,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSInteger count = selectedFolders.count;
 	NSInteger index;
 	
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		Folder * folder = selectedFolders[index];
         
         if (folder.isUnsubscribed) {
@@ -2601,18 +2517,14 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSInteger count = selectedFolders.count;
 	NSInteger index;
 	
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		Folder * folder = selectedFolders[index];
 		NSInteger folderID = folder.itemId;
 		
-		if (loadFullHTMLPages)
-		{
+		if (loadFullHTMLPages) {
 			[folder setFlag:VNAFolderFlagLoadFullHTML];
             [[Database sharedManager] setFlag:VNAFolderFlagLoadFullHTML forFolder:folderID];
-		}
-		else
-		{
+		} else {
 			[folder clearFlag:VNAFolderFlagLoadFullHTML];
             [[Database sharedManager] clearFlag:VNAFolderFlagLoadFullHTML forFolder:folderID];
 		}
@@ -2643,8 +2555,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	Article * thisArticle = self.selectedArticle;
 	Folder * folder = (thisArticle) ? [db folderFromID:thisArticle.folderId] : [db folderFromID:self.foldersTree.actualSelection];
-	if (thisArticle || folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)
+	if (thisArticle || folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) {
 		[self openURLFromString:folder.homePage inPreferredBrowser:YES];
+	}
 }
 
 /* viewSourceHomePageInAlternateBrowser
@@ -2654,8 +2567,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	Article * thisArticle = self.selectedArticle;
 	Folder * folder = (thisArticle) ? [db folderFromID:thisArticle.folderId] : [db folderFromID:self.foldersTree.actualSelection];
-	if (thisArticle || folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)
+	if (thisArticle || folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) {
 		[self openURLFromString:folder.homePage inPreferredBrowser:NO];
+	}
 }
 
 - (IBAction)openHomePage:(id)sender
@@ -2732,22 +2646,22 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
 	Preferences * prefs = [Preferences standardPreferences];
 	NSString * alternateLocation;
-	if (prefs.openLinksInVienna)
-	{
+	if (prefs.openLinksInVienna) {
 		alternateLocation = getDefaultBrowser();
-		if (alternateLocation == nil)
+		if (alternateLocation == nil) {
 			alternateLocation = NSLocalizedString(@"External Browser", nil);
-	}
-	else
+		}
+	} else {
 		alternateLocation = NSRunningApplication.currentApplication.localizedName;
+	}
 	NSMenuItem * item = menuItemWithAction(@selector(viewSourceHomePageInAlternateBrowser:));
-	if (item != nil)
-	{
+	if (item != nil) {
 		item.title = [NSString stringWithFormat:NSLocalizedString(@"Open Subscription Home Page in %@", nil), alternateLocation];
 	}
 	item = menuItemWithAction(@selector(viewArticlePagesInAlternateBrowser:));
-	if (item != nil)
+	if (item != nil) {
 		item.title = [NSString stringWithFormat:NSLocalizedString(@"Open Article Page in %@", nil), alternateLocation];
+	}
 }
 
 /* updateStatusBarFilterButtonVisibility
@@ -2757,11 +2671,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)updateStatusBarFilterButtonVisibility
 {
     id<Tab> activeBrowserTab = self.browser.activeTab;
-	if (activeBrowserTab)
-	{
+	if (activeBrowserTab) {
 		[self setFilterBarState:NO withAnimation:NO];
-	}
-	else {
+	} else {
 		[self setFilterBarState:[Preferences standardPreferences].showFilterBar withAnimation:NO];
 	}
 }
@@ -2776,27 +2688,20 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	Preferences * prefs = [Preferences standardPreferences];
 	
 	// START of rather verbose implementation of switching between "Search all articles" and "Search current web page".
-	if (activeBrowserTab)
-	{
+	if (activeBrowserTab) {
 		// If the current view is a browser view and "Search all articles" is the current SearchMethod, switch to "Search current webpage"
-		if ([prefs.searchMethod.displayName isEqualToString:[SearchMethod allArticlesSearchMethod].displayName])
-		{
-			for (NSMenuItem * menuItem in ((NSSearchFieldCell *)self.toolbarSearchField.cell).searchMenuTemplate.itemArray)
-			{
+		if ([prefs.searchMethod.displayName isEqualToString:[SearchMethod allArticlesSearchMethod].displayName]) {
+			for (NSMenuItem * menuItem in ((NSSearchFieldCell *)self.toolbarSearchField.cell).searchMenuTemplate.itemArray) {
 				if ([[menuItem.representedObject displayName] isEqualToString:[SearchMethod currentWebPageSearchMethod].displayName]) {
                     self.toolbarSearchField.placeholderString = [SearchMethod currentWebPageSearchMethod].displayName;
 					[Preferences standardPreferences].searchMethod = menuItem.representedObject;
 				}
 			}
 		}
-	}
-	else 
-	{
+	} else {
 		// If the current view is anything else "Search current webpage" is active, switch to "Search all articles".
-		if ([prefs.searchMethod.displayName isEqualToString:[SearchMethod currentWebPageSearchMethod].displayName])
-		{
-			for (NSMenuItem * menuItem in ((NSSearchFieldCell *)self.toolbarSearchField.cell).searchMenuTemplate.itemArray)
-			{
+		if ([prefs.searchMethod.displayName isEqualToString:[SearchMethod currentWebPageSearchMethod].displayName]) {
+			for (NSMenuItem * menuItem in ((NSSearchFieldCell *)self.toolbarSearchField.cell).searchMenuTemplate.itemArray) {
 				if ([[menuItem.representedObject displayName] isEqualToString:[SearchMethod allArticlesSearchMethod].displayName]) {
                     self.toolbarSearchField.placeholderString = [SearchMethod allArticlesSearchMethod].displayName;
 					[Preferences standardPreferences].searchMethod = menuItem.representedObject;
@@ -2818,12 +2723,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)setFocusToSearchField:(id)sender
 {
-	if (self.mainWindow.toolbar.visible && [self toolbarItemWithIdentifier:@"SearchItem"] && self.mainWindow.toolbar.displayMode != NSToolbarDisplayModeLabelOnly)
+	if (self.mainWindow.toolbar.visible && [self toolbarItemWithIdentifier:@"SearchItem"] && self.mainWindow.toolbar.displayMode != NSToolbarDisplayModeLabelOnly) {
 		[self.mainWindow makeFirstResponder:self.toolbarSearchField];
-	else
-	{
-		if (!searchPanel)
+	} else {
+		if (!searchPanel) {
 			searchPanel = [[SearchPanel alloc] init];
+		}
 		[searchPanel runSearchPanel:self.mainWindow];
 	}
 }
@@ -2893,8 +2798,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(IBAction)searchUsingToolbarTextField:(id)sender
 {
     if ([sender isKindOfClass:[NSMenuItem class]]) {
-        if (!searchPanel)
+        if (!searchPanel) {
             searchPanel = [[SearchPanel alloc] init];
+        }
         [searchPanel runSearchPanel:self.mainWindow];
     } else {
         self.searchString = self.toolbarSearchField.stringValue;
@@ -2941,8 +2847,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(void)searchArticlesWithString:(NSString *)theSearchString
 {
-	if (!theSearchString.vna_isBlank)
-	{
+	if (!theSearchString.vna_isBlank) {
         db.searchString = theSearchString;
         if (self.foldersTree.actualSelection != db.searchFolderId) {
 			[self.foldersTree selectFolder:db.searchFolderId];
@@ -3100,8 +3005,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	// Send our Apple Event.
 	OSStatus err = AESendMessage(event.aeDesc, NULL, kAENoReply | kAEDontReconnect | kAENeverInteract | kAEDontRecord, kAEDefaultTimeout);
-	if (err != noErr) 
+	if (err != noErr) { 
 		NSLog(@"Error sending Apple Event: %li", (long)err );
+	}
 }
 
 #pragma mark Toolbar And Menu Bar Validation
@@ -3119,29 +3025,24 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	
 	*validateFlag = NO;
     
-	if (theAction == @selector(refreshAllSubscriptions:) || theAction == @selector(cancelAllRefreshesToolbar:))
-	{
+	if (theAction == @selector(refreshAllSubscriptions:) || theAction == @selector(cancelAllRefreshesToolbar:)) {
 		*validateFlag = !db.readOnly;
 		return YES;
 	}
 
-	if (theAction == @selector(newSubscription:))
-	{
+	if (theAction == @selector(newSubscription:)) {
 		*validateFlag = !db.readOnly && isMainWindowVisible;
 		return YES;
 	}
-	if (theAction == @selector(newSmartFolder:))
-	{
+	if (theAction == @selector(newSmartFolder:)) {
 		*validateFlag = !db.readOnly && isMainWindowVisible;
 		return YES;
 	}
-	if (theAction == @selector(skipFolder:))
-	{
+	if (theAction == @selector(skipFolder:)) {
 		*validateFlag = !db.readOnly && isAnyArticleView && isMainWindowVisible && db.countOfUnread > 0;
 		return YES;
 	}
-	if (theAction == @selector(getInfo:))
-	{
+	if (theAction == @selector(getInfo:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
 		*validateFlag = (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && isMainWindowVisible;
 		return YES;
@@ -3151,18 +3052,15 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 		*validateFlag = folder.type == VNAFolderTypeOpenReader;
 		return YES;
 	}
-	if (theAction == @selector(viewArticlesTab:))
-	{
+	if (theAction == @selector(viewArticlesTab:)) {
 		*validateFlag = !isAnyArticleView;
 		return YES;
 	}
-	if (theAction == @selector(viewNextUnread:))
-	{
+	if (theAction == @selector(viewNextUnread:)) {
 		*validateFlag = db.countOfUnread > 0;
 		return YES;
 	}
-    if (theAction == @selector(markAllRead:))
-    {
+    if (theAction == @selector(markAllRead:)) {
         Folder *folder = [db folderFromID:self.foldersTree.actualSelection];
         if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) {
             *validateFlag = folder && folder.unreadCount > 0 && !db.readOnly && isMainWindowVisible;
@@ -3171,8 +3069,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         }
         return YES;
     }
-	if (theAction == @selector(goBack:))
-	{
+	if (theAction == @selector(goBack:)) {
         *validateFlag = isMainWindowVisible && isAnyArticleView && self.articleController.canGoBack;
         return YES;
 	}
@@ -3182,13 +3079,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	    		&& isMainWindowVisible && folder.type != VNAFolderTypeOpenReader;
 		return YES;
 	}
-	if (theAction == @selector(emptyTrash:))
-	{
+	if (theAction == @selector(emptyTrash:)) {
 		*validateFlag = !db.readOnly;
 		return YES;
 	}
-	if (theAction == @selector(searchUsingToolbarTextField:))
-	{
+	if (theAction == @selector(searchUsingToolbarTextField:)) {
 		*validateFlag = isMainWindowVisible;
 	}
 	return NO;
@@ -3200,8 +3095,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(BOOL)validateToolbarItem:(NSToolbarItem *)toolbarItem
 {
 	BOOL flag;
-	if (toolbarItem.action == @selector(showHideFilterBar:))
-	{
+	if (toolbarItem.action == @selector(showHideFilterBar:)) {
 		return self.mainWindow.visible && self.browser.activeTab == nil;
 	}
 	[self validateCommonToolbarAndMenuItems:toolbarItem.action validateFlag:&flag];
@@ -3220,65 +3114,44 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	BOOL isArticleView = self.browser.activeTab == nil;
 	BOOL flag;
 	
-	if ([self validateCommonToolbarAndMenuItems:theAction validateFlag:&flag])
-	{
+	if ([self validateCommonToolbarAndMenuItems:theAction validateFlag:&flag]) {
 		return flag;
 	}
-	if (theAction == @selector(printDocument:))
-	{
-		if (!isMainWindowVisible)
+	if (theAction == @selector(printDocument:)) {
+		if (!isMainWindowVisible) {
 			return NO;
-		if (isAnyArticleView)
-		{
-			return self.selectedArticle != nil;
 		}
-		else
-		{
+		if (isAnyArticleView) {
+			return self.selectedArticle != nil;
+		} else {
 			return !self.browser.activeTab.isLoading;
 		}
-	}
-	else if (theAction == @selector(goForward:))
-	{
+	} else if (theAction == @selector(goForward:)) {
         return isMainWindowVisible && isAnyArticleView && self.articleController.canGoForward;
-	}
-	else if (theAction == @selector(newGroupFolder:))
-	{
+	} else if (theAction == @selector(newGroupFolder:)) {
 		return !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(showHideFilterBar:))
-	{
-		if ([Preferences standardPreferences].showFilterBar)
+	} else if (theAction == @selector(showHideFilterBar:)) {
+		if ([Preferences standardPreferences].showFilterBar) {
 			[menuItem setTitle:NSLocalizedString(@"Hide Filter Bar", nil)];
-		else
+		} else {
 			[menuItem setTitle:NSLocalizedString(@"Show Filter Bar", nil)];
+		}
 		return isMainWindowVisible && isAnyArticleView;
-	}
-	else if (theAction == @selector(makeTextStandardSize:))
-	{
+	} else if (theAction == @selector(makeTextStandardSize:)) {
         return self.browser.activeTab != nil;
-	}
-	else if (theAction == @selector(makeTextLarger:))
-	{
+	} else if (theAction == @selector(makeTextLarger:)) {
         return self.browser.activeTab != nil;
-	}
-	else if (theAction == @selector(makeTextSmaller:))
-	{
+	} else if (theAction == @selector(makeTextSmaller:)) {
         return self.browser.activeTab != nil;
-	}
-	else if (theAction == @selector(doViewColumn:))
-	{
+	} else if (theAction == @selector(doViewColumn:)) {
 		Field * field = menuItem.representedObject;
 		menuItem.state = field.visible ? NSControlStateValueOn : NSControlStateValueOff;
 		return isMainWindowVisible && isArticleView;
-	}
-	else if (theAction == @selector(doSelectStyle:))
-	{
+	} else if (theAction == @selector(doSelectStyle:)) {
 		NSString * styleName = menuItem.title;
 		menuItem.state = [styleName isEqualToString:[Preferences standardPreferences].displayStyle] ? NSControlStateValueOn : NSControlStateValueOff;
 		return isMainWindowVisible && isAnyArticleView;
-	}
-	else if (theAction == @selector(doSortColumn:))
-	{
+	} else if (theAction == @selector(doSortColumn:)) {
 		Field * field = menuItem.representedObject;
         if ([field.name isEqualToString:self.articleController.sortColumnIdentifier]) {
 			menuItem.state = NSControlStateValueOn;
@@ -3286,9 +3159,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			menuItem.state = NSControlStateValueOff;
         }
 		return isMainWindowVisible && isAnyArticleView;
-	}
-	else if (theAction == @selector(doSortDirection:))
-	{
+	} else if (theAction == @selector(doSortDirection:)) {
 		NSNumber * ascendingNumber = menuItem.representedObject;
 		BOOL ascending = ascendingNumber.integerValue;
         if (ascending == self.articleController.sortIsAscending) {
@@ -3297,193 +3168,134 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			menuItem.state = NSControlStateValueOff;
         }
 		return isMainWindowVisible && isAnyArticleView;
-	}
-	else if (theAction == @selector(unsubscribeFeed:))
-	{
+	} else if (theAction == @selector(unsubscribeFeed:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
-		if (folder)
-		{
-			if (folder.isUnsubscribed)
+		if (folder) {
+			if (folder.isUnsubscribed) {
 				[menuItem setTitle:NSLocalizedString(@"Resubscribe to Feed", nil)];
-			else
+			} else {
 				[menuItem setTitle:NSLocalizedString(@"Unsubscribe from Feed", nil)];
+			}
 		}
 		return folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(useCurrentStyleForArticles:))
-	{
+	} else if (theAction == @selector(useCurrentStyleForArticles:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
-		if (folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && !folder.loadsFullHTML)
+		if (folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && !folder.loadsFullHTML) {
 			menuItem.state = NSControlStateValueOn;
-		else
+		} else {
 			menuItem.state = NSControlStateValueOff;
+		}
 		return folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(useWebPageForArticles:))
-	{
+	} else if (theAction == @selector(useWebPageForArticles:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
-		if (folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && folder.loadsFullHTML)
+		if (folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && folder.loadsFullHTML) {
 			menuItem.state = NSControlStateValueOn;
-		else
+		} else {
 			menuItem.state = NSControlStateValueOff;
+		}
 		return folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(deleteFolder:))
-	{
+	} else if (theAction == @selector(deleteFolder:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
-		if (folder.type == VNAFolderTypeSearch)
+		if (folder.type == VNAFolderTypeSearch) {
 			[menuItem setTitle:NSLocalizedString(@"Delete", @"Title of a menu item")];
-		else
+		} else {
 			[menuItem setTitle:NSLocalizedString(@"Delete…", @"Title of a menu item")];
+		}
 		return folder && folder.type != VNAFolderTypeTrash && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(refreshSelectedSubscriptions:))
-	{
+	} else if (theAction == @selector(refreshSelectedSubscriptions:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
 		return folder && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeGroup || folder.type == VNAFolderTypeOpenReader) && !db.readOnly;
-	}
-	else if (theAction == @selector(refreshAllFolderIcons:))
-	{
+	} else if (theAction == @selector(refreshAllFolderIcons:)) {
 		return !self.connecting && !db.readOnly;
-	}
-	else if (theAction == @selector(renameFolder:))
-	{
+	} else if (theAction == @selector(renameFolder:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
 		return folder && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(markAllSubscriptionsRead:))
-	{
+	} else if (theAction == @selector(markAllSubscriptionsRead:)) {
 		return !db.readOnly && isMainWindowVisible && db.countOfUnread > 0;
-	}
-	else if (theAction == @selector(importSubscriptions:))
-	{
+	} else if (theAction == @selector(importSubscriptions:)) {
 		return !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(cancelAllRefreshes:))
-	{
+	} else if (theAction == @selector(cancelAllRefreshes:)) {
 		return !db.readOnly && self.connecting;
-	}
-	else if ((theAction == @selector(viewSourceHomePage:)) || (theAction == @selector(viewSourceHomePageInAlternateBrowser:)))
-	{
+	} else if ((theAction == @selector(viewSourceHomePage:)) || (theAction == @selector(viewSourceHomePageInAlternateBrowser:))) {
 		Article * thisArticle = self.selectedArticle;
 		Folder * folder = (thisArticle) ? [db folderFromID:thisArticle.folderId] : [db folderFromID:self.foldersTree.actualSelection];
 		return folder && (thisArticle || folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) && (folder.homePage && !folder.homePage.vna_isBlank && isMainWindowVisible);
-	}
-	else if ((theAction == @selector(viewArticlePages:)) || (theAction == @selector(viewArticlePagesInAlternateBrowser:)))
-	{
+	} else if ((theAction == @selector(viewArticlePages:)) || (theAction == @selector(viewArticlePagesInAlternateBrowser:))) {
 		Article * thisArticle = self.selectedArticle;
-		if (thisArticle != nil)
+		if (thisArticle != nil) {
 			return (thisArticle.link && !thisArticle.link.vna_isBlank && isMainWindowVisible);
+		}
 		return NO;
-	}
-	else if (theAction == @selector(exportSubscriptions:))
-	{
+	} else if (theAction == @selector(exportSubscriptions:)) {
 		return isMainWindowVisible;
-	}
-	else if (theAction == @selector(reindexDatabase:))
-	{
+	} else if (theAction == @selector(reindexDatabase:)) {
 		return !self.connecting && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(editFolder:))
-	{
+	} else if (theAction == @selector(editFolder:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
 		return folder && (folder.type == VNAFolderTypeSmart || folder.type == VNAFolderTypeRSS) && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(restoreMessage:))
-	{
+	} else if (theAction == @selector(restoreMessage:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
 		return folder.type == VNAFolderTypeTrash && self.selectedArticle != nil && !db.readOnly && isMainWindowVisible;
-	}
-	else if (theAction == @selector(previousTab:))
-	{
+	} else if (theAction == @selector(previousTab:)) {
 		return isMainWindowVisible && self.browser.browserTabCount > 1;
-	}
-	else if (theAction == @selector(nextTab:))
-	{
+	} else if (theAction == @selector(nextTab:)) {
 		return isMainWindowVisible && self.browser.browserTabCount > 1;
-	}
-	else if (theAction == @selector(closeActiveTab:))
-	{
+	} else if (theAction == @selector(closeActiveTab:)) {
 		return isMainWindowVisible && !isArticleView;
-	}
-	else if (theAction == @selector(closeAllTabs:))
-	{
+	} else if (theAction == @selector(closeAllTabs:)) {
 		return isMainWindowVisible && self.browser.browserTabCount > 1;
-	}
-	else if (theAction == @selector(reloadPage:))
-	{
+	} else if (theAction == @selector(reloadPage:)) {
 		return self.browser.activeTab.isLoading;
-	}
-	else if (theAction == @selector(stopReloadingPage:))
-	{
+	} else if (theAction == @selector(stopReloadingPage:)) {
 		return self.browser.activeTab.isLoading;
-	}
-	else if (theAction == @selector(keepFoldersArranged:))
-	{
+	} else if (theAction == @selector(keepFoldersArranged:)) {
 		Preferences * prefs = [Preferences standardPreferences];
 		menuItem.state = (prefs.self.foldersTreeSortMethod == menuItem.tag) ? NSControlStateValueOn : NSControlStateValueOff;
 		return isMainWindowVisible;
-	}
-	else if (theAction == @selector(setFocusToSearchField:))
-	{
+	} else if (theAction == @selector(setFocusToSearchField:)) {
 		return isMainWindowVisible;
-	}
-	else if (theAction == @selector(reportLayout:))
-	{
+	} else if (theAction == @selector(reportLayout:)) {
 		Preferences * prefs = [Preferences standardPreferences];
 		menuItem.state = (prefs.layout == VNALayoutReport) ? NSControlStateValueOn : NSControlStateValueOff;
 		return isMainWindowVisible;
-	}
-	else if (theAction == @selector(condensedLayout:))
-	{
+	} else if (theAction == @selector(condensedLayout:)) {
 		Preferences * prefs = [Preferences standardPreferences];
 		menuItem.state = (prefs.layout == VNALayoutCondensed) ? NSControlStateValueOn : NSControlStateValueOff;
 		return isMainWindowVisible;
-	}
-	else if (theAction == @selector(unifiedLayout:))
-	{
+	} else if (theAction == @selector(unifiedLayout:)) {
 		Preferences * prefs = [Preferences standardPreferences];
 		menuItem.state = (prefs.layout == VNALayoutUnified) ? NSControlStateValueOn : NSControlStateValueOff;
 		return isMainWindowVisible;
-	}
-	else if (theAction == @selector(markFlagged:))
-	{
+	} else if (theAction == @selector(markFlagged:)) {
 		Article * thisArticle = self.selectedArticle;
-		if (thisArticle != nil)
-		{
-			if (thisArticle.flagged)
+		if (thisArticle != nil) {
+			if (thisArticle.flagged) {
 				[menuItem setTitle:NSLocalizedString(@"Mark Unflagged", nil)];
-			else
+			} else {
 				[menuItem setTitle:NSLocalizedString(@"Mark Flagged", nil)];
+			}
 		}
 		return (thisArticle != nil && !db.readOnly && isMainWindowVisible);
-	}
-	else if (theAction == @selector(markRead:))
-	{
+	} else if (theAction == @selector(markRead:)) {
 		Article * thisArticle = self.selectedArticle;
 		return (thisArticle != nil && !db.readOnly && isMainWindowVisible);
-	}
-	else if (theAction == @selector(markUnread:))
-	{
+	} else if (theAction == @selector(markUnread:)) {
 		Article * thisArticle = self.selectedArticle;
 		return (thisArticle != nil && !db.readOnly && isMainWindowVisible);
-	}
-	else if (theAction == @selector(downloadEnclosure:))
-	{
+	} else if (theAction == @selector(downloadEnclosure:)) {
         if (self.articleController.markedArticleRange.count > 1) {
 			[menuItem setTitle:NSLocalizedString(@"Download Enclosures", @"Title of a menu item")];
         } else {
 			[menuItem setTitle:NSLocalizedString(@"Download Enclosure", @"Title of a menu item")];
         }
 		return (self.selectedArticle.hasEnclosure && isMainWindowVisible);
-	}
-	else if (theAction == @selector(setSearchMethod:))
-	{
+	} else if (theAction == @selector(setSearchMethod:)) {
 		Preferences * prefs = [Preferences standardPreferences];
-		if ([prefs.searchMethod.displayName isEqualToString:[menuItem.representedObject displayName]])
+		if ([prefs.searchMethod.displayName isEqualToString:[menuItem.representedObject displayName]]) {
 			menuItem.state = NSControlStateValueOn;
-		else 
+		} else { 
 			menuItem.state = NSControlStateValueOff;
+		}
 		return YES;
 	} else if (theAction == @selector(openVienna:)) {
         return self.mainWindow.isKeyWindow == false;

--- a/Vienna/Sources/Application/URLHandlerCommand.m
+++ b/Vienna/Sources/Application/URLHandlerCommand.m
@@ -39,8 +39,7 @@
 
 	[scanner scanUpToString:@":" intoString:&urlPrefix];
 	[scanner scanString:@":" intoString:nil];
-	if (urlPrefix && [urlPrefix isEqualToString:@"feed"])
-	{
+	if (urlPrefix && [urlPrefix isEqualToString:@"feed"]) {
 		NSString * feedScheme = nil;
 
 		// Throw away the next few bits if they exist
@@ -53,10 +52,12 @@
 		NSString * linkPath = nil;
 
 		[scanner scanUpToString:@"" intoString:&linkPath];
-		if (linkPath == nil)
+		if (linkPath == nil) {
 			return nil;
-		if (feedScheme == nil)
+		}
+		if (feedScheme == nil) {
 			feedScheme = @"http:";
+		}
 		linkPath = [NSString stringWithFormat:@"%@//%@", feedScheme, linkPath];
 
 		// Allow the run loop to run first, because this may be called at launch,

--- a/Vienna/Sources/Application/ViennaApp.m
+++ b/Vienna/Sources/Application/ViennaApp.m
@@ -68,35 +68,29 @@
 	NSMutableArray * newArgArray = [NSMutableArray array];
 	BOOL hasError = NO;
 
-	if ([argObject isKindOfClass:[Folder class]])
+	if ([argObject isKindOfClass:[Folder class]]) {
 		[newArgArray addObject:argObject];
-
-	else if ([argObject isKindOfClass:[NSArray class]])
-	{
+	} else if ([argObject isKindOfClass:[NSArray class]]) {
 		NSArray * argArray = (NSArray *)argObject;
 		NSInteger index;
 
-		for (index = 0; index < argArray.count; ++index)
-		{
+		for (index = 0; index < argArray.count; ++index) {
 			id argItem = argArray[index];
-			if ([argItem isKindOfClass:[Folder class]])
-			{
+			if ([argItem isKindOfClass:[Folder class]]) {
 				[newArgArray addObject:argItem];
 				continue;
 			}
-			if ([argItem isKindOfClass:[NSScriptObjectSpecifier class]])
-			{
+			if ([argItem isKindOfClass:[NSScriptObjectSpecifier class]]) {
 				id evaluatedItem = [argItem objectsByEvaluatingSpecifier];
-				if ([evaluatedItem isKindOfClass:[Folder class]])
-				{
+				if ([evaluatedItem isKindOfClass:[Folder class]]) {
 					[newArgArray addObject:evaluatedItem];
 					continue;
 				}
-				if ([evaluatedItem isKindOfClass:[NSArray class]])
-				{
+				if ([evaluatedItem isKindOfClass:[NSArray class]]) {
 					NSArray * newArray = [self evaluatedArrayOfFolders:evaluatedItem withCommand:cmd];
-					if (newArray == nil)
+					if (newArray == nil) {
 						return nil;
+					}
 
 					[newArgArray addObjectsFromArray:newArray];
 					continue;
@@ -106,8 +100,9 @@
 			break;
 		}
 	}
-	if (!hasError)
+	if (!hasError) {
 		return [newArgArray copy];
+	}
 
 	// At least one of the arguments didn't evaluate to a Folder object
 	cmd.scriptErrorNumber = errASIllegalFormalParameter;
@@ -122,8 +117,9 @@
 {
 	NSDictionary * args = cmd.evaluatedArguments;
 	NSArray * argArray = [self evaluatedArrayOfFolders:args[@"Folder"] withCommand:cmd];
-	if (argArray != nil)
+	if (argArray != nil) {
 		[[RefreshManager sharedManager] refreshSubscriptions:argArray ignoringSubscriptionStatus:YES];
+	}
 
 	return nil;
 }
@@ -135,8 +131,9 @@
 {
 	NSDictionary * args = cmd.evaluatedArguments;
 	NSArray * argArray = [self evaluatedArrayOfFolders:args[@"Folder"] withCommand:cmd];
-	if (argArray != nil)
+	if (argArray != nil) {
 		[(AppController*)self.delegate markSelectedFoldersRead:argArray];
+	}
 
 	return nil;
 }
@@ -190,8 +187,9 @@
 	NSArray * argArray = argObject ? [self evaluatedArrayOfFolders:argObject withCommand:cmd] : [[Database sharedManager] arrayOfFolders:VNAFolderTypeRoot];
 
 	NSInteger countExported = 0;
-	if (argArray != nil)
+	if (argArray != nil) {
 		countExported = [Export exportToFile:args[@"FileName"] from:argArray inFoldersTree:((AppController*)self.delegate).foldersTree withGroups:YES];
+	}
 	return @(countExported);
 }
 
@@ -277,8 +275,7 @@
 {
 	id<Tab> activeBrowserTab = ((AppController*)self.delegate).browser.activeTab;
 
-	if (activeBrowserTab != nil)
-	{
+	if (activeBrowserTab != nil) {
         return activeBrowserTab.html;
 	}
 	return @"";
@@ -289,8 +286,7 @@
     id<Tab> activeBrowserTab = ((AppController*)self.delegate).browser.activeTab;
 	if (activeBrowserTab) {
 		return activeBrowserTab.tabUrl.absoluteString;
-	}
-    else {
+	} else {
 		return @"";
     }
 }

--- a/Vienna/Sources/Database/ArticleRef.m
+++ b/Vienna/Sources/Database/ArticleRef.m
@@ -28,8 +28,7 @@
  */
 -(instancetype)initWithReference:(NSString *)aGuid inFolder:(NSInteger)aFolderId
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		guid = aGuid;
 		folderId = aFolderId;
 	}

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -90,11 +90,11 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         // then we need to prompt the user for a different location.
         if (_databaseQueue == nil) {
         	dbPath = [self relocateLockedDatabase:dbPath];
-        	if (dbPath != nil)
+        	if (dbPath != nil) {
         		_databaseQueue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+        	}
         }
-        if (![self initialiseDatabase])
-		{
+        if (![self initialiseDatabase]) {
 			self = nil;
 		}
     }
@@ -137,8 +137,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         [alert addButtonWithTitle:NSLocalizedString(@"Upgrade Database", @"Title of a button on an alert")];
         [alert addButtonWithTitle:NSLocalizedString(@"Quit Vienna", @"Title of a button on an alert")];
         NSInteger modalReturn = [alert runModal];
-        if (modalReturn == NSAlertSecondButtonReturn)
-        {
+        if (modalReturn == NSAlertSecondButtonReturn) {
             return NO;
         }
 
@@ -235,31 +234,29 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     NSArray * allFolders = self.foldersDict.allKeys;
     NSUInteger count = allFolders.count;
     NSUInteger index;
-    for (index = 0u; index < count; ++index)
-    {
+    for (index = 0u; index < count; ++index) {
         previousSibling = folderId;
         folderId = [allFolders[index] integerValue];
-        if (index == 0u)
+        if (index == 0u) {
             [self setFirstChild:folderId forFolder:VNAFolderTypeRoot];
-        else
+        } else {
             [self setNextSibling:folderId forFolder:previousSibling];
+        }
     }
     
     // If we have a DemoFeeds.plist in the resources then use it to create some initial demo
     // RSS feeds.
     NSBundle *thisBundle = [NSBundle bundleForClass:[self class]];
     NSString * pathToPList = [thisBundle pathForResource:@"DemoFeeds.plist" ofType:@""];
-    if (pathToPList != nil)
-    {
+    if (pathToPList != nil) {
         NSDictionary * demoFeedsDict = [NSDictionary dictionaryWithContentsOfFile:pathToPList];
-        if (demoFeedsDict)
-        {
-            for (NSString * feedName in demoFeedsDict)
-            {
+        if (demoFeedsDict) {
+            for (NSString * feedName in demoFeedsDict) {
                 NSDictionary * itemDict = demoFeedsDict[feedName];
                 NSString * feedURL = [itemDict valueForKey:@"URL"];
-                if (feedURL != nil && feedName != nil)
+                if (feedURL != nil && feedName != nil) {
                     previousSibling = [self addRSSFolder:feedName underParent:VNAFolderTypeRoot afterChild:previousSibling subscriptionURL:feedURL];
+                }
             }
         }
     }
@@ -352,15 +349,14 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     NSModalResponse alertResponse = [alert runModal];
 
     // When the cancel button is pressed.
-	if (alertResponse == NSAlertSecondButtonReturn)
+	if (alertResponse == NSAlertSecondButtonReturn) {
 		return nil;
+	}
 
 	// When the locate button is pressed.
-	if (alertResponse == NSAlertFirstButtonReturn)
-	{
+	if (alertResponse == NSAlertFirstButtonReturn) {
 		// Delete any existing database.
-		if (sqlDatabase != nil)
-		{
+		if (sqlDatabase != nil) {
 			[sqlDatabase close];
 			sqlDatabase = nil;
 			[[NSFileManager defaultManager] removeItemAtPath:path error:nil];
@@ -370,8 +366,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 		NSOpenPanel * openPanel = [NSOpenPanel openPanel];
 		[openPanel setCanChooseFiles:NO];
 		[openPanel setCanChooseDirectories:YES];
-        if ([openPanel runModal] == NSModalResponseCancel)
+		if ([openPanel runModal] == NSModalResponseCancel) {
 			return nil;
+		}
 		
 		// Make the new database name.
 		NSString * databaseName = path.lastPathComponent;
@@ -379,8 +376,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 		
 		// And try to open it.
 		sqlDatabase = [[FMDatabase alloc] initWithPath:newPath];
-		if (!sqlDatabase || ![sqlDatabase open])
-		{
+		if (!sqlDatabase || ![sqlDatabase open]) {
             NSAlert *alert = [NSAlert new];
             alert.alertStyle = NSAlertStyleCritical;
             alert.messageText = NSLocalizedString(@"Sorry but Vienna was unable to open the database", nil);
@@ -408,8 +404,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  */
 -(void)createInitialSmartFolder:(NSString *)folderName withCriteria:(Criteria *)criteria
 {
-	if ([self createFolderOnDatabase:folderName underParent:VNAFolderTypeRoot withType:VNAFolderTypeSmart] >= 0)
-	{
+	if ([self createFolderOnDatabase:folderName underParent:VNAFolderTypeRoot withType:VNAFolderTypeSmart] >= 0) {
 		CriteriaTree * criteriaTree = [[CriteriaTree alloc] init];
         criteriaTree.criteriaTree = [criteriaTree.criteriaTree arrayByAddingObject:(id<CriteriaElement>)criteria];
 		
@@ -455,8 +450,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(void)addField:(NSString *)name type:(NSInteger)type tag:(NSInteger)tag sqlField:(NSString *)sqlField visible:(BOOL)visible width:(NSInteger)width
 {
 	Field * field = [Field new];
-	if (field != nil)
-	{
+	if (field != nil) {
 		field.name = name;
 		field.type = type;
 		field.tag = tag;
@@ -501,8 +495,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     [self.databaseQueue inDatabase:^(FMDatabase *db) {
         FMResultSet * results = [db executeQuery:@"SELECT version FROM info"];
         dbVersion = 0;
-        if ([results next])
-        {
+        if ([results next]) {
             dbVersion = [results intForColumn:@"version"];
         }
         [results close];
@@ -549,12 +542,12 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(void)clearFlag:(NSUInteger)flag forFolder:(NSInteger)folderId
 {
 	// Exit now if we're read-only
-	if (self.readOnly)
+	if (self.readOnly) {
 		return;
+	}
 	
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
 		[folder clearFlag:flag];
         FMDatabaseQueue *queue = self.databaseQueue;
         [queue inDatabase:^(FMDatabase *db) {
@@ -579,8 +572,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
     
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
 		[folder setFlag:flag];
         FMDatabaseQueue *queue = self.databaseQueue;
         [queue inDatabase:^(FMDatabase *db) {
@@ -604,8 +596,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
 	// If no change to last update, do nothing
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader))
-	{
+	if (folder != nil && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)) {
         if ([folder.lastUpdate isEqualToDate:lastUpdate]) {
 			return;
         }
@@ -633,10 +624,10 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
 	// If no change to last update string, do nothing
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader))
-	{
-		if ([folder.lastUpdateString isEqualToString:lastUpdateString])
+	if (folder != nil && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)) {
+		if ([folder.lastUpdateString isEqualToString:lastUpdateString]) {
 			return;
+		}
 		
 		folder.lastUpdateString = lastUpdateString;
         FMDatabaseQueue *queue = self.databaseQueue;
@@ -663,8 +654,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
 	
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil && ![folder.feedURL isEqualToString:feed_url])
-	{
+	if (folder != nil && ![folder.feedURL isEqualToString:feed_url]) {
 		folder.feedURL = feed_url;
         FMDatabaseQueue *queue = self.databaseQueue;
         [queue inDatabase:^(FMDatabase *db) {
@@ -695,8 +685,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
 
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil && ![folder.remoteId isEqualToString:remoteId])
-	{
+	if (folder != nil && ![folder.remoteId isEqualToString:remoteId]) {
 		folder.remoteId = remoteId;
         FMDatabaseQueue *queue = self.databaseQueue;
         [queue inDatabase:^(FMDatabase *db) {
@@ -762,8 +751,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(NSInteger)addRSSFolder:(NSString *)feedName underParent:(NSInteger)parentId afterChild:(NSInteger)predecessorId subscriptionURL:(NSString *)feed_url
 {
 	NSInteger folderId = [self addFolder:parentId afterChild:predecessorId folderName:feedName type:VNAFolderTypeRSS canAppendIndex:YES];
-	if (folderId != -1)
-	{
+	if (folderId != -1) {
         FMDatabaseQueue *queue = self.databaseQueue;
         __block BOOL success;
         [queue inDatabase:^(FMDatabase *db) {
@@ -798,40 +786,38 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	[self initFolderArray];
 
 	// Exit now if we're read-only
-	if (self.readOnly)
+	if (self.readOnly) {
 		return -1;
-
-	if (!canAppendIndex)
-	{
-		folder = [self folderFromName:name];
-		if (folder)
-			return folder.itemId;
 	}
-	else
-	{
+
+	if (!canAppendIndex) {
+		folder = [self folderFromName:name];
+		if (folder) {
+			return folder.itemId;
+		}
+	} else {
 		// If a folder of that name already exists then adjust the name by appending
 		// an index number to make it unique.
 		NSString * oldName = name;
 		NSUInteger index = 1;
 
-		while (([self folderFromName:name]) != nil)
+		while (([self folderFromName:name]) != nil) {
 			name = [NSString stringWithFormat:@"%@ (%lu)", oldName, (unsigned long)index++];
+		}
 	}
 
 	NSInteger nextSibling = 0;
 	BOOL manualSort = [Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual;
-	if (manualSort)
-	{
-		if (predecessorId > 0)
-		{
+	if (manualSort) {
+		if (predecessorId > 0) {
 			Folder * predecessor = [self folderFromID:predecessorId];
-			if (predecessor != nil)
+			if (predecessor != nil) {
 				nextSibling = predecessor.nextSiblingId;
-			else
+			} else {
 				predecessorId = 0;
+			}
 		}
-		if (predecessorId < 0)
-		{
+		if (predecessorId < 0) {
             FMDatabaseQueue *queue = self.databaseQueue;
             
             [queue inDatabase:^(FMDatabase *db) {
@@ -844,39 +830,39 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 				[siblings close];
 			}];
 		}
-		if (predecessorId == 0)
-		{
-			if (parentId == VNAFolderTypeRoot)
+		if (predecessorId == 0) {
+			if (parentId == VNAFolderTypeRoot) {
 				nextSibling = self.firstFolderId;
-			else
-			{
+			} else {
 				Folder * parent = [self folderFromID:parentId];
-				if (parent != nil)
+				if (parent != nil) {
 					nextSibling = parent.firstChildId;
+				}
 			}
 		}
 	}
 
 	// Here we create the folder anew.
 	NSInteger newItemId = [self createFolderOnDatabase:name underParent:parentId withType:type];
-	if (newItemId != -1)
-	{
+	if (newItemId != -1) {
 		// Add this new folder to our internal cache. If this is an RSS or Open Reader
 		// folder, mark it so that somewhere down the line we'll request the
 		// image for the folder.
 		folder = [[Folder alloc] initWithId:newItemId parentId:parentId name:name type:type];
-		if ((type == VNAFolderTypeRSS)||(type == VNAFolderTypeOpenReader))
+		if ((type == VNAFolderTypeRSS)||(type == VNAFolderTypeOpenReader)) {
 			[folder setFlag:VNAFolderFlagCheckForImage];
+		}
 		self.foldersDict[@(newItemId)] = folder;
 		
-		if (manualSort)
-		{
-			if (nextSibling > 0)
+		if (manualSort) {
+			if (nextSibling > 0) {
 				[self setNextSibling:nextSibling forFolder:newItemId];
-			if (predecessorId > 0)
+			}
+			if (predecessorId > 0) {
 				[self setNextSibling:newItemId forFolder:predecessorId];
-			else
+			} else {
 				[self setFirstChild:newItemId forFolder:parentId];
+			}
 		}
 
 		// Send a notification when new folders are added
@@ -956,8 +942,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	folder = [self folderFromID:folderId];
 	NSInteger adjustment = -folder.unreadCount;
 	folder = [self folderFromID:folder.parentId];
-	while (folder != nil)
-	{
+	while (folder != nil) {
 		folder.childUnreadCount = folder.childUnreadCount + adjustment;
 		folder = [self folderFromID:folder.parentId];
 	}
@@ -973,52 +958,46 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
 	// If this is an RSS feed, delete from the feeds
 	// and delete raw feed source
-	if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)
-	{
+	if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) {
         [queue inTransaction:^(FMDatabase *db, BOOL * rollback) {
             [db executeUpdate:@"DELETE FROM rss_folders WHERE folder_id=?", @(folderId)];
             [db executeUpdate:@"DELETE FROM rss_guids WHERE folder_id=?", @(folderId)];
         }];
 		
 		NSString * feedSourceFilePath = folder.feedSourceFilePath;
-		if (feedSourceFilePath != nil)
-		{
+		if (feedSourceFilePath != nil) {
 			BOOL isDirectory = YES;
-			if ([[NSFileManager defaultManager] fileExistsAtPath:feedSourceFilePath isDirectory:&isDirectory] && !isDirectory)
-			{
+			if ([[NSFileManager defaultManager] fileExistsAtPath:feedSourceFilePath isDirectory:&isDirectory] && !isDirectory) {
 				[[NSFileManager defaultManager] removeItemAtPath:feedSourceFilePath error:NULL];
 			}
 			
 			NSString * backupPath = [feedSourceFilePath stringByAppendingPathExtension:@"bak"];
-			if ([[NSFileManager defaultManager] fileExistsAtPath:backupPath isDirectory:&isDirectory] && !isDirectory)
-			{
+			if ([[NSFileManager defaultManager] fileExistsAtPath:backupPath isDirectory:&isDirectory] && !isDirectory) {
 				[[NSFileManager defaultManager] removeItemAtPath:backupPath error:NULL];
 			}
 		}
 	}
 
 	// If we deleted the search folder, null out our cached handle
-	if (folder.type == VNAFolderTypeSearch)
-	{
+	if (folder.type == VNAFolderTypeSearch) {
 		[self setSearchFolder:nil];
 	}
 
 	// Update the sort order if necessary
-	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual)
-	{
+	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual) {
 		__block NSInteger previousSibling = -999;
         [queue inDatabase:^(FMDatabase *db) {
             FMResultSet * results = [db executeQuery:@"SELECT folder_id FROM folders WHERE parent_id=? AND next_sibling=?", @(folder.parentId), @(folderId)];
-			if ([results next])
-			{
+			if ([results next]) {
 				previousSibling = [results intForColumn:@"folder_id"];
 			}
 			[results close];
 		}];
-		if (previousSibling != -999)
+		if (previousSibling != -999) {
 			[self setNextSibling:folder.nextSiblingId forFolder:previousSibling];
-		else
+		} else {
 			[self setFirstChild:folder.nextSiblingId forFolder:folder.parentId];
+		}
 
 
 	}
@@ -1050,21 +1029,22 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	BOOL result;
 
 	// Exit now if we're read-only
-	if (self.readOnly)
+	if (self.readOnly) {
 		return NO;
+	}
 
 	// Make sure this is a valid folder
 	folder = [self folderFromID:folderId];
-	if (folder == nil)
+	if (folder == nil) {
 		return NO;
+	}
 
 	arrayOfChildFolders = [self arrayOfSubFolders:folder];
 	arrayOfFolderIds = [NSMutableArray arrayWithCapacity:arrayOfChildFolders.count];
 
 	// Send the pre-delete notification before we start the transaction so that the handlers can
 	// safely do any database access.
-	for (folder in arrayOfChildFolders)
-	{
+	for (folder in arrayOfChildFolders) {
 		numFolder = @(folder.itemId);
 		[arrayOfFolderIds addObject:numFolder];
 		[[NSNotificationCenter defaultCenter] vna_postNotificationOnMainThreadWithName:VNADatabaseWillDeleteFolderNotification object:numFolder];
@@ -1100,8 +1080,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     
 	// Find our folder element.
 	Folder * folder = [self folderFromID:folderId];
-	if (!folder)
+	if (!folder) {
 		return NO;
+	}
 
 	// Do nothing if the name hasn't changed. Otherwise it is wasted
 	// effort, basically.
@@ -1184,8 +1165,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
 	// Find our folder element.
 	Folder * folder = [self folderFromID:folderId];
-	if (!folder)
+	if (!folder) {
 		return NO;
+	}
 
 	// Do nothing if the link hasn't changed. Otherwise it is wasted
 	// effort, basically.
@@ -1216,15 +1198,21 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(BOOL)setFolderUsername:(NSInteger)folderId newUsername:(NSString *)name
 {
 	// Exit now if we're read-only
-	if (self.readOnly) return NO;
+	if (self.readOnly) {
+		return NO;
+	}
 	
 	// Find our folder element.
 	Folder * folder = [self folderFromID:folderId];
-	if (!folder) return NO;
+	if (!folder) {
+		return NO;
+	}
 	
 	// Do nothing if the link hasn't changed. Otherwise it is wasted
 	// effort, basically.
-	if ([folder.username isEqualToString:name]) return NO;
+	if ([folder.username isEqualToString:name]) {
+		return NO;
+	}
 	
 	folder.username = name;
 	
@@ -1249,30 +1237,30 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
 	
 	Folder * folder = [self folderFromID:folderId];
-	if (folder.parentId == newParentID)
+	if (folder.parentId == newParentID) {
 		return NO;
+	}
 
 	// Sanity check. Make sure we're not reparenting to our
 	// subordinate.
 	Folder * parentFolder = [self folderFromID:newParentID];
-	while (parentFolder != nil)
-	{
-		if (parentFolder.itemId == folderId)
+	while (parentFolder != nil) {
+		if (parentFolder.itemId == folderId) {
 			return NO;
+		}
 		parentFolder = [self folderFromID:parentFolder.parentId];
 	}
 
 	// Adjust the child unread count for the old parent.
 	NSInteger adjustment = 0;
-	if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)
+	if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) {
 		adjustment = folder.unreadCount;
-	else if (folder.groupFolder)
+	} else if (folder.groupFolder) {
 		adjustment = folder.childUnreadCount;
-	if (adjustment > 0)
-	{
+	}
+	if (adjustment > 0) {
 		parentFolder = [self folderFromID:folder.parentId];
-		while (parentFolder != nil)
-		{
+		while (parentFolder != nil) {
 			parentFolder.childUnreadCount = parentFolder.childUnreadCount - adjustment;
 			parentFolder = [self folderFromID:parentFolder.parentId];
 		}
@@ -1283,11 +1271,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	
 	// In addition to reparenting the child, we also need to fix up the unread count for all
 	// precedent parents.
-	if (adjustment > 0)
-	{
+	if (adjustment > 0) {
 		parentFolder = [self folderFromID:newParentID];
-		while (parentFolder != nil)
-		{
+		while (parentFolder != nil) {
 			parentFolder.childUnreadCount = parentFolder.childUnreadCount + adjustment;
 			parentFolder = [self folderFromID:parentFolder.parentId];
 		}
@@ -1314,17 +1300,15 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	
     FMDatabaseQueue *queue = self.databaseQueue;
     
-	if (folderId == VNAFolderTypeRoot)
-	{
+	if (folderId == VNAFolderTypeRoot) {
 		[queue inDatabase:^(FMDatabase *db) {
             [db executeUpdate:@"UPDATE info SET first_folder=?", @(childId)];
         }];
-	}
-	else
-	{
+	} else {
 		Folder * folder = [self folderFromID:folderId];
-		if (folder == nil)
+		if (folder == nil) {
 			return NO;
+		}
 		
 		folder.firstChildId = childId;
         [queue inDatabase:^(FMDatabase *db) {
@@ -1347,8 +1331,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     }
     
 	Folder * folder = [self folderFromID:folderId];
-	if (folder == nil)
+	if (folder == nil) {
 		return NO;
+	}
 	
 	folder.nextSiblingId = nextSiblingId;
 	
@@ -1370,8 +1355,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     FMDatabaseQueue *queue = self.databaseQueue;
     [queue inDatabase:^(FMDatabase *db) {
         FMResultSet * results = [db executeQuery:@"SELECT first_folder FROM info"];
-        if ([results next])
-        {
+        if ([results next]) {
             folderId = [results intForColumn:@"first_folder"];
         }
         [results close];
@@ -1394,8 +1378,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  */
 -(NSInteger)searchFolderId
 {
-	if (self.searchFolder == nil)
-	{
+	if (self.searchFolder == nil) {
 		NSInteger folderId = [self addFolder:VNAFolderTypeRoot afterChild:0 folderName: NSLocalizedString(@"Search Results", nil) type:VNAFolderTypeSearch canAppendIndex:YES];
 		self.searchFolder = [self folderFromID:folderId];
 	}
@@ -1414,12 +1397,12 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  * Retrieve a Folder given its name.
  */
 -(Folder *)folderFromName:(NSString *)wantedName
-{	
+{
 	Folder * folder;
-	for (folder in [self.foldersDict objectEnumerator])
-	{
-		if ([folder.name isEqualToString:wantedName])
+	for (folder in [self.foldersDict objectEnumerator]) {
+		if ([folder.name isEqualToString:wantedName]) {
 			break;
+		}
 	}
 	return folder;
 }
@@ -1436,10 +1419,10 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 {
 	Folder * folder;
 	
-	for (folder in [self.foldersDict objectEnumerator])
-	{
-		if ([folder.feedURL isEqualToString:wantedFeedURL])
+	for (folder in [self.foldersDict objectEnumerator]) {
+		if ([folder.feedURL isEqualToString:wantedFeedURL]) {
 			break;
+		}
 	}
 	return folder;
 }
@@ -1456,10 +1439,10 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 {
 	Folder * folder;
 
-	for (folder in [self.foldersDict objectEnumerator])
-	{
-		if ([folder.remoteId isEqualToString:wantedRemoteId])
+	for (folder in [self.foldersDict objectEnumerator]) {
+		if ([folder.remoteId isEqualToString:wantedRemoteId]) {
 			break;
+		}
 	}
 	return folder;
 }
@@ -1487,8 +1470,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     FMDatabaseQueue *queue = self.databaseQueue;
 
     // Exit now if we're read-only
-	if (self.readOnly)
+	if (self.readOnly) {
 		return NO;
+	}
 
     // Extract the article data from the dictionary.
     NSString * articleBody = article.body;
@@ -1509,14 +1493,17 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     article.createdDate = [NSDate date];
 
     // Set some defaults
-    if (articleDate == nil)
+    if (articleDate == nil) {
         articleDate = [NSDate date];
-    if (userName == nil)
+    }
+    if (userName == nil) {
         userName = @"";
+    }
 
     // Parse off the title
-    if (articleTitle == nil || articleTitle.vna_isBlank)
+    if (articleTitle == nil || articleTitle.vna_isBlank) {
         articleTitle = [NSString vna_stringByRemovingHTML:articleBody].vna_firstNonBlankLine;
+    }
 
     // Dates are stored as time intervals
     NSTimeInterval interval = articleDate.timeIntervalSince1970;
@@ -1566,8 +1553,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(BOOL)updateArticle:(Article *)existingArticle ofFolder:(NSInteger)folderID withArticle:(Article *)article
 {
     // Exit now if we're read-only
-	if (self.readOnly)
+	if (self.readOnly) {
 		return NO;
+	}
 
 	FMDatabaseQueue *queue = self.databaseQueue;
 
@@ -1582,14 +1570,17 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     BOOL revised_flag = article.revised;
 
     // Set some defaults
-    if (articleDate == nil)
+    if (articleDate == nil) {
         articleDate = existingArticle.date;
-    if (userName == nil)
+    }
+    if (userName == nil) {
         userName = @"";
+    }
 
     // Parse off the title
-    if (articleTitle == nil || articleTitle.vna_isBlank)
+    if (articleTitle == nil || articleTitle.vna_isBlank) {
         articleTitle = [NSString vna_stringByRemovingHTML:articleBody].vna_firstNonBlankLine;
+    }
 
     // Dates are stored as time intervals
     NSTimeInterval interval = articleDate.timeIntervalSince1970;
@@ -1598,12 +1589,10 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
     NSString * existingTitle = existingArticle.title;
     BOOL isArticleRevised = ![existingTitle isEqualToString:articleTitle];
-    if (!isArticleRevised)
-    {
+    if (!isArticleRevised) {
         __block NSString * existingBody = existingArticle.body;
         // the article text may not have been loaded yet, for instance if the folder is not displayed
-        if (existingBody == nil)
-        {
+        if (existingBody == nil) {
             [queue inDatabase:^(FMDatabase *db) {
                 FMResultSet * results = [db executeQuery:@"SELECT text FROM messages WHERE folder_id=? AND message_id=?",
                                          @(folderID), articleGuid];
@@ -1618,13 +1607,13 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         isArticleRevised = ![existingBody isEqualToString:articleBody];
     }
 
-    if (isArticleRevised)
-    {
+    if (isArticleRevised) {
         // Articles preexisting in database should be marked as revised.
         // New articles created during the current refresh should not be marked as revised,
         // even if there are multiple versions of the new article in the feed.
-        if (existingArticle.revised || (existingArticle.status == ArticleStatusEmpty))
+        if (existingArticle.revised || (existingArticle.status == ArticleStatusEmpty)) {
             revised_flag = YES;
+        }
 
         __block BOOL success;
         [queue inDatabase:^(FMDatabase *db) {
@@ -1642,10 +1631,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
         }];
         
-        if (!success)
+        if (!success) {
             return NO;
-        else
-        {
+        } else {
             // update the existing article in memory
             existingArticle.title = articleTitle;
             existingArticle.body = articleBody;
@@ -1655,9 +1643,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
             existingArticle.link = articleLink;
             return YES;
         }
-    }
-    else
-    {
+    } else {
         return NO;
     }
 }
@@ -1700,8 +1686,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 		success = [db executeUpdate:@"DELETE FROM messages WHERE deleted_flag=1"];
 	}];
 
-	if (success)
-	{
+	if (success) {
 		for (Folder * folder in [self.foldersDict objectEnumerator])
 			[folder clearCache];
 
@@ -1717,8 +1702,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	NSInteger folderId = article.folderId;
 	NSString * guid = article.guid;
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
         FMDatabaseQueue *queue = self.databaseQueue;
         __block BOOL success;
         [queue inDatabase:^(FMDatabase *db) {
@@ -1726,14 +1710,11 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                        @(folderId), guid];
         }];
 
-        if (success)
-        {
-            if (!article.read)
-            {
+        if (success) {
+            if (!article.read) {
                 [self setFolderUnreadCount:folder adjustment:-1];
             }
-            if (folder.countOfCachedArticles > 0)
-			{
+            if (folder.countOfCachedArticles > 0) {
 				// If we're in a smart folder, the cached article may be different.
 				Article * cachedArticle = [folder articleFromGuid:guid];
 				[cachedArticle markDeleted:YES];
@@ -1750,16 +1731,14 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  */
 -(void)initSmartfoldersDict
 {
-	if (!self.initializedSmartfoldersDict)
-	{
+	if (!self.initializedSmartfoldersDict) {
         FMDatabaseQueue *queue = self.databaseQueue;
         // Make sure we have a database queue.
 		NSAssert(queue, @"Database queue not assigned for this item");
 		
 		[queue inDatabase:^(FMDatabase *db) {
 			FMResultSet * results = [db executeQuery:@"SELECT folder_id, search_string FROM smart_folders"];
-			while([results next])
-			{
+			while ([results next]) {
 				NSInteger folderId = [results stringForColumnIndex:0].integerValue;
 				NSString * search_string = [results stringForColumnIndex:1];
 				
@@ -1789,8 +1768,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(NSInteger)addSmartFolder:(NSString *)folderName underParent:(NSInteger)parentId withQuery:(CriteriaTree *)criteriaTree
 {
 	NSInteger folderId = [self addFolder:parentId afterChild:0 folderName:folderName type:VNAFolderTypeSmart canAppendIndex:NO];
-	if (folderId != -1)
-	{
+	if (folderId != -1) {
         FMDatabaseQueue *queue = self.databaseQueue;
         [queue inDatabase:^(FMDatabase *db) {
             [db executeUpdate:@"INSERT INTO smart_folders (folder_id, search_string) VALUES (?, ?)",
@@ -1833,8 +1811,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  */
 -(void)initFolderArray
 {
-	if (!self.initializedfoldersDict)
-	{
+	if (!self.initializedfoldersDict) {
 		// Make sure we have a database.
 		NSAssert(self.databaseQueue, @"Database not assigned for this item");
 		
@@ -1851,8 +1828,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                 return;
             }
             
-            while ([results next])
-            {
+            while ([results next]) {
                 NSInteger newItemId = [results stringForColumnIndex:0].integerValue;
                 NSInteger newParentId = [results stringForColumnIndex:1].integerValue;
                 NSString * name = [results stringForColumnIndex:2];
@@ -1894,8 +1870,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 		
         	// Load all RSS folders and add them to the list.
 			results = [db executeQuery:@"SELECT folder_id, feed_url, username, last_update_string, description, home_page, bloglines_id FROM rss_folders"];
-			while ([results next])
-			{
+			while ([results next]) {
 				NSInteger folderId = [results stringForColumnIndex:0].integerValue;
 				NSString * url = [results stringForColumnIndex:1];
 				NSString * username = [results stringForColumnIndex:2];
@@ -1915,13 +1890,10 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 			[results close];
 		}];
 		// Fix the childUnreadCount for every parent
-		for (Folder * folder in [self.foldersDict objectEnumerator])
-		{
-			if (folder.unreadCount > 0 && folder.parentId != VNAFolderTypeRoot)
-			{
+		for (Folder * folder in [self.foldersDict objectEnumerator]) {
+			if (folder.unreadCount > 0 && folder.parentId != VNAFolderTypeRoot) {
 				Folder * parentFolder = [self folderFromID:folder.parentId];
-				while (parentFolder != nil)
-				{
+				while (parentFolder != nil) {
 					parentFolder.childUnreadCount = parentFolder.childUnreadCount + folder.unreadCount;
 					parentFolder = [self folderFromID:parentFolder.parentId];
 				}
@@ -1941,16 +1913,16 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(NSArray *)arrayOfFolders:(NSInteger)parentId
 {
 	// Prime the cache
-	if (self.initializedfoldersDict == NO)
+	if (self.initializedfoldersDict == NO) {
 		[self initFolderArray];
+	}
 
 	NSMutableArray * newArray = [NSMutableArray array];
-	if (newArray != nil)
-	{		
-		for (Folder * folder in [self.foldersDict objectEnumerator])
-		{
-			if (folder.parentId == parentId)
+	if (newArray != nil) {
+		for (Folder * folder in [self.foldersDict objectEnumerator]) {
+			if (folder.parentId == parentId) {
 				[newArray addObject:folder];
+			}
 		}
 	}
 	return [newArray copy];
@@ -1961,18 +1933,14 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  */
 -(NSArray *)arrayOfSubFolders:(Folder *)folder {
 	NSMutableArray * newArray = [NSMutableArray arrayWithObject:folder];
-	if (newArray != nil)
-	{
+	if (newArray != nil) {
 		NSInteger parentId = folder.itemId;
 		
-		for (Folder * item in [self.foldersDict objectEnumerator])
-		{
-			if (item.parentId == parentId)
-			{
+		for (Folder * item in [self.foldersDict objectEnumerator]) {
+			if (item.parentId == parentId) {
                 if (item.type == VNAFolderTypeGroup) {
 					[newArray addObjectsFromArray:[self arrayOfSubFolders:item]];
-                }
-                else {
+                } else {
 					[newArray addObject:item];
                 }
 			}
@@ -1987,8 +1955,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(NSArray *)arrayOfAllFolders
 {
 	// Prime the cache
-	if (self.initializedfoldersDict == NO)
+	if (self.initializedfoldersDict == NO) {
 		[self initFolderArray];
+	}
 	
 	return self.foldersDict.allValues;
 }
@@ -2009,8 +1978,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     FMDatabaseQueue *queue = self.databaseQueue;
     [queue inDatabase:^(FMDatabase *db) {
         FMResultSet * results = [db executeQueryWithFormat:@"SELECT message_id, read_flag, marked_flag, deleted_flag, title, link, revised_flag, hasenclosure_flag, enclosure FROM messages WHERE folder_id=%ld", (long)folderId];
-        while([results next])
-        {
+        while ([results next]) {
             NSString * guid = [results stringForColumnIndex:0];
             BOOL read_flag = [results stringForColumnIndex:1].integerValue;
             BOOL marked_flag = [results stringForColumnIndex:2].integerValue;
@@ -2022,8 +1990,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
             NSString * enclosure = [results stringForColumnIndex:8];
 
             // Keep our own track of unread articles
-            if (!read_flag)
+            if (!read_flag) {
                 ++unread_count;
+            }
             
             Article * article = [[Article alloc] initWithGuid:guid];
             [article markRead:read_flag];
@@ -2044,8 +2013,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     // own count of unread is in sync with the folders count and fix
     // them if not.
     Folder * folder = [self folderFromID:folderId];
-    if (unread_count != folder.unreadCount)
-    {
+    if (unread_count != folder.unreadCount) {
         NSLog(@"Fixing unread count for %@ (%ld on folder versus %ld in articles)", folder.name, (long)folder.unreadCount, (long)unread_count);
         NSInteger diff = (unread_count - folder.unreadCount);
         [self setFolderUnreadCount:folder adjustment:diff];
@@ -2067,10 +2035,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	NSInteger folderId;
 
 	// If folder is nil, rather than report an error, default to some impossible value
-	if (folder != nil)
+	if (folder != nil) {
 		folderId = folder.itemId;
-	else
-	{
+	} else {
 		subScope = NO;
 		folderId = 0;
 	}
@@ -2097,15 +2064,16 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     if (count > 1) {
 		[sqlString appendString:@"("];
     }
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		Folder * folder = childFolders[index];
-		if (index > 0)
+		if (index > 0) {
 			[sqlString appendString:conditionString];
+		}
 		[sqlString appendFormat:@"%@%@%ld", field, operatorString, (long)folder.itemId];
 	}
-	if (count > 1)
+	if (count > 1) {
 		[sqlString appendString:@")"];
+	}
 	return sqlString;
 }
 
@@ -2116,8 +2084,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(CriteriaTree *)criteriaForFolder:(NSInteger)folderId
 {
 	Folder * folder = [self folderFromID:folderId];
-	if (folder == nil)
+	if (folder == nil) {
 		return nil;
+	}
 
 	if (folder.type == VNAFolderTypeSearch) {
         CriteriaTree *tree = [CriteriaTree new];
@@ -2128,16 +2097,14 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         return tree;
     }
 	
-	if (folder.type == VNAFolderTypeTrash)
-	{
+	if (folder.type == VNAFolderTypeTrash) {
 		CriteriaTree * tree = [[CriteriaTree alloc] init];
 		Criteria * clause = [[Criteria alloc] initWithField:MA_Field_Deleted operatorType:VNACriteriaOperatorEqualTo value:@"Yes"];
 		tree.criteriaTree = [tree.criteriaTree arrayByAddingObject:(id<CriteriaElement>)clause];
 		return tree;
 	}
 
-	if (folder.type == VNAFolderTypeSmart)
-	{
+	if (folder.type == VNAFolderTypeSmart) {
 		[self initSmartfoldersDict];
 		return self.smartfoldersDict[@(folderId)];
 	}
@@ -2156,23 +2123,21 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(NSArray *)arrayOfUnreadArticlesRefs:(NSInteger)folderId
 {
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
         NSMutableArray * newArray = [NSMutableArray arrayWithCapacity:folder.unreadCount];
         FMDatabaseQueue *queue = self.databaseQueue;
         [queue inDatabase:^(FMDatabase *db) {
             FMResultSet * results = [db executeQuery:@"SELECT message_id FROM messages WHERE folder_id=? AND read_flag=0", @(folderId)];
-            while ([results next])
-            {
+            while ([results next]) {
                 NSString * guid = [results stringForColumnIndex:0];
                 [newArray addObject:[ArticleReference makeReferenceFromGUID:guid inFolder:folderId]];
             }
             [results close];
         }];
         return [newArray copy];
+	} else {
+		return nil;
 	}
-	else
-	    return nil;
 }
 
 /* arrayOfArticles
@@ -2194,8 +2159,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
 	// If folderId is zero then we're searching the entire database
 	// otherwise we need to construct a criteria tree for this folder
-	if (folderId != 0)
-	{
+	if (folderId != 0) {
 		folder = [self folderFromID:folderId];
         if (folder == nil) {
 			return nil;
@@ -2223,8 +2187,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 		} else {
 			results = [db executeQuery:queryString, filterString, filterString];
 		}
-		while ([results next])
-		{
+		while ([results next]) {
 			Article * article = [[Article alloc] initWithGuid:[results stringForColumnIndex:0]];
 			article.folderId = [results intForColumnIndex:1];
 			article.parentId = [results intForColumnIndex:2];
@@ -2242,12 +2205,14 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 			article.hasEnclosure = [results intForColumnIndex:13];
 			article.enclosure = [results stringForColumnIndex:14];
 		
-			if (folder == nil || !article.deleted || folder.type == VNAFolderTypeTrash)
+			if (folder == nil || !article.deleted || folder.type == VNAFolderTypeTrash) {
 				[newArray addObject:article];
+			}
 			
 			// Keep our own track of unread articles
-			if (!article.read)
+			if (!article.read) {
 				++unread_count;
+			}
 			
 		}
 		[results close];
@@ -2256,10 +2221,8 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     // This is a good time to do a quick check to ensure that our
     // own count of unread is in sync with the folders count and fix
     // them if not.
-    if (folder && [filterString isEqualTo:@""] && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader))
-    {
-        if (unread_count != folder.unreadCount)
-        {
+    if (folder && [filterString isEqualTo:@""] && (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)) {
+        if (unread_count != folder.unreadCount) {
             NSLog(@"Fixing unread count for %@ (%ld on folder versus %ld in articles)", folder.name, (long)folder.unreadCount, (long)unread_count);
             NSInteger diff = (unread_count - folder.unreadCount);
             [self setFolderUnreadCount:folder adjustment:diff];
@@ -2280,15 +2243,14 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	BOOL result = NO;
 
 	// Recurse and mark child folders read too
-	for (folder in [self arrayOfFolders:folderId])
-	{
-		if ([self markFolderRead:folder.itemId])
+	for (folder in [self arrayOfFolders:folderId]) {
+		if ([self markFolderRead:folder.itemId]) {
 			result = YES;
+		}
 	}
 
 	folder = [self folderFromID:folderId];
-	if (folder != nil && folder.unreadCount > 0)
-	{
+	if (folder != nil && folder.unreadCount > 0) {
         FMDatabaseQueue *queue = self.databaseQueue;
         __block BOOL success;
         [queue inDatabase:^(FMDatabase *db) {
@@ -2296,10 +2258,8 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
              @(folderId)];
         }];
 
-		if (success)
-		{
-			if (folder.countOfCachedArticles > 0)
-			{
+		if (success) {
+			if (folder.countOfCachedArticles > 0) {
 			    // update the existing cache of articles and update the unread count
 			    [folder markArticlesInCacheRead];
 			}
@@ -2317,11 +2277,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(void)markArticleRead:(NSInteger)folderId guid:(NSString *)guid isRead:(BOOL)isRead
 {
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
 		Article * article = [folder articleFromGuid:guid];
-		if (article != nil && isRead != article.read)
-		{
+		if (article != nil && isRead != article.read) {
 			// Mark an individual article read
             FMDatabaseQueue *queue = self.databaseQueue;
             __block BOOL success;
@@ -2329,8 +2287,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                 success = [db executeUpdate:@"UPDATE messages SET read_flag=? WHERE folder_id=? AND message_id=?",
                            @(isRead), @(folderId), guid];
             }];
-			if (success)
-			{
+			if (success) {
 				NSInteger adjustment = (isRead ? -1 : 1);
 
 				[article markRead:isRead];
@@ -2347,8 +2304,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 {
     FMDatabaseQueue *queue = self.databaseQueue;
     NSInteger folderId = folder.itemId;
-	if(guidArray.count>0)
-	{
+	if (guidArray.count>0) {
 		NSString * guidList = [guidArray componentsJoinedByString:@"','"];
         [queue inTransaction:^(FMDatabase *db, BOOL *rollback) {
 			NSString * statement1 = [NSString stringWithFormat:@"UPDATE messages SET read_flag=1 WHERE folder_id=%ld AND read_flag=0 AND message_id NOT IN ('%@')", (long)folderId, guidList];
@@ -2356,9 +2312,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 			NSString * statement2 = [NSString stringWithFormat:@"UPDATE messages SET read_flag=0 WHERE folder_id=%ld AND read_flag=1 AND message_id IN ('%@')", (long)folderId, guidList];
 			[db executeUpdate:statement2];
         }];
-	}
-	else
-	{
+	} else {
         [queue inDatabase:^(FMDatabase *db) {
             [db executeUpdate:@"UPDATE messages SET read_flag=1 WHERE folder_id=? AND read_flag=0", @(folderId)];
         }];
@@ -2374,8 +2328,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 {
     FMDatabaseQueue *queue = self.databaseQueue;
     NSInteger folderId = folder.itemId;
-	if(guidArray.count>0)
-	{
+	if (guidArray.count>0) {
 		NSString * guidList = [guidArray componentsJoinedByString:@"','"];
 		[queue inTransaction:^(FMDatabase *db, BOOL *rollback) {
 			NSString * statement1 = [NSString stringWithFormat:@"UPDATE messages SET marked_flag=1 WHERE folder_id=%ld AND marked_flag=0 AND message_id IN ('%@')", (long)folderId, guidList];
@@ -2383,9 +2336,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 			NSString * statement2 = [NSString stringWithFormat:@"UPDATE messages SET marked_flag=0 WHERE folder_id=%ld AND marked_flag=1 AND message_id NOT IN ('%@')", (long)folderId, guidList];
 			[db executeUpdate:statement2];
         }];
-	}
-	else
-	{
+	} else {
         [queue inDatabase:^(FMDatabase *db) {
             [db executeUpdate:@"UPDATE messages SET marked_flag=0 WHERE folder_id=? AND marked_flag=1", @(folderId)];
         }];
@@ -2409,8 +2360,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
 	// Update childUnreadCount for parents.
 	Folder * tmpFolder = [self folderFromID:folder.parentId];
-	while (tmpFolder != nil)
-	{
+	while (tmpFolder != nil) {
 		tmpFolder.childUnreadCount = tmpFolder.childUnreadCount + adjustment;
 		tmpFolder = [self folderFromID:tmpFolder.parentId];
 	}
@@ -2422,11 +2372,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 -(void)markArticleFlagged:(NSInteger)folderId guid:(NSString *)guid isFlagged:(BOOL)isFlagged
 {
 	Folder * folder = [self folderFromID:folderId];
-	if (folder != nil)
-	{
+	if (folder != nil) {
 		Article * article = [folder articleFromGuid:guid];
-		if (article != nil && isFlagged != article.flagged)
-		{
+		if (article != nil && isFlagged != article.flagged) {
             FMDatabaseQueue *queue = self.databaseQueue;
             __block BOOL success;
             [queue inDatabase:^(FMDatabase *db) {
@@ -2436,8 +2384,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                  guid];
             }];
 
-			if (success)
-			{
+			if (success) {
 				// Mark an individual article flagged
                 [article markFlagged:isFlagged];
 			}
@@ -2466,15 +2413,13 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         }];
         if (isDeleted && !article.deleted) {
             [article markDeleted:YES];
-            if (folder.countOfCachedArticles > 0)
-			{
+            if (folder.countOfCachedArticles > 0) {
 				// If we're in a smart folder, the cached article may be different.
 				Article * cachedArticle = [folder articleFromGuid:guid];
 				[cachedArticle markDeleted:YES];
 				[folder removeArticleFromCache:guid];
 			}
-        }
-        else if (!isDeleted) {
+        } else if (!isDeleted) {
             // if we undelete, allow the RSS or OpenReader folder
             // to get the restored article 
             [folder restoreArticleToCache:article];
@@ -2492,12 +2437,11 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     FMDatabaseQueue *queue = self.databaseQueue;
 	[queue inDatabase:^(FMDatabase *db) {
         FMResultSet * results = [db executeQuery:@"SELECT deleted_flag FROM messages WHERE deleted_flag=1"];
-        if ([results next])
-        {
+        if ([results next]) {
             result= NO;
-        }
-        else
+        } else {
             result=YES;
+        }
         [results close];
     }];
 
@@ -2513,11 +2457,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     FMDatabaseQueue *queue = self.databaseQueue;
     [queue inDatabase:^(FMDatabase *db) {
 		FMResultSet * results = [db executeQuery:@"SELECT message_id FROM rss_guids WHERE folder_id=?", @(folderId)];
-		while ([results next])
-		{
+		while ([results next]) {
 			NSString * guid = [results stringForColumn:@"message_id"];
-			if (guid != nil)
-			{
+			if (guid != nil) {
 				[articleGuids addObject:guid];
 			}
 		}
@@ -2542,11 +2484,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     BOOL isDir;
     
     
-    if (![fileManager fileExistsAtPath:databaseFolder isDirectory:&isDir])
-    {
+    if (![fileManager fileExistsAtPath:databaseFolder isDirectory:&isDir]) {
         NSError *error;
-        if (![fileManager createDirectoryAtPath:databaseFolder withIntermediateDirectories:YES attributes:NULL error:&error])
-        {
+        if (![fileManager createDirectoryAtPath:databaseFolder withIntermediateDirectories:YES attributes:NULL error:&error]) {
             NSAlert *alert = [NSAlert alertWithError:error];
             alert.alertStyle = NSAlertStyleCritical;
             alert.messageText = NSLocalizedString(@"Sorry, but Vienna was unable to create the database folder", nil);

--- a/Vienna/Sources/Database/Export.m
+++ b/Vienna/Sources/Database/Export.m
@@ -39,28 +39,22 @@
                    inFoldersTree:(FoldersTree *)foldersTree withGroups:(BOOL)groupFlag
 {
 	NSInteger countExported = 0;
-	for (Folder * folder in feedArray)
-	{
+	for (Folder * folder in feedArray) {
 		NSMutableDictionary * itemDict = [[NSMutableDictionary alloc] init];
 		NSString * name = folder.name;
-		if (folder.type == VNAFolderTypeGroup)
-		{
+		if (folder.type == VNAFolderTypeGroup) {
 			NSArray * subFolders = [foldersTree children:folder.itemId];
 			
             if (!groupFlag) {
 				countExported += [Export exportSubscriptionGroup:parentElement fromArray:subFolders inFoldersTree:foldersTree withGroups:groupFlag];
-            }
-			else
-			{
+            } else {
 				itemDict[@"text"] = SafeString(name);
                 NSXMLElement *outlineElement = [NSXMLElement elementWithName:@"outline"];
                 [outlineElement setAttributesWithDictionary:itemDict];
                 [parentElement addChild:outlineElement];
 				countExported += [Export exportSubscriptionGroup:outlineElement fromArray:subFolders inFoldersTree:foldersTree withGroups:groupFlag];
 			}
-		}
-		else if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader)
-		{
+		} else if (folder.type == VNAFolderTypeRSS || folder.type == VNAFolderTypeOpenReader) {
 			NSString * link = folder.homePage;
 			NSString * description = folder.feedDescription;
 			NSString * url = folder.feedURL;
@@ -90,8 +84,7 @@
     	// Now write the complete XML to the file
     
 	NSString * fqFilename = exportFileName.stringByExpandingTildeInPath;
-	if (![[NSFileManager defaultManager] createFileAtPath:fqFilename contents:nil attributes:nil])
-	{
+	if (![[NSFileManager defaultManager] createFileAtPath:fqFilename contents:nil attributes:nil]) {
 		return -1; // Indicate an error condition (impossible number of exports)
 	}
 
@@ -111,16 +104,16 @@
 {
     NSInteger countExported = 0;
     NSArray * folders;
-	if (selectionFlag)
-	    folders = foldersTree.selectedFolders;
-	else
-	    folders = [foldersTree children:0];
+	if (selectionFlag) {
+		folders = foldersTree.selectedFolders;
+	} else {
+		folders = [foldersTree children:0];
+	}
     NSXMLDocument *opmlDocument = [Export opmlDocumentFromFolders:folders inFoldersTree:foldersTree withGroups:groupFlag exportCount:&countExported];
     	// Now write the complete XML to the file
     
 	NSString * fqFilename = exportFileName.stringByExpandingTildeInPath;
-	if (![[NSFileManager defaultManager] createFileAtPath:fqFilename contents:nil attributes:nil])
-	{
+	if (![[NSFileManager defaultManager] createFileAtPath:fqFilename contents:nil attributes:nil]) {
 		return -1; // Indicate an error condition (impossible number of exports)
 	}
 

--- a/Vienna/Sources/Database/Import.m
+++ b/Vienna/Sources/Database/Import.m
@@ -34,22 +34,18 @@
     BOOL hasError = NO;
     NSInteger countImported = 0;
     
-    if (data != nil)
-    {
+    if (data != nil) {
         NSError *error = nil;
         NSXMLDocument *opmlDocument = [[NSXMLDocument alloc] initWithData:data
                                                                   options:NSXMLNodeLoadExternalEntitiesNever
                                                                     error:&error];
-        if (error)
-        {
+        if (error) {
             NSAlert *alert = [NSAlert new];
             alert.messageText = NSLocalizedString(@"Import error", nil);
             alert.informativeText = NSLocalizedString(@"Cannot import the specified file. The file contents are not valid OPML XML format.", nil);
             [alert runModal];
             hasError = YES;
-        }
-        else
-        {
+        } else {
             NSArray *outlines = [opmlDocument nodesForXPath:@"opml/body/outline" error:nil];
             
             countImported = [self importSubscriptionGroup:outlines underParent:VNAFolderTypeRoot];
@@ -57,8 +53,7 @@
     }
     
     // Announce how many we successfully imported
-    if (!hasError)
-    {
+    if (!hasError) {
         NSAlert *alert = [NSAlert new];
         alert.alertStyle = NSAlertStyleInformational;
         alert.messageText = NSLocalizedString(@"Import Completed", nil);
@@ -75,8 +70,7 @@
 {
 	NSInteger countImported = 0;
 	
-	for (NSXMLElement *outlineElement in outlines)
-	{
+	for (NSXMLElement *outlineElement in outlines) {
         NSString *feedText = ([outlineElement attributeForName:@"text"].stringValue).vna_stringByEscapingExtendedCharacters;
         NSString *feedDescription = ([outlineElement attributeForName:@"description"].stringValue).vna_stringByEscapingExtendedCharacters;
         NSString *feedURL = ([outlineElement attributeForName:@"xmlUrl"].stringValue).vna_stringByEscapingExtendedCharacters;
@@ -85,8 +79,7 @@
         Database * dbManager = [Database sharedManager];
 
 		// Some OPML exports use 'title' instead of 'text'.
-		if (feedText == nil || feedText.length == 0u)
-		{
+		if (feedText == nil || feedText.length == 0u) {
             NSString * feedTitle = ([outlineElement attributeForName:@"title"].stringValue).vna_stringByEscapingExtendedCharacters;
             if (feedTitle != nil) {
 				feedText = feedTitle;
@@ -98,12 +91,10 @@
 		feedText = feedText.vna_stringByUnescapingExtendedCharacters;
 		feedDescription = feedDescription.vna_stringByUnescapingExtendedCharacters;
 		
-		if (feedURL == nil)
-		{
+		if (feedURL == nil) {
 			// This is a new group so try to create it. If there's an error then default to adding
 			// the sub-group items under the parent.
-			if (feedText != nil)
-			{
+			if (feedText != nil) {
 				NSInteger folderId = [dbManager addFolder:parentId afterChild:-1
                                          folderName:feedText type:VNAFolderTypeGroup
                                      canAppendIndex:NO];
@@ -112,16 +103,13 @@
                 }
 				countImported += [self importSubscriptionGroup:outlineElement.children underParent:folderId];
 			}
-		}
-		else if (feedText != nil)
-		{
+		} else if (feedText != nil) {
 			Folder * folder;
 			NSInteger folderId;
 
-			if ((folder = [dbManager folderFromFeedURL:feedURL]) != nil)
+			if ((folder = [dbManager folderFromFeedURL:feedURL]) != nil) {
 				folderId = folder.itemId;
-			else
-			{
+			} else {
 				folderId = [dbManager addRSSFolder:feedText underParent:parentId afterChild:-1 subscriptionURL:feedURL];
 				++countImported;
 			}

--- a/Vienna/Sources/Download window/DownloadManager.m
+++ b/Vienna/Sources/Download window/DownloadManager.m
@@ -233,8 +233,9 @@
 
         if ([firstFile compare:secondFile
                        options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-            if (item.state != DownloadStateCompleted)
+            if (item.state != DownloadStateCompleted) {
                 return NO;
+            }
 
             // File completed download but possibly moved or deleted after
             // download so check the file system.

--- a/Vienna/Sources/Download window/DownloadWindow.m
+++ b/Vienna/Sources/Download window/DownloadWindow.m
@@ -35,8 +35,7 @@
  */
 -(instancetype)init
 {
-	if ((self = [super initWithWindowNibName:@"Downloads"]) != nil)
-	{
+	if ((self = [super initWithWindowNibName:@"Downloads"]) != nil) {
 		lastCount = 0;
 	}
 	return self;
@@ -100,12 +99,10 @@
 {
 	
 	// Dynamically generate Open With submenu for item
-	if (menu == openWithMenu)
-	{
+	if (menu == openWithMenu) {
 		NSArray * list = [DownloadManager sharedInstance].downloadsList;
 		NSInteger index = table.selectedRow;
-		if (index != -1)
-		{
+		if (index != -1) {
 			DownloadItem * item = list[index];
 			[[NSWorkspace sharedWorkspace] vna_openWithMenuForFile:item.filename target:nil action:nil menu:menu];
 		}
@@ -120,8 +117,7 @@
 		BOOL completed = [notification.userInfo[UserNotificationContextKey] isEqualToString:UserNotificationContextFileDownloadCompleted];
 		BOOL failed = [notification.userInfo[UserNotificationContextKey] isEqualToString:UserNotificationContextFileDownloadFailed];
 
-		if (completed || failed)
-		{
+		if (completed || failed) {
 			[center removeDeliveredNotification: notification];
 		}
 	}];
@@ -143,8 +139,7 @@
 {
 	NSArray * list = [DownloadManager sharedInstance].downloadsList;
 	NSInteger index = table.selectedRow;
-	if (index != -1)
-	{
+	if (index != -1) {
 		DownloadItem * item = list[index];
 		if (item) {
             NSURL *url = [NSURL fileURLWithPath:item.filename];
@@ -164,16 +159,13 @@
 {
 	NSArray * list = [DownloadManager sharedInstance].downloadsList;
 	NSInteger index = table.selectedRow;
-	if (index != -1)
-	{
+	if (index != -1) {
 		DownloadItem * item = list[index];
-		if (item && [[NSFileManager defaultManager] fileExistsAtPath:item.filename])
-		{
-			if ([[NSWorkspace sharedWorkspace] selectFile:item.filename inFileViewerRootedAtPath:@""] == NO)
+		if (item && [[NSFileManager defaultManager] fileExistsAtPath:item.filename]) {
+			if ([[NSWorkspace sharedWorkspace] selectFile:item.filename inFileViewerRootedAtPath:@""] == NO) {
 				runOKAlertSheet(NSLocalizedString(@"Vienna cannot show the file.", nil), NSLocalizedString(@"Vienna cannot show the file \"%@\" because it moved since you downloaded it.", nil), item.filename.lastPathComponent);
-		}
-		else
-		{
+			}
+		} else {
 			NSBeep();
 		}
 	}
@@ -186,8 +178,7 @@
 {
 	NSArray * list = [DownloadManager sharedInstance].downloadsList;
 	NSInteger index = table.selectedRow;
-	if (index != -1)
-	{
+	if (index != -1) {
 		DownloadItem * item = list[index];
 		[[DownloadManager sharedInstance] removeItem:item];
 		[table reloadData];
@@ -201,8 +192,7 @@
 {
 	NSArray * list = [DownloadManager sharedInstance].downloadsList;
 	NSInteger index = table.selectedRow;
-	if (index != -1)
-	{
+	if (index != -1) {
 		DownloadItem * item = list[index];
 		[[DownloadManager sharedInstance] cancelItem:item];
 		[table reloadData];
@@ -227,11 +217,11 @@
 -(void)tableView:(ExtendedTableView *)tableView menuWillAppear:(NSEvent *)theEvent
 {
 	NSInteger row = [table rowAtPoint:[table convertPoint:theEvent.locationInWindow fromView:nil]];
-	if (row >= 0)
-	{
+	if (row >= 0) {
 		// Select the row under the cursor if it isn't already selected
-		if (table.numberOfSelectedRows <= 1)
+		if (table.numberOfSelectedRows <= 1) {
 			[table selectRowIndexes:[NSIndexSet indexSetWithIndex:(NSUInteger)row] byExtendingSelection:NO];
+		}
 	}
 }
 
@@ -240,13 +230,13 @@
  */
 -(void)tableView:(NSTableView *)aTableView willDisplayCell:(id)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
 {
-	if ([aCell isKindOfClass:[ImageAndTextCell class]])
-	{
+	if ([aCell isKindOfClass:[ImageAndTextCell class]]) {
 		NSArray * list = [DownloadManager sharedInstance].downloadsList;
 		DownloadItem * item = list[rowIndex];
 
-		if (item.image != nil)
+		if (item.image != nil) {
 			[aCell setImage:item.image];
+		}
 		[aCell setTextColor:(rowIndex == aTableView.selectedRow) ? [NSColor whiteColor] : [NSColor controlTextColor]];
 	}
 }
@@ -263,8 +253,9 @@
 	// TODO: return item when we have a cell that can parse it. Until then, construct our own data.
 	NSString * rawfilename = item.filename.lastPathComponent;
     NSString * filename = [rawfilename stringByRemovingPercentEncoding];
-	if (filename == nil)
+	if (filename == nil) {
 		filename = @"";
+	}
 
 	// Different layout depending on the state
 	NSString * objectString = filename;
@@ -287,13 +278,10 @@
 			// Size gathered so far at bottom
 			NSString * progressString = @"";
 
-			if (item.expectedSize == -1)
-			{
+			if (item.expectedSize == -1) {
                 progressString = [NSByteCountFormatter stringFromByteCount:item.size
                                                                 countStyle:NSByteCountFormatterCountStyleFile];
-			}
-			else
-			{
+			} else {
                 NSString *bytesSoFar = [NSByteCountFormatter stringFromByteCount:item.size
                                                                       countStyle:NSByteCountFormatterCountStyleFile];
                 NSString *expectedBytes = [NSByteCountFormatter stringFromByteCount:item.expectedSize
@@ -318,19 +306,15 @@
 	DownloadItem * item = (DownloadItem *)notification.object;
 	NSArray * list = [DownloadManager sharedInstance].downloadsList;
 	NSUInteger  rowIndex = [list indexOfObject:item];
-	if (list.count != lastCount)
-	{
+	if (list.count != lastCount) {
 		[table reloadData];
-		if (rowIndex != NSNotFound)
-		{
+		if (rowIndex != NSNotFound) {
 			NSIndexSet * indexes = [NSIndexSet indexSetWithIndex:rowIndex];
 			[table selectRowIndexes:indexes byExtendingSelection:NO];
 			[table scrollRowToVisible:rowIndex];
 		}
 		lastCount = list.count;
-	}
-	else
-	{
+	} else {
 		[table reloadData];
 	}
 }

--- a/Vienna/Sources/Download window/ImageAndTextCell.m
+++ b/Vienna/Sources/Download window/ImageAndTextCell.m
@@ -34,8 +34,7 @@
  */
 -(instancetype)init
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		image = nil;
 		auxiliaryImage = nil;
 		offset = 0;
@@ -122,15 +121,12 @@
 
     NSColor *newColourRGB = [newColour colorUsingColorSpace:[NSColorSpace deviceRGBColorSpace]];
     
-    if (newColourRGB)
-    {
+    if (newColourRGB) {
         countBackgroundColourGradientEnd = [NSColor colorWithHue:newColourRGB.hueComponent
                                                       saturation:newColourRGB.saturationComponent - 0.07
                                                       brightness:newColourRGB.brightnessComponent + 0.07
                                                            alpha:newColourRGB.alphaComponent];
-    }
-    else
-    {
+    } else {
         countBackgroundColourGradientEnd = countBackgroundColour.copy;
     }
 }
@@ -156,8 +152,7 @@
  */
 -(void)drawCellImage:(NSRect *)cellFrame inView:(NSView *)controlView
 {
-	if (image != nil)
-	{
+	if (image != nil) {
 		NSSize imageSize;
 		NSRect imageFrame;
 		
@@ -180,12 +175,12 @@
 {
 	// If the cell has an image, draw the image and then reduce
 	// cellFrame to move the text to the right of the image.
-	if (image != nil)
+	if (image != nil) {
 		[self drawCellImage:&cellFrame inView:controlView];
+	}
 
 	// If we have an error image, it appears on the right hand side.
-	if (auxiliaryImage)
-	{
+	if (auxiliaryImage) {
 		NSSize imageSize;
 		NSRect imageFrame;
 		
@@ -201,8 +196,7 @@
 	
 	// If the cell has a count button, draw the count
 	// button on the right of the cell.
-	if (hasCount)
-	{
+	if (hasCount) {
 		NSString * number = [NSString stringWithFormat:@"%li", (long)count];
 
 		// Use the current font point size as a guide for the count font size
@@ -241,8 +235,9 @@
         // Push new graphics state so we can draw using a shadow if needed
         [NSGraphicsContext saveGraphicsState];
         {
-            if (countLabelShadow)
+            if (countLabelShadow) {
                 [countLabelShadow set];
+            }
             
             // Draw the count in the rounded rectangle we just created.
             NSPoint point = NSMakePoint(NSMidX(countFrame) - numSize.width / 2.0f,  NSMidY(countFrame) - numSize.height / 2.0f );

--- a/Vienna/Sources/Info panel/InfoPanelController.m
+++ b/Vienna/Sources/Info panel/InfoPanelController.m
@@ -97,10 +97,11 @@
 	// Set the header details
 	self.folderName.stringValue = folder.name;
 	self.folderImage.image = folder.image; 
-	if ([folder.lastUpdate isEqualToDate:[NSDate distantPast]])
+	if ([folder.lastUpdate isEqualToDate:[NSDate distantPast]]) {
 		[self.lastRefreshDate setStringValue:NSLocalizedString(@"Never", nil)];
-	else
-        self.lastRefreshDate.stringValue = [NSDateFormatter vna_relativeDateStringFromDate:folder.lastUpdate];
+	} else {
+		self.lastRefreshDate.stringValue = [NSDateFormatter vna_relativeDateStringFromDate:folder.lastUpdate];
+	}
 
 	// Fill out the panels
 	self.urlField.stringValue = folder.feedURL;
@@ -139,8 +140,7 @@
 {
     if (self.isSubscribed.state == NSControlStateValueOn) {
         [[Database sharedManager] clearFlag:VNAFolderFlagUnsubscribed forFolder:self.infoFolderId];
-    }
-    else {
+    } else {
 		[[Database sharedManager] setFlag:VNAFolderFlagUnsubscribed forFolder:self.infoFolderId];
     }
 }
@@ -152,8 +152,7 @@
 {
     if (self.loadFullHTML.state == NSControlStateValueOn) {
         [[Database sharedManager] setFlag:VNAFolderFlagLoadFullHTML forFolder:self.infoFolderId];
-    }
-    else {
+    } else {
 		[[Database sharedManager] clearFlag:VNAFolderFlagLoadFullHTML forFolder:self.infoFolderId];
     }
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_LoadFullHTMLChange"

--- a/Vienna/Sources/Info panel/InfoPanelManager.m
+++ b/Vienna/Sources/Info panel/InfoPanelManager.m
@@ -54,8 +54,7 @@
  */
 -(instancetype)init
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		controllerList = [[NSMutableDictionary alloc] initWithCapacity:10];
 		
 		NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
@@ -85,8 +84,7 @@
 	InfoPanelController * infoWindow;
 	
 	infoWindow = controllerList[folderNumber];
-	if (infoWindow != nil)
-	{
+	if (infoWindow != nil) {
 		[infoWindow close];
 		[controllerList removeObjectForKey:folderNumber];
 	}
@@ -103,8 +101,9 @@
 	InfoPanelController * infoWindow;
 	
 	infoWindow = controllerList[folderNumber];
-	if (infoWindow != nil)
+	if (infoWindow != nil) {
 		[infoWindow updateFolder];
+	}
 }
 
 /**
@@ -119,8 +118,7 @@
 	InfoPanelController * infoWindow;
 
 	infoWindow = controllerList[folderNumber];
-	if (infoWindow == nil)
-	{
+	if (infoWindow == nil) {
 		infoWindow = [[InfoPanelController alloc] initWithFolder:folderId];
         block(infoWindow);
 		controllerList[folderNumber] = infoWindow;

--- a/Vienna/Sources/Main window/ArticleCellView.m
+++ b/Vienna/Sources/Main window/ArticleCellView.m
@@ -27,8 +27,7 @@
 
 -(instancetype)initWithFrame:(NSRect)frameRect
 {
-	if((self = [super initWithFrame:frameRect]))
-	{
+	if ((self = [super initWithFrame:frameRect])) {
 		controller = APPCONTROLLER;
         [self initializeWebKitArticleView:frameRect];
 
@@ -52,8 +51,7 @@
 	[super drawRect:dirtyRect];
 	if([self.listView.selectedRowIndexes containsIndex:articleRow]) {
 		[[NSColor selectedControlColor] set];
-	}
-	else {
+	} else {
 		[[NSColor controlColor] set];
     }
 
@@ -62,10 +60,8 @@
 	[roundedRect fill];
 
 	//Progress indicator
-	if (self.inProgress)
-	{
-		if (!progressIndicator)
-		{
+	if (self.inProgress) {
+		if (!progressIndicator) {
 			// Allocate and initialize the spinning progress indicator.
 			NSRect progressRect = NSMakeRect(PROGRESS_INDICATOR_LEFT_MARGIN, NSHeight(self.bounds) - PROGRESS_INDICATOR_DIMENSION_REGULAR,
 												PROGRESS_INDICATOR_DIMENSION_REGULAR, PROGRESS_INDICATOR_DIMENSION_REGULAR);
@@ -77,14 +73,13 @@
 
 		// Add the progress indicator as a subview of the cell if
 		// it is not already one.
-		if (progressIndicator.superview != self)
+		if (progressIndicator.superview != self) {
 			[self addSubview:progressIndicator];
+		}
 
 		// Start the animation.
 		[progressIndicator startAnimation:self];
-	}
-	else
-	{
+	} else {
 		// Stop the animation and remove from the superview.
 		[progressIndicator stopAnimation:self];
 		[progressIndicator.superview setNeedsDisplayInRect:progressIndicator.frame];

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -56,8 +56,7 @@
  */
 -(instancetype)init
 {
-    if ((self = [super init]) != nil)
-	{
+    if ((self = [super init]) != nil) {
 		isBacktracking = NO;
 		currentFolderId = -1;
 		articleToPreserve = nil;
@@ -150,8 +149,7 @@
 {
 	Article * currentSelectedArticle = self.selectedArticle;
 
-	switch (newLayout)
-	{
+	switch (newLayout) {
 		case VNALayoutReport:
 		case VNALayoutCondensed:
 			self.mainArticleView = self.articleListView;
@@ -164,8 +162,7 @@
 
 	[self loadView];
 	[Preferences standardPreferences].layout = newLayout;
-	if (currentSelectedArticle != nil)
-	{
+	if (currentSelectedArticle != nil) {
 		[self selectFolderAndArticle:currentFolderId guid:currentSelectedArticle.guid];
 		[self ensureSelectedArticle];
 	}
@@ -238,8 +235,9 @@
  */
 -(NSString *)searchPlaceholderString
 {
-	if (currentFolderId == -1)
+	if (currentFolderId == -1) {
 		return @"";
+	}
 
 	Folder * folder = [[Database sharedManager] folderFromID:currentFolderId];
 	return [NSString stringWithFormat:NSLocalizedString(@"Filter in %@", nil), folder.name];
@@ -269,20 +267,18 @@
 	Preferences * prefs = [Preferences standardPreferences];
 	NSMutableArray * descriptors = [NSMutableArray arrayWithArray:prefs.articleSortDescriptors];
 	
-	if ([sortColumnIdentifier isEqualToString:columnName])
+	if ([sortColumnIdentifier isEqualToString:columnName]) {
 		descriptors[0] = [descriptors[0] reversedSortDescriptor];
-	else
-	{
+	} else {
 		[self setSortColumnIdentifier:columnName];
 		[prefs setObject:sortColumnIdentifier forKey:MAPref_SortColumn];
 		NSSortDescriptor * sortDescriptor;
 		NSDictionary * specifier = [articleSortSpecifiers valueForKey:sortColumnIdentifier];
 		NSUInteger index = [[descriptors valueForKey:@"key"] indexOfObject:[specifier valueForKey:@"key"]];
 
-		if (index == NSNotFound)
+		if (index == NSNotFound) {
 			sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[specifier valueForKey:@"key"] ascending:YES selector:NSSelectorFromString([specifier valueForKey:@"selector"])];
-		else
-		{
+		} else {
 			sortDescriptor = descriptors[index];
 			[descriptors removeObjectAtIndex:index];
 		}
@@ -315,8 +311,7 @@
 	NSSortDescriptor * sortDescriptor = descriptors[0];
 	
 	BOOL existingAscending = sortDescriptor.ascending;
-	if ( newAscending != existingAscending )
-	{
+	if ( newAscending != existingAscending ) {
 		descriptors[0] = sortDescriptor.reversedSortDescriptor;
 		prefs.articleSortDescriptors = descriptors;
 		[mainArticleView refreshFolder:VNARefreshSortAndRedraw];
@@ -351,23 +346,18 @@
 {
 	// mark current article read
 	Article * currentArticle = self.selectedArticle;
-	if (currentArticle != nil && !currentArticle.read)
-	{
+	if (currentArticle != nil && !currentArticle.read) {
 		[self markReadByArray:@[currentArticle] readFlag:YES];
 	}
 
 	// If there are any unread articles then select the first one in the
 	// first folder.
-	if ([Database sharedManager].countOfUnread > 0)
-	{
+	if ([Database sharedManager].countOfUnread > 0) {
 		// Get the first folder with unread articles.
 		NSInteger firstFolderWithUnread = self.foldersTree.firstFolderWithUnread;
-		if (firstFolderWithUnread == currentFolderId)
-		{
+		if (firstFolderWithUnread == currentFolderId) {
             [self->mainArticleView selectFirstUnreadInFolder];
-		}
-		else
-		{
+		} else {
 			// Seed in order to select the first unread article.
 			firstUnreadArticleRequired = YES;
 			// Select the folder in the tree view.
@@ -384,28 +374,21 @@
 {
 	// mark current article read
 	Article * currentArticle = self.selectedArticle;
-	if (currentArticle != nil && !currentArticle.read)
-	{
+	if (currentArticle != nil && !currentArticle.read) {
 		[self markReadByArray:@[currentArticle] readFlag:YES];
 	}
 
 	// If there are any unread articles then select the nexst one
-	if ([Database sharedManager].countOfUnread > 0)
-	{
+	if ([Database sharedManager].countOfUnread > 0) {
 		// Search other articles in the same folder, starting from current position
-        if (!mainArticleView.viewNextUnreadInFolder)
-		{
+        if (!mainArticleView.viewNextUnreadInFolder) {
 			// If nothing found and smart folder, search if we have other fresh articles from same folder
 			Folder * currentFolder = [[Database sharedManager] folderFromID:currentFolderId];
-			if (currentFolder.type == VNAFolderTypeSmart || currentFolder.type == VNAFolderTypeTrash || currentFolder.type == VNAFolderTypeSearch)
-			{
-                if (!mainArticleView.selectFirstUnreadInFolder)
-				{
+			if (currentFolder.type == VNAFolderTypeSmart || currentFolder.type == VNAFolderTypeTrash || currentFolder.type == VNAFolderTypeSearch) {
+                if (!mainArticleView.selectFirstUnreadInFolder) {
 					[self displayNextFolderWithUnread];
 				}
-			}
-			else
-			{
+			} else {
 				[self displayNextFolderWithUnread];
 			}
 		}
@@ -419,8 +402,7 @@
 -(void)displayNextFolderWithUnread
 {
 	NSInteger nextFolderWithUnread = [self.foldersTree nextFolderWithUnread:currentFolderId];
-	if (nextFolderWithUnread != -1)
-	{
+	if (nextFolderWithUnread != -1) {
 		// Seed in order to select the first unread article.
 		firstUnreadArticleRequired = YES;
 		[self.foldersTree selectFolder:nextFolderWithUnread];
@@ -434,8 +416,7 @@
  */
 -(void)displayFolder:(NSInteger)newFolderId
 {
-	if (currentFolderId != newFolderId && newFolderId != 0)
-	{
+	if (currentFolderId != newFolderId && newFolderId != 0) {
 		// Clear all of the articles in the current folder.
 		// This will reset the scroller position and deselect all.
 		// Otherwise, the new folder might attempt to preserve selection.
@@ -456,14 +437,11 @@
 -(void)selectFolderAndArticle:(NSInteger)folderId guid:(NSString *)guid
 {
 	// If we're in the right folder, select the article
-	if (folderId == currentFolderId)
-	{
+	if (folderId == currentFolderId) {
 		if (guid != nil) {
 			[mainArticleView scrollToArticle:guid];
 		}
-	}
-	else
-	{
+	} else {
 		// We seed guidOfArticleToSelect so that
 		// after notification of folder selection change has been processed,
 		// it will select the requisite article on our behalf.
@@ -538,23 +516,18 @@
 	NSString * guidOfArticleToPreserve = articleToPreserve.guid;
 	
 	NSInteger filterMode = [Preferences standardPreferences].filterMode;
-	for (NSInteger index = filteredArray.count - 1; index >= 0; --index)
-	{
+	for (NSInteger index = filteredArray.count - 1; index >= 0; --index) {
 		Article * article = filteredArray[index];
 		if (guidOfArticleToPreserve != nil 
 			&& article.folderId == articleToPreserve.folderId 
-			&& [article.guid isEqualToString:guidOfArticleToPreserve])
-		{
+			&& [article.guid isEqualToString:guidOfArticleToPreserve]) {
 			guidOfArticleToPreserve = nil;
-		}
-        else if ([self filterArticle:article usingMode:filterMode] == false)
-		{
+		} else if ([self filterArticle:article usingMode:filterMode] == false) {
 			[filteredArray removeObjectAtIndex:index];
         }
 	}
 	
-	if (guidOfArticleToPreserve != nil)
-	{
+	if (guidOfArticleToPreserve != nil) {
 		[filteredArray addObject:articleToPreserve];
 	}
 	articleToPreserve = nil;
@@ -603,26 +576,22 @@
         [self innerMarkFlaggedByArray:articleArray flagged:NO];
 		
 		Article * firstArticle = articleArray.firstObject;
-		if (firstArticle != nil) // Should always be true
-		{
+		// Should always be true
+		if (firstArticle != nil) {
 			// We want to select the next non-deleted article
 			NSUInteger articleIndex = [currentArrayOfArticles indexOfObject:firstArticle];
-			if (articleIndex != NSNotFound)
-			{
+			if (articleIndex != NSNotFound) {
 				NSUInteger count = currentArrayOfArticles.count;
-				for (NSUInteger i = articleIndex + 1; i < count; ++i)
-				{
+				for (NSUInteger i = articleIndex + 1; i < count; ++i) {
                     Article * nextArticle = currentArrayOfArticles[i];
-					if (![articleArray containsObject:nextArticle])
-					{
+					if (![articleArray containsObject:nextArticle]) {
 						guidToSelect = nextArticle.guid;
 						break;
 					}
 				}
 				
 				// Otherwise, we want to select the previous article.
-				if (guidToSelect == nil && articleIndex > 0)
-				{
+				if (guidToSelect == nil && articleIndex > 0) {
                     Article * nextArticle = currentArrayOfArticles[articleIndex - 1];
 					guidToSelect = nextArticle.guid;
 				}
@@ -635,42 +604,33 @@
 
 	// Iterate over every selected article in the table and set the deleted
 	// flag on the article while simultaneously removing it from our copies
-	for (Article * theArticle in articleArray)
-	{
+	for (Article * theArticle in articleArray) {
 		[[Database sharedManager] markArticleDeleted:theArticle isDeleted:deleteFlag];
-		if (![currentArrayOfArticles containsObject:theArticle])
+		if (![currentArrayOfArticles containsObject:theArticle]) {
 			needReload = YES;
-		else if (deleteFlag && (currentFolderId != [Database sharedManager].trashFolderId))
-		{
+		} else if (deleteFlag && (currentFolderId != [Database sharedManager].trashFolderId)) {
 			[currentArrayCopy removeObject:theArticle];
 			[folderArrayCopy removeObject:theArticle];
-		}
-		else if (!deleteFlag && (currentFolderId == [Database sharedManager].trashFolderId))
-		{
+		} else if (!deleteFlag && (currentFolderId == [Database sharedManager].trashFolderId)) {
 			[currentArrayCopy removeObject:theArticle];
 			[folderArrayCopy removeObject:theArticle];
-		}
-		else
+		} else {
 			needReload = YES;
+		}
 	}
 
 	self.currentArrayOfArticles = currentArrayCopy;
 	self.folderArrayOfArticles = folderArrayCopy;
-	if (needReload)
+	if (needReload) {
 		[self reloadArrayOfArticles];
-	else
-	{
+	} else {
 		[mainArticleView refreshFolder:VNARefreshRedrawList];
-		if (currentArrayOfArticles.count > 0u)
-		{
-			if (guidToSelect != nil)
-			{
+		if (currentArrayOfArticles.count > 0u) {
+			if (guidToSelect != nil) {
 				[mainArticleView scrollToArticle:guidToSelect];
 			}
 			[mainArticleView ensureSelectedArticle];
-		}
-		else
-		{
+		} else {
 			[NSApp.mainWindow makeFirstResponder:self.foldersTree.mainView];
 		}
 	}
@@ -689,26 +649,22 @@
 	
 	NSString * guidToSelect = nil;
 	Article * firstArticle = articleArray.firstObject;
-	if (firstArticle != nil) // Should always be true
-	{
+	// Should always be true
+	if (firstArticle != nil) {
 		// We want to select the next non-deleted article
 		NSUInteger articleIndex = [currentArrayOfArticles indexOfObject:firstArticle];
-		if (articleIndex != NSNotFound)
-		{
+		if (articleIndex != NSNotFound) {
 			NSUInteger count = currentArrayOfArticles.count;
-			for (NSUInteger i = articleIndex + 1; i < count; ++i)
-			{
+			for (NSUInteger i = articleIndex + 1; i < count; ++i) {
                 Article * nextArticle = currentArrayOfArticles[i];
-				if (![articleArray containsObject:nextArticle])
-				{
+				if (![articleArray containsObject:nextArticle]) {
 					guidToSelect = nextArticle.guid;
 					break;
 				}
 			}
 			
 			// Otherwise, we want to select the previous article.
-			if (guidToSelect == nil && articleIndex > 0)
-			{
+			if (guidToSelect == nil && articleIndex > 0) {
                 Article * nextArticle = currentArrayOfArticles[articleIndex - 1];
 				guidToSelect = nextArticle.guid;
 			}
@@ -720,10 +676,8 @@
 
 	// Iterate over every selected article in the table and remove it from
 	// the database.
-	for (Article * theArticle in articleArray)	
-	{
-		if ([[Database sharedManager] deleteArticle:theArticle])
-		{
+	for (Article * theArticle in articleArray) {
+		if ([[Database sharedManager] deleteArticle:theArticle]) {
 			[currentArrayCopy removeObject:theArticle];
 			[folderArrayCopy removeObject:theArticle];
 		}
@@ -734,8 +688,7 @@
 
 	// Ensure there's a valid selection
     if (currentArrayOfArticles.count > 0u) {
-		if (guidToSelect != nil)
-		{
+		if (guidToSelect != nil) {
 			[mainArticleView scrollToArticle:guidToSelect];
 		}
 		[mainArticleView ensureSelectedArticle];
@@ -780,8 +733,7 @@
  */
 -(void)innerMarkFlaggedByArray:(NSArray *)articleArray flagged:(BOOL)flagged
 {
-	for (Article * theArticle in articleArray)
-	{
+	for (Article * theArticle in articleArray) {
 		Folder *myFolder = [[Database sharedManager] folderFromID:theArticle.folderId];
 		if (myFolder.type == VNAFolderTypeOpenReader) {
 			[[OpenReader sharedManager] markStarred:theArticle starredFlag:flagged];
@@ -832,11 +784,9 @@
 {
 	NSInteger lastFolderId = -1;
 	
-	for (Article * theArticle in articleArray)
-	{
+	for (Article * theArticle in articleArray) {
 		NSInteger folderId = theArticle.folderId;
-		if (theArticle.read != readFlag)
-		{
+		if (theArticle.read != readFlag) {
 			if ([[Database sharedManager] folderFromID:folderId].type == VNAFolderTypeOpenReader) {
 				[[OpenReader sharedManager] markRead:theArticle readFlag:readFlag];
 			} else {
@@ -864,8 +814,7 @@
 	Database * db = [Database sharedManager];
 	NSInteger lastFolderId = -1;
 
-	for (ArticleReference * articleRef in articleArray)
-	{
+	for (ArticleReference * articleRef in articleArray) {
 		NSInteger folderId = articleRef.folderId;
 		Folder * folder = [db folderFromID:folderId];
 		if (folder.type == VNAFolderTypeOpenReader){
@@ -910,8 +859,7 @@
 -(void)markAllFoldersReadByArray:(NSArray *)folderArray
 {
 	NSArray * refArray = [self wrappedMarkAllFoldersReadInArray:folderArray];
-	if (refArray != nil && refArray.count > 0)
-	{
+	if (refArray != nil && refArray.count > 0) {
 		NSUndoManager * undoManager = NSApp.mainWindow.undoManager;
 		[undoManager registerUndoWithTarget:self selector:@selector(markAllReadUndo:) object:refArray];
 		[undoManager setActionName:NSLocalizedString(@"Mark All Read", nil)];
@@ -920,8 +868,7 @@
 	// Smart and Search folders are not included in folderArray when you mark all subscriptions read,
 	// so we need to mark articles read if they're the current folder.
 	Folder * currentFolder = [[Database sharedManager] folderFromID:currentFolderId];
-	if (currentFolder != nil && ![folderArray containsObject:currentFolder])
-	{
+	if (currentFolder != nil && ![folderArray containsObject:currentFolder]) {
 		for (Article * theArticle in folderArrayOfArticles)
 			[theArticle markRead:YES];
 	}
@@ -937,30 +884,21 @@
 {
 	NSMutableArray * refArray = [NSMutableArray array];
 	
-	for (Folder * folder in folderArray)
-	{
+	for (Folder * folder in folderArray) {
 		NSInteger folderId = folder.itemId;
-		if (folder.type == VNAFolderTypeGroup)
-		{
+		if (folder.type == VNAFolderTypeGroup) {
 			[refArray addObjectsFromArray:[self wrappedMarkAllFoldersReadInArray:[[Database sharedManager] arrayOfFolders:folderId]]];
-		}
-		else if (folder.type == VNAFolderTypeRSS)
-		{
+		} else if (folder.type == VNAFolderTypeRSS) {
 			[refArray addObjectsFromArray:[folder arrayOfUnreadArticlesRefs]];
 			[[Database sharedManager] markFolderRead:folderId];
-		}
-		else if (folder.type == VNAFolderTypeOpenReader)
-		{
+		} else if (folder.type == VNAFolderTypeOpenReader) {
 			NSArray * articleArray = [folder arrayOfUnreadArticlesRefs];
 			[refArray addObjectsFromArray:articleArray];
 			[[OpenReader sharedManager] markAllReadInFolder:folder];
-		}
-		else
-		{
+		} else {
 			// For smart folders, we only mark all read the current folder to
 			// simplify things.
-			if (folderId == currentFolderId)
-			{
+			if (folderId == currentFolderId) {
 				[refArray addObjectsFromArray:currentArrayOfArticles];
 				[self innerMarkReadByArray:currentArrayOfArticles readFlag:YES];
 			}
@@ -984,8 +922,7 @@
 	[undoManager registerUndoWithTarget:self selector:markAllReadUndoAction object:refArray];
 	[undoManager setActionName:NSLocalizedString(@"Mark All Read", nil)];
 	
-	for (ArticleReference *ref in refArray)
-	{
+	for (ArticleReference *ref in refArray) {
 		NSInteger folderId = ref.folderId;
 		NSString * theGuid = ref.guid;
 		Folder * folder = [dbManager folderFromID:folderId];
@@ -1015,8 +952,7 @@
 	if (lastFolderId != -1 && [dbManager folderFromID:currentFolderId].type != VNAFolderTypeRSS
 		&& [dbManager folderFromID:currentFolderId].type != VNAFolderTypeOpenReader) {
 		[self reloadArrayOfArticles];
-	}
-	else if (needRefilter) {
+	} else if (needRefilter) {
 		[mainArticleView refreshFolder:VNARefreshReapplyFilter];
 	}
 }
@@ -1027,8 +963,9 @@
  */
 -(void)addBacktrack:(NSString *)guid
 {
-	if (!isBacktracking)
+	if (!isBacktracking) {
 		[backtrackArray addToQueue:currentFolderId guid:guid];
+	}
 }
 
 /* goForward
@@ -1039,8 +976,7 @@
 	NSInteger folderId;
 	NSString * guid;
 	
-	if ([backtrackArray nextItemAtQueue:&folderId guidPointer:&guid])
-	{
+	if ([backtrackArray nextItemAtQueue:&folderId guidPointer:&guid]) {
 		isBacktracking = YES;
 		[self selectFolderAndArticle:folderId guid:guid];
 		isBacktracking = NO;
@@ -1055,8 +991,7 @@
 	NSInteger folderId;
 	NSString * guid;
 	
-	if ([backtrackArray previousItemAtQueue:&folderId guidPointer:&guid])
-	{
+	if ([backtrackArray previousItemAtQueue:&folderId guidPointer:&guid]) {
 		isBacktracking = YES;
 		[self selectFolderAndArticle:folderId guid:guid];
 		isBacktracking = NO;

--- a/Vienna/Sources/Main window/ArticleConverter.m
+++ b/Vienna/Sources/Main window/ArticleConverter.m
@@ -45,11 +45,11 @@
     NSMutableString * newString = [NSMutableString stringWithString:SafeString(theString)];
     NSUInteger tagStartIndex = 0;
 
-    while ((tagStartIndex = [newString vna_indexOfCharacterInString:'$' afterIndex:tagStartIndex]) != NSNotFound)
-    {
+    while ((tagStartIndex = [newString vna_indexOfCharacterInString:'$' afterIndex:tagStartIndex]) != NSNotFound) {
         NSUInteger tagEndIndex = [newString vna_indexOfCharacterInString:'$' afterIndex:tagStartIndex + 1];
-        if (tagEndIndex == NSNotFound)
+        if (tagEndIndex == NSNotFound) {
             break;
+        }
 
         NSUInteger tagLength = (tagEndIndex - tagStartIndex) + 1;
         NSString * tagName = [newString substringWithRange:NSMakeRange(tagStartIndex + 1, tagLength - 2)];
@@ -67,14 +67,14 @@
         NSString * (*func)(id, SEL) = (void *)imp;
         replacementString = func(theArticle, selector);
 
-        if (replacementString == nil)
+        if (replacementString == nil) {
             [newString deleteCharactersInRange:NSMakeRange(tagStartIndex, tagLength)];
-        else
-        {
+        } else {
             [newString replaceCharactersInRange:NSMakeRange(tagStartIndex, tagLength) withString:replacementString];
 
-            if (!replacementString.vna_isBlank)
+            if (!replacementString.vna_isBlank) {
                 cond = NO;
+            }
 
             tagStartIndex += replacementString.length;
         }

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -78,8 +78,7 @@ static void *ObserverContext = &ObserverContext;
 -(instancetype)initWithFrame:(NSRect)frame
 {
     self= [super initWithFrame:frame];
-    if (self)
-	{
+    if (self) {
         isChangingOrientation = NO;
 		isInTableInit = NO;
 		blockSelectionHandler = NO;
@@ -206,17 +205,18 @@ static void *ObserverContext = &ObserverContext;
 	Field * field;
 	NSUInteger  index;
 	
-	for (index = 0; index < dataArray.count;)
-	{
+	for (index = 0; index < dataArray.count;) {
 		NSString * name;
 		NSInteger width = 100;
 		BOOL visible = NO;
 		
 		name = dataArray[index++];
-		if (index < dataArray.count)
+		if (index < dataArray.count) {
 			visible = [dataArray[index++] integerValue] == YES;
-		if (index < dataArray.count)
+		}
+		if (index < dataArray.count) {
 			width = [dataArray[index++] integerValue];
+		}
 		
 		field = [db fieldByName:name];
 		field.visible = visible;
@@ -295,25 +295,20 @@ static void *ObserverContext = &ObserverContext;
 	NSInteger column = articleList.clickedColumn;
 	NSArray * allArticles = self.controller.articleController.allArticles;
 	
-	if (row >= 0 && row < (NSInteger)allArticles.count)
-	{
+	if (row >= 0 && row < (NSInteger)allArticles.count) {
 		NSArray * columns = articleList.tableColumns;
-		if (column >= 0 && column < (NSInteger)columns.count)
-		{
+		if (column >= 0 && column < (NSInteger)columns.count) {
 			Article * theArticle = allArticles[row];
 			NSString * columnName = ((NSTableColumn *)columns[column]).identifier;
-			if ([columnName isEqualToString:MA_Field_Read])
-			{
+			if ([columnName isEqualToString:MA_Field_Read]) {
 				[self.controller.articleController markReadByArray:@[theArticle] readFlag:!theArticle.read];
 				return;
 			}
-			if ([columnName isEqualToString:MA_Field_Flagged])
-			{
+			if ([columnName isEqualToString:MA_Field_Flagged]) {
 				[self.controller.articleController markFlaggedByArray:@[theArticle] flagged:!theArticle.flagged];
 				return;
 			}
-			if ([columnName isEqualToString:MA_Field_HasEnclosure])
-			{
+			if ([columnName isEqualToString:MA_Field_HasEnclosure]) {
 				// TODO: Do interesting stuff with the enclosure here.
 			}
 			
@@ -328,8 +323,7 @@ static void *ObserverContext = &ObserverContext;
 -(IBAction)doubleClickRow:(id)sender
 {
 	NSInteger clickedRow = articleList.clickedRow;
-	if (clickedRow != -1)
-	{
+	if (clickedRow != -1) {
 		Article * theArticle = self.controller.articleController.allArticles[clickedRow];
 		[self.controller openURLFromString:theArticle.link inPreferredBrowser:YES];
 	}
@@ -367,8 +361,7 @@ static void *ObserverContext = &ObserverContext;
 	[self updateArticleListRowHeight];
 	
 	// Create the new columns
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		Field * field = fields[index];
 		NSString * identifier = field.name;
 		NSInteger tag = field.tag;
@@ -376,15 +369,16 @@ static void *ObserverContext = &ObserverContext;
 		
 		// Handle which fields can be visible in the condensed (vertical) layout
 		// versus the report (horizontal) layout
-		if (tableLayout == VNALayoutReport)
+		if (tableLayout == VNALayoutReport) {
 			showField = field.visible && tag != ArticleFieldIDHeadlines && tag != ArticleFieldIDComments;
-		else
-		{
+		} else {
 			showField = NO;
-			if (tag == ArticleFieldIDRead || tag == ArticleFieldIDFlagged || tag == ArticleFieldIDHasEnclosure)
+			if (tag == ArticleFieldIDRead || tag == ArticleFieldIDFlagged || tag == ArticleFieldIDHasEnclosure) {
 				showField = field.visible;
-			if (tag == ArticleFieldIDHeadlines)
+			}
+			if (tag == ArticleFieldIDHeadlines) {
 				showField = YES;
+			}
 		}
 
 		// Set column hidden or shown
@@ -393,8 +387,7 @@ static void *ObserverContext = &ObserverContext;
 
 		// Add to the end only those columns which should be visible
 		// and aren't created yet
-		if (showField && [articleList columnWithIdentifier:identifier]==-1)
-		{
+		if (showField && [articleList columnWithIdentifier:identifier]==-1) {
 			NSTableColumn * column = [[NSTableColumn alloc] initWithIdentifier:identifier];
 			
 			// Replace the normal text field cell with a progress text cell so we can
@@ -402,20 +395,19 @@ static void *ObserverContext = &ObserverContext;
 			// in willDisplayCell:forTableColumn:row: where it sets the inProgress flag.
 			// We need to use a different column for condensed layout vs. table layout.
 			BOOL isProgressColumn = NO;
-			if (tableLayout == VNALayoutReport && [column.identifier isEqualToString:MA_Field_Subject])
+			if (tableLayout == VNALayoutReport && [column.identifier isEqualToString:MA_Field_Subject]) {
 				isProgressColumn = YES;
-			if (tableLayout == VNALayoutCondensed && [column.identifier isEqualToString:MA_Field_Headlines])
+			}
+			if (tableLayout == VNALayoutCondensed && [column.identifier isEqualToString:MA_Field_Headlines]) {
 				isProgressColumn = YES;
+			}
 			
-			if (isProgressColumn)
-			{
+			if (isProgressColumn) {
 				ProgressTextCell * progressCell;
 				
 				progressCell = [[ProgressTextCell alloc] init];
 				column.dataCell = progressCell;
-			}
-			else
-			{
+			} else {
 				VNAVerticallyCenteredTextFieldCell * cell;
 
 				cell = [[VNAVerticallyCenteredTextFieldCell alloc] init];
@@ -438,8 +430,7 @@ static void *ObserverContext = &ObserverContext;
 		}
 
 		// Set column size for visible columns
-		if (showField)
-		{
+		if (showField) {
 			NSTableColumn *column = [articleList tableColumnWithIdentifier:identifier];
 			column.width = field.width;
 		}
@@ -481,10 +472,11 @@ static void *ObserverContext = &ObserverContext;
 	// Put the selection back
 	[articleList selectRowIndexes:selArray byExtendingSelection:NO];
 	
-	if (tableLayout == VNALayoutReport)
+	if (tableLayout == VNALayoutReport) {
 		articleList.autosaveName = @"Vienna3ReportLayoutColumns";
-	else
+	} else {
 		articleList.autosaveName = @"Vienna3CondensedLayoutColumns";
+	}
 	[articleList setAutosaveTableColumns:YES];
 
 	// Done
@@ -508,8 +500,7 @@ static void *ObserverContext = &ObserverContext;
 	
 	// Create the new columns
 	
-	for (Field * field in  [[Database sharedManager] arrayOfFields])
-	{
+	for (Field * field in  [[Database sharedManager] arrayOfFields]) {
 		[dataArray addObject:field.name];
 		[dataArray addObject:@(field.visible)];
 		[dataArray addObject:@(field.width)];
@@ -557,21 +548,25 @@ static void *ObserverContext = &ObserverContext;
 	CGFloat height = [APPCONTROLLER.layoutManager defaultLineHeightForFont:articleListFont];
 	NSInteger numberOfRowsInCell;
 
-	if (tableLayout == VNALayoutReport)
+	if (tableLayout == VNALayoutReport) {
 		numberOfRowsInCell = 1;
-	else
-	{
+	} else {
 		numberOfRowsInCell = 0;
-		if ([db fieldByName:MA_Field_Subject].visible)
+		if ([db fieldByName:MA_Field_Subject].visible) {
 			++numberOfRowsInCell;
-		if ([db fieldByName:MA_Field_Folder].visible || [db fieldByName:MA_Field_Date].visible || [db fieldByName:MA_Field_Author].visible)
+		}
+		if ([db fieldByName:MA_Field_Folder].visible || [db fieldByName:MA_Field_Date].visible || [db fieldByName:MA_Field_Author].visible) {
 			++numberOfRowsInCell;
-		if ([db fieldByName:MA_Field_Link].visible)
+		}
+		if ([db fieldByName:MA_Field_Link].visible) {
 			++numberOfRowsInCell;
-		if ([db fieldByName:MA_Field_Summary].visible)
+		}
+		if ([db fieldByName:MA_Field_Summary].visible) {
 			++numberOfRowsInCell;
-		if (numberOfRowsInCell == 0)
+		}
+		if (numberOfRowsInCell == 0) {
 			++numberOfRowsInCell;
+		}
 	}
 	articleList.rowHeight = (height + 2.0f) * (CGFloat)numberOfRowsInCell;
 }
@@ -583,16 +578,12 @@ static void *ObserverContext = &ObserverContext;
 {
 	NSString * sortColumnIdentifier = self.controller.articleController.sortColumnIdentifier;
 	
-	for (NSTableColumn * column in articleList.tableColumns)
-	{
-		if ([column.identifier isEqualToString:sortColumnIdentifier])
-		{
+	for (NSTableColumn * column in articleList.tableColumns) {
+		if ([column.identifier isEqualToString:sortColumnIdentifier]) {
 			NSString * imageName = ([[Preferences standardPreferences].articleSortDescriptors[0] ascending]) ? @"NSAscendingSortIndicator" : @"NSDescendingSortIndicator";
 			articleList.highlightedTableColumn = column;
 			[articleList setIndicatorImage:[NSImage imageNamed:imageName] inTableColumn:column];
-		}
-		else
-		{
+		} else {
 			// Remove any existing image in the column header.
 			[articleList setIndicatorImage:nil inTableColumn:column];
 		}
@@ -604,13 +595,10 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)scrollToArticle:(NSString *)guid
 {
-	if (guid != nil)
-	{
+	if (guid != nil) {
 		NSInteger rowIndex = 0;
-		for (Article * thisArticle in self.controller.articleController.allArticles)
-		{
-			if ([thisArticle.guid isEqualToString:guid])
-			{
+		for (Article * thisArticle in self.controller.articleController.allArticles) {
+			if ([thisArticle.guid isEqualToString:guid]) {
 				[self makeRowSelectedAndVisible:rowIndex];
 				return;
 			}
@@ -762,8 +750,7 @@ static void *ObserverContext = &ObserverContext;
 -(void)handleArticleListFontChange:(NSNotification *)note
 {
 	[self setTableViewFont];
-	if (self == self.controller.articleController.mainArticleView)
-	{
+	if (self == self.controller.articleController.mainArticleView) {
 		[articleList reloadData];
 	}
 }
@@ -773,8 +760,9 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)handleLoadFullHTMLChange:(NSNotification *)note
 {
-	if (self == self.controller.articleController.mainArticleView)
+	if (self == self.controller.articleController.mainArticleView) {
 		[self refreshArticlePane];
+	}
 }
 
 /* handleReadingPaneChange
@@ -782,8 +770,7 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)handleReadingPaneChange:(NSNotificationCenter *)nc
 {
-	if (self == self.controller.articleController.mainArticleView)
-	{
+	if (self == self.controller.articleController.mainArticleView) {
 		[self setOrientation:[Preferences standardPreferences].layout];
 		[self updateVisibleColumns];
 		[articleList reloadData];
@@ -813,12 +800,9 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)makeRowSelectedAndVisible:(NSInteger)rowIndex
 {
-	if (self.controller.articleController.allArticles.count == 0u)
-	{
+	if (self.controller.articleController.allArticles.count == 0u) {
 		[articleList deselectAll:self];
-	}
-    else if (rowIndex != articleList.selectedRow)
-	{
+	} else if (rowIndex != articleList.selectedRow) {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
 
 		// make sure our current selection is visible
@@ -828,8 +812,9 @@ static void *ObserverContext = &ObserverContext;
 		NSInteger lastRow = articleList.numberOfRows - 1;
 		NSInteger visibleRow = rowIndex + (pageSize / 2);
 
-		if (visibleRow > lastRow)
+		if (visibleRow > lastRow) {
 			visibleRow = lastRow;
+		}
 		[articleList scrollRowToVisible:visibleRow];
 	}
 }
@@ -849,17 +834,16 @@ static void *ObserverContext = &ObserverContext;
  */
 -(BOOL)viewNextUnreadInCurrentFolder:(NSInteger)currentRow
 {
-	if (currentRow < 0)
+	if (currentRow < 0) {
 		currentRow = 0;
+	}
 	
 	NSArray * allArticles = self.controller.articleController.allArticles;
 	NSInteger totalRows = allArticles.count;
 	Article * theArticle;
-	while (currentRow < totalRows)
-	{
+	while (currentRow < totalRows) {
 		theArticle = allArticles[currentRow];
-		if (!theArticle.read)
-		{
+		if (!theArticle.read) {
 			[self makeRowSelectedAndVisible:currentRow];
 			return YES;
 		}
@@ -895,11 +879,11 @@ static void *ObserverContext = &ObserverContext;
 -(BOOL)selectFirstUnreadInFolder
 {
 	BOOL result = [self viewNextUnreadInCurrentFolder:-1];
-	if (!result)
-	{
+	if (!result) {
 		NSInteger count = self.controller.articleController.allArticles.count;
-		if (count > 0)
+		if (count > 0) {
 			[self makeRowSelectedAndVisible:0];
+		}
 	}
 	return result;
 }
@@ -941,11 +925,9 @@ static void *ObserverContext = &ObserverContext;
 	[self.controller.articleController reloadArrayOfArticles];
 	
 	// This action is send continuously by the filter field, so make sure not the mark read while searching
-    if (articleList.selectedRow < 0 && self.controller.articleController.allArticles.count > 0 )
-	{
+    if (articleList.selectedRow < 0 && self.controller.articleController.allArticles.count > 0 ) {
 		BOOL shouldSelectArticle = YES;
-		if ([Preferences standardPreferences].markReadInterval > 0.0f)
-		{
+		if ([Preferences standardPreferences].markReadInterval > 0.0f) {
 			Article * article = self.controller.articleController.allArticles[0u];
             if (!article.read) {
 				shouldSelectArticle = NO;
@@ -968,8 +950,7 @@ static void *ObserverContext = &ObserverContext;
 
     Article * currentSelectedArticle = self.selectedArticle;
 
-    switch (refreshFlag)
-    {
+    switch (refreshFlag) {
         case VNARefreshRedrawList:
             break;
         case VNARefreshReapplyFilter:
@@ -992,8 +973,7 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)startLoadIndicator
 {
-	if (progressIndicator == nil)
-	{
+	if (progressIndicator == nil) {
 		NSRect progressIndicatorFrame;
 		progressIndicatorFrame.size = NSMakeSize(articleList.visibleRect.size.width, PROGRESS_INDICATOR_DIMENSION);
 		progressIndicatorFrame.origin = articleList.visibleRect.origin;
@@ -1022,15 +1002,15 @@ static void *ObserverContext = &ObserverContext;
 	[self refreshArticlePane];
 	
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !theArticle.read)
-	{
+	if (theArticle != nil && !theArticle.read) {
 		CGFloat interval = [Preferences standardPreferences].markReadInterval;
-		if (interval > 0 && !isAppInitialising)
+		if (interval > 0 && !isAppInitialising) {
 			markReadTimer = [NSTimer scheduledTimerWithTimeInterval:(double)interval
 															 target:self
 														   selector:@selector(markCurrentRead:)
 														   userInfo:nil
 															repeats:NO];
+		}
 	}
 }
 
@@ -1040,13 +1020,10 @@ static void *ObserverContext = &ObserverContext;
 -(void)refreshArticleAtCurrentRow
 {
 	Article * article = self.selectedArticle;
-	if (article == nil)
-	{
+	if (article == nil) {
 		[articleText setArticles:@[]];
 		[self hideEnclosureView];
-	}
-	else
-	{
+	} else {
 		[self refreshImmediatelyArticleAtCurrentRow];
 		
 		// Add this to the backtrack list
@@ -1060,8 +1037,9 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)handleRefreshArticle:(NSNotification *)nc
 {
-	if (self == self.controller.articleController.mainArticleView && !isAppInitialising)
+	if (self == self.controller.articleController.mainArticleView && !isAppInitialising) {
 		[self refreshArticlePane];
+	}
 }
 
 /* handleArticleViewEnded
@@ -1081,8 +1059,7 @@ static void *ObserverContext = &ObserverContext;
 -(void)clearCurrentURL
 {
 	// If we already have an URL release it.
-	if (currentURL)
-	{
+	if (currentURL) {
 		currentURL = nil;
 	}
 }
@@ -1118,10 +1095,11 @@ static void *ObserverContext = &ObserverContext;
  */
 -(NSURL *)url
 {
-	if (self.isCurrentPageFullHTML)
+	if (self.isCurrentPageFullHTML) {
 		return currentURL;
-	else 
+	} else { 
 		return nil;
+	}
 }
 
 /* refreshArticlePane
@@ -1131,8 +1109,7 @@ static void *ObserverContext = &ObserverContext;
 {
 	NSArray * msgArray = self.markedArticleRange;
 	
-	if (msgArray.count == 0)
-	{
+	if (msgArray.count == 0) {
 		// Clear the current URL.
 		[self clearCurrentURL];
 
@@ -1141,13 +1118,10 @@ static void *ObserverContext = &ObserverContext;
 		
 		// Clear out the page.
 		[articleText setArticles:@[]];
-	}
-	else
-	{
+	} else {
 		Article * firstArticle = msgArray[0];
 		Folder * folder = [[Database sharedManager] folderFromID:firstArticle.folderId];
-		if (folder.loadsFullHTML && msgArray.count == 1)
-		{
+		if (folder.loadsFullHTML && msgArray.count == 1) {
 			if (!self.currentPageFullHTML) {
 			    // Clear out the text so the user knows something happened in response to the
 			    // click on the article.
@@ -1163,9 +1137,7 @@ static void *ObserverContext = &ObserverContext;
 			// queued up into the event loop, otherwise the WebView class won't draw the
 			// clearing of the HTML before this new link gets loaded.
 			[self performSelector: @selector(loadArticleLink:) withObject:firstArticle.link afterDelay:0.0];
-		}
-		else
-		{
+		} else {
 			// Clear the current URL.
 			[self clearCurrentURL];
 
@@ -1184,15 +1156,13 @@ static void *ObserverContext = &ObserverContext;
 	
 	// Show the enclosure view if just one article is selected and it has an
 	// enclosure.
-	if (msgArray.count != 1)
+	if (msgArray.count != 1) {
 		[self hideEnclosureView];
-	else
-	{
+	} else {
 		Article * oneArticle = msgArray[0];
-		if (!oneArticle.hasEnclosure)
+		if (!oneArticle.hasEnclosure) {
 			[self hideEnclosureView];
-		else
-		{
+		} else {
 			[self showEnclosureView];
 			[self.enclosureView setEnclosureFile:oneArticle.enclosure];
 		}
@@ -1205,8 +1175,7 @@ static void *ObserverContext = &ObserverContext;
 -(void)markCurrentRead:(NSTimer *)aTimer
 {
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !theArticle.read && ![Database sharedManager].readOnly)
-	{
+	if (theArticle != nil && !theArticle.read && ![Database sharedManager].readOnly) {
 		[self.controller.articleController markReadByArray:@[theArticle] readFlag:YES];
 	}
 }
@@ -1230,12 +1199,12 @@ static void *ObserverContext = &ObserverContext;
 	NSArray * allArticles = self.controller.articleController.allArticles;
 	Article * theArticle;
 	
-	if(rowIndex < 0 || rowIndex >= allArticles.count)
-	    return nil;
+	if(rowIndex < 0 || rowIndex >= allArticles.count) {
+		return nil;
+	}
 	theArticle = allArticles[rowIndex];
 	NSString * identifier = aTableColumn.identifier;
-	if ([identifier isEqualToString:MA_Field_Read])
-	{
+	if ([identifier isEqualToString:MA_Field_Read]) {
         if (!theArticle.read) {
             if (@available(macOS 11, *)) {
                 NSImage *image = nil;
@@ -1261,8 +1230,7 @@ static void *ObserverContext = &ObserverContext;
         }
         return nil;
 	}
-	if ([identifier isEqualToString:MA_Field_Flagged])
-	{
+	if ([identifier isEqualToString:MA_Field_Flagged]) {
         if (theArticle.flagged) {
             if (@available(macOS 11, *)) {
                 NSImage *image = [NSImage imageWithSystemSymbolName:@"flag.fill"
@@ -1276,8 +1244,7 @@ static void *ObserverContext = &ObserverContext;
         }
         return nil;
 	}
-	if ([identifier isEqualToString:MA_Field_Comments])
-	{
+	if ([identifier isEqualToString:MA_Field_Comments]) {
         if (theArticle.hasComments) {
             if (@available(macOS 11, *)) {
                 NSImage *image = [NSImage imageWithSystemSymbolName:@"ellipsis.bubble.fill"
@@ -1290,8 +1257,7 @@ static void *ObserverContext = &ObserverContext;
         return nil;
 	}
 	
-	if ([identifier isEqualToString:MA_Field_HasEnclosure])
-	{
+	if ([identifier isEqualToString:MA_Field_HasEnclosure]) {
         if (theArticle.hasEnclosure) {
             if (@available(macOS 11, *)) {
                 NSImage *image = [NSImage imageWithSystemSymbolName:@"paperclip"
@@ -1305,19 +1271,18 @@ static void *ObserverContext = &ObserverContext;
 	}
 	
 	NSMutableAttributedString * theAttributedString;
-	if ([identifier isEqualToString:MA_Field_Headlines])
-	{
+	if ([identifier isEqualToString:MA_Field_Headlines]) {
 		theAttributedString = [[NSMutableAttributedString alloc] initWithString:@""];
 		BOOL isSelectedRow = [aTableView isRowSelected:rowIndex] && (NSApp.mainWindow.firstResponder == aTableView);
 
-		if ([db fieldByName:MA_Field_Subject].visible)
-		{
+		if ([db fieldByName:MA_Field_Subject].visible) {
 			NSDictionary * topLineDictPtr;
 
-			if (theArticle.read)
+			if (theArticle.read) {
 				topLineDictPtr = (isSelectedRow ? selectionDict : topLineDict);
-			else
+			} else {
 				topLineDictPtr = (isSelectedRow ? unreadTopLineSelectionDict : unreadTopLineDict);
+			}
 			NSString * topString = [NSString stringWithFormat:@"%@", theArticle.title];
 			NSMutableAttributedString * topAttributedString = [[NSMutableAttributedString alloc] initWithString:topString attributes:topLineDictPtr];
 			[topAttributedString fixFontAttributeInRange:NSMakeRange(0u, topAttributedString.length)];
@@ -1325,8 +1290,7 @@ static void *ObserverContext = &ObserverContext;
 		}
 
 		// Add the summary line that appears below the title.
-		if ([db fieldByName:MA_Field_Summary].visible)
-		{
+		if ([db fieldByName:MA_Field_Summary].visible) {
 			NSString * summaryString = theArticle.summary;
 			NSInteger maxSummaryLength = MIN([summaryString length], 150);
 			NSString * middleString = [NSString stringWithFormat:@"\n%@", [summaryString substringToIndex:maxSummaryLength]];
@@ -1337,16 +1301,13 @@ static void *ObserverContext = &ObserverContext;
 		}
 		
 		// Add the link line that appears below the summary and title.
-		if ([db fieldByName:MA_Field_Link].visible)
-		{
+		if ([db fieldByName:MA_Field_Link].visible) {
 			NSString * articleLink = theArticle.link;
-			if (articleLink != nil)
-			{
+			if (articleLink != nil) {
 				NSString * linkString = [NSString stringWithFormat:@"\n%@", articleLink];
 				NSMutableDictionary * linkLineDictPtr = (isSelectedRow ? selectionDict : linkLineDict);
 				NSURL * articleURL = [NSURL URLWithString:articleLink];
-				if (articleURL != nil)
-				{
+				if (articleURL != nil) {
 					linkLineDictPtr = [linkLineDictPtr mutableCopy];
 					linkLineDictPtr[NSLinkAttributeName] = articleURL;
 				}
@@ -1361,24 +1322,23 @@ static void *ObserverContext = &ObserverContext;
 		NSMutableString * summaryString = [NSMutableString stringWithString:@""];
 		NSString * delimiter = @"";
 
-		if ([db fieldByName:MA_Field_Folder].visible)
-		{
+		if ([db fieldByName:MA_Field_Folder].visible) {
 			Folder * folder = [db folderFromID:theArticle.folderId];
 			[summaryString appendFormat:@"%@", folder.name];
 			delimiter = @" - ";
 		}
-		if ([db fieldByName:MA_Field_Date].visible)
-		{
+		if ([db fieldByName:MA_Field_Date].visible) {
 			[summaryString appendFormat:@"%@%@", delimiter, [NSDateFormatter vna_relativeDateStringFromDate:theArticle.date]];
 			delimiter = @" - ";
 		}
-		if ([db fieldByName:MA_Field_Author].visible)
-		{
-			if (!theArticle.author.vna_isBlank)
+		if ([db fieldByName:MA_Field_Author].visible) {
+			if (!theArticle.author.vna_isBlank) {
 				[summaryString appendFormat:@"%@%@", delimiter, theArticle.author];
+			}
 		}
-		if (![summaryString isEqualToString:@""])
+		if (![summaryString isEqualToString:@""]) {
 			summaryString = [NSMutableString stringWithFormat:@"\n%@", summaryString];
+		}
 
 		NSMutableAttributedString * summaryAttributedString = [[NSMutableAttributedString alloc] initWithString:summaryString attributes:bottomLineDictPtr];
 		[summaryAttributedString fixFontAttributeInRange:NSMakeRange(0u, summaryAttributedString.length)];
@@ -1387,37 +1347,22 @@ static void *ObserverContext = &ObserverContext;
 	}
 	
 	NSString * cellString;
-	if ([identifier isEqualToString:MA_Field_Date])
-	{
+	if ([identifier isEqualToString:MA_Field_Date]) {
         cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.date];
-	}
-	else if ([identifier isEqualToString:MA_Field_Folder])
-	{
+	} else if ([identifier isEqualToString:MA_Field_Folder]) {
 		Folder * folder = [db folderFromID:theArticle.folderId];
 		cellString = folder.name;
-	}
-	else if ([identifier isEqualToString:MA_Field_Author])
-	{
+	} else if ([identifier isEqualToString:MA_Field_Author]) {
 		cellString = theArticle.author;
-	}
-	else if ([identifier isEqualToString:MA_Field_Link])
-	{
+	} else if ([identifier isEqualToString:MA_Field_Link]) {
 		cellString = theArticle.link;
-	}
-	else if ([identifier isEqualToString:MA_Field_Subject])
-	{
+	} else if ([identifier isEqualToString:MA_Field_Subject]) {
 		cellString = theArticle.title;
-	}
-	else if ([identifier isEqualToString:MA_Field_Summary])
-	{
+	} else if ([identifier isEqualToString:MA_Field_Summary]) {
 		cellString = theArticle.summary;
-	}
-	else if ([identifier isEqualToString:MA_Field_Enclosure])
-	{
+	} else if ([identifier isEqualToString:MA_Field_Enclosure]) {
 		cellString = theArticle.enclosure;
-	}
-	else
-	{
+	} else {
 		cellString = @"";
 		[NSException raise:@"ArticleListView unknown table column identifier exception" format:@"Unknown table column identifier: %@", identifier];
 	}
@@ -1434,11 +1379,9 @@ static void *ObserverContext = &ObserverContext;
 -(void)tableView:(ExtendedTableView *)tableView menuWillAppear:(NSEvent *)theEvent
 {
 	NSInteger row = [articleList rowAtPoint:[articleList convertPoint:theEvent.locationInWindow fromView:nil]];
-	if (row >= 0)
-	{
+	if (row >= 0) {
 		// Select the row under the cursor if it isn't already selected
-		if (articleList.numberOfSelectedRows <= 1)
-		{
+		if (articleList.numberOfSelectedRows <= 1) {
 			blockSelectionHandler = YES; // to prevent expansion tooltip from overlapping the menu
 			if (row != articleList.selectedRow) {
 				[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
@@ -1458,8 +1401,7 @@ static void *ObserverContext = &ObserverContext;
 	[markReadTimer invalidate];
 	markReadTimer = nil;
 
-	if (!blockSelectionHandler)
-	{
+	if (!blockSelectionHandler) {
 		[self refreshArticleAtCurrentRow];
 	}
 }
@@ -1489,14 +1431,12 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)tableViewColumnDidResize:(NSNotification *)notification
 {
-	if (!isInTableInit && !isAppInitialising && !isChangingOrientation)
-	{
+	if (!isInTableInit && !isAppInitialising && !isChangingOrientation) {
 		NSTableColumn * tableColumn = notification.userInfo[@"NSTableColumn"];
 		Field * field = [[Database sharedManager] fieldByName:tableColumn.identifier];
 		NSInteger oldWidth = [notification.userInfo[@"NSOldWidth"] integerValue];
 		
-		if (oldWidth != tableColumn.width)
-		{
+		if (oldWidth != tableColumn.width) {
 			field.width = tableColumn.width;
 			[self saveTableSettings];
 		}
@@ -1522,24 +1462,24 @@ static void *ObserverContext = &ObserverContext;
 	BOOL isProgressColumn = NO;
 
 	// We need to use a different column for condensed layout vs. table layout.
-	if (tableLayout == VNALayoutReport && [columnIdentifer isEqualToString:MA_Field_Subject])
+	if (tableLayout == VNALayoutReport && [columnIdentifer isEqualToString:MA_Field_Subject]) {
 		isProgressColumn = YES;
-	else if (tableLayout == VNALayoutCondensed && [columnIdentifer isEqualToString:MA_Field_Headlines])
+	} else if (tableLayout == VNALayoutCondensed && [columnIdentifer isEqualToString:MA_Field_Headlines]) {
 		isProgressColumn = YES;
+	}
 	
-	if (isProgressColumn)
-	{
+	if (isProgressColumn) {
 		ProgressTextCell * realCell = (ProgressTextCell *)cell;
 		
 		// Set the in-progress flag as appropriate so the progress indicator gets
 		// displayed and removed as needed.
-		if ([realCell respondsToSelector:@selector(setInProgress:forRow:)])
-		{
-            if (rowIndex == tv.selectedRow && isLoadingHTMLArticle)
+		if ([realCell respondsToSelector:@selector(setInProgress:forRow:)]) {
+			if (rowIndex == tv.selectedRow && isLoadingHTMLArticle) {
 				[realCell setInProgress:YES forRow:rowIndex];
-			else
+			} else {
 				[realCell setInProgress:NO forRow:rowIndex];
-        }
+			}
+		}
 	}
 }
 
@@ -1571,8 +1511,7 @@ static void *ObserverContext = &ObserverContext;
 	
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
-	while (msgIndex != NSNotFound)
-	{
+	while (msgIndex != NSNotFound) {
 		Article * thisArticle = self.controller.articleController.allArticles[msgIndex];
 		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
@@ -1597,8 +1536,7 @@ static void *ObserverContext = &ObserverContext;
 		// Add HTML version too.
 		[fullHTMLText appendFormat:@"<a href=\"%@\">%@</a><br />%@<br /><br />", msgLink, msgTitle, msgText];
 		
-		if (count == 1)
-		{
+		if (count == 1) {
 			[pboard setString:msgLink forType:VNAPasteboardTypeURL];
 			[pboard setString:msgTitle forType:VNAPasteboardTypeURLName];
 			
@@ -1627,14 +1565,12 @@ static void *ObserverContext = &ObserverContext;
 -(NSArray *)markedArticleRange
 {
 	NSMutableArray * articleArray = nil;
-	if (articleList.numberOfSelectedRows > 0)
-	{
+	if (articleList.numberOfSelectedRows > 0) {
 		NSIndexSet * rowIndexes = articleList.selectedRowIndexes;
 		NSUInteger  rowIndex = rowIndexes.firstIndex;
 
 		articleArray = [NSMutableArray arrayWithCapacity:rowIndexes.count];
-		while (rowIndex != NSNotFound)
-		{
+		while (rowIndex != NSNotFound) {
 			[articleArray addObject:self.controller.articleController.allArticles[rowIndex]];
 			rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
 		}

--- a/Vienna/Sources/Main window/BackTrackArray.m
+++ b/Vienna/Sources/Main window/BackTrackArray.m
@@ -29,8 +29,7 @@
  */
 -(instancetype)initWithMaximum:(NSUInteger)theMax
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		maxItems = theMax;
 		queueIndex = -1;
 		array = [[NSMutableArray alloc] initWithCapacity:maxItems];
@@ -60,8 +59,7 @@
  */
 -(BOOL)previousItemAtQueue:(NSInteger *)folderId guidPointer:(NSString **)guidPointer
 {
-	if (queueIndex > 0)
-	{
+	if (queueIndex > 0) {
 		ArticleReference * item = array[--queueIndex];
 		*folderId = item.folderId;
 		*guidPointer = item.guid;
@@ -76,8 +74,7 @@
  */
 -(BOOL)nextItemAtQueue:(NSInteger *)folderId guidPointer:(NSString **)guidPointer
 {
-	if (queueIndex < (NSInteger)array.count - 1)
-	{
+	if (queueIndex < (NSInteger)array.count - 1) {
 		ArticleReference * item = array[++queueIndex];
 		*folderId = item.folderId;
 		*guidPointer = item.guid;
@@ -97,18 +94,18 @@
  */
 -(void)addToQueue:(NSInteger)folderId guid:(NSString *)guid
 {
-	while (queueIndex + 1 < (NSInteger)array.count)
+	while (queueIndex + 1 < (NSInteger)array.count) {
 		[array removeObjectAtIndex:queueIndex + 1];
-	if (array.count == maxItems)
-	{
+	}
+	if (array.count == maxItems) {
 		[array removeObjectAtIndex:0];
 		--queueIndex;
 	}
-	if (array.count > 0)
-	{
+	if (array.count > 0) {
 		ArticleReference * item = array[array.count - 1];
-		if ([item.guid isEqualToString:guid] && item.folderId == folderId)
+		if ([item.guid isEqualToString:guid] && item.folderId == folderId) {
 			return;
+		}
 	}
 	[array addObject:[ArticleReference makeReferenceFromGUID:guid inFolder:folderId]];
 	++queueIndex;

--- a/Vienna/Sources/Main window/EnclosureView.m
+++ b/Vienna/Sources/Main window/EnclosureView.m
@@ -40,8 +40,7 @@
  */
 -(instancetype)initWithFrame:(NSRect)frameRect
 {
-	if ((self = [super initWithFrame:frameRect]) != nil)
-	{
+	if ((self = [super initWithFrame:frameRect]) != nil) {
 		enclosureURLString = nil;
 
 		// Register to be notified when a download completes.
@@ -65,8 +64,9 @@
  */
 -(void)handleDownloadCompleted:(NSNotification *)notification
 {
-	if (enclosureURLString != nil)
+	if (enclosureURLString != nil) {
 		[self setEnclosureFile:enclosureURLString];
+	}
 }
 
 /* setEnclosureFile
@@ -81,23 +81,19 @@
     enclosureURLString = enclosureUrl.absoluteString;
 
 	NSString * basename = enclosureUrl.lastPathComponent;
-	if (basename==nil)
-	{
+	if (basename==nil) {
 		return;
 	}
 
 	// Find the file's likely location in Finder and see if it is already there.
 	// We'll set the options in the pane based on whether the file is there or not.
 	NSString * destPath = [DownloadManager fullDownloadPath:basename];
-	if (![DownloadManager isFileDownloaded:destPath])
-	{
+	if (![DownloadManager isFileDownloaded:destPath]) {
 		[downloadButton setTitle:NSLocalizedString(@"Download", nil)];
 		[downloadButton sizeToFit];
 		downloadButton.action = @selector(downloadFile:);
 		[filenameLabel setStringValue:NSLocalizedString(@"This article contains an enclosed file.", nil)];
-	}
-	else
-	{
+	} else {
 		NSString * appPath = [[NSWorkspace sharedWorkspace] vna_defaultHandlerApplicationForFile:destPath];
         NSString *displayName = [[[NSFileManager defaultManager] displayNameAtPath:appPath] stringByDeletingPathExtension];
         [downloadButton setTitle:[NSString stringWithFormat:NSLocalizedString(@"Open with %@", "Name the application which should open a file"), displayName]];

--- a/Vienna/Sources/Main window/FolderView.m
+++ b/Vienna/Sources/Main window/FolderView.m
@@ -89,8 +89,9 @@ static void *ObserverContext = &ObserverContext;
 {
     if (theEvent.characters.length == 1) {
         unichar keyChar = [theEvent.characters characterAtIndex:0];
-        if ([APPCONTROLLER handleKeyDown:keyChar withFlags:theEvent.modifierFlags])
+        if ([APPCONTROLLER handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
             return;
+        }
     }
     [super keyDown:theEvent];
 }

--- a/Vienna/Sources/Main window/FoldersFilterable.m
+++ b/Vienna/Sources/Main window/FoldersFilterable.m
@@ -12,8 +12,9 @@
 
 - (instancetype)initWithDataSource:(id <NSOutlineViewDataSource>)dataSource {
     self = [super init];
-    if (!self)
+    if (!self) {
         return nil;
+    }
 
     _dataSource = dataSource;
     return self;
@@ -93,8 +94,9 @@
 }
 
 - (NSInteger)outlineView:(NSOutlineView *)outlineView numberOfChildrenOfItem:(id)item {
-    if (_filterPredicate == nil)
+    if (_filterPredicate == nil) {
         return [_dataSource outlineView:outlineView numberOfChildrenOfItem:item];
+    }
 
     if (item == nil) {
         item = _root;
@@ -111,8 +113,9 @@
 }
 
 - (id)outlineView:(NSOutlineView *)outlineView child:(NSInteger)index ofItem:(id)item {
-    if (_filterPredicate == nil)
+    if (_filterPredicate == nil) {
         return [_dataSource outlineView:outlineView child:index ofItem:item];
+    }
 
     if (item == nil) {
         item = _root;
@@ -129,8 +132,9 @@
 }
 
 - (BOOL)outlineView:(NSOutlineView *)outlineView isItemExpandable:(id)item {
-    if (_filterPredicate == nil)
+    if (_filterPredicate == nil) {
         return [_dataSource outlineView:outlineView isItemExpandable:item];
+    }
 
     dispatch_group_wait(_loadGroup, DISPATCH_TIME_FOREVER);
 
@@ -163,8 +167,7 @@
                     [array removeObject:item];
                     dispatch_group_leave(parentGroup);
                 });
-            }
-            else {
+            } else {
                 dispatch_group_leave(parentGroup);
             }
 
@@ -184,8 +187,7 @@
                     dispatch_async(self->_queueMap, ^{
                         [childArray addObject:child];
                     });
-                }
-                else {
+                } else {
                     [childArray addObject:child];
                 }
 
@@ -197,15 +199,13 @@
                            generation:generation
                             predicate:predicate
                           parentGroup:childGroup];
-            }
-            else {
+            } else {
                 if ([predicate evaluateWithObject:child]) {
                     if (hasSpinned) {
                         dispatch_async(self->_queueMap, ^{
                             [childArray addObject:child];
                         });
-                    }
-                    else {
+                    } else {
                         [childArray addObject:child];
                     }
                 }
@@ -217,9 +217,9 @@
                 if (![predicate evaluateWithObject:item]) {
                     [array removeObject:item];
                 }
-            }
-            else
+            } else {
                 [table setObject:childArray forKey:item? item: self->_root];
+            }
 
             dispatch_group_leave(parentGroup);
         });
@@ -227,8 +227,9 @@
 }
 
 - (void)reloadData:(NSOutlineView*)outlineView {
-    if (_filterPredicate == nil)
+    if (_filterPredicate == nil) {
         return;
+    }
 
     _generation++;
 
@@ -275,12 +276,14 @@
 
 - (NSDictionary*)vna_scrollState {
     NSClipView* clipView = (NSClipView*)self.superview;
-    if (![clipView isKindOfClass:[NSClipView class]])
+    if (![clipView isKindOfClass:[NSClipView class]]) {
         return @{};
+    };
 
     NSScrollView* scrollView = (NSScrollView*)clipView.superview;
-    if (![scrollView isKindOfClass:[NSScrollView class]])
+    if (![scrollView isKindOfClass:[NSScrollView class]]) {
         return @{};
+    };
 
     return @{
              @"VisibleRect": [NSValue valueWithRect:scrollView.documentVisibleRect]
@@ -289,8 +292,9 @@
 
 - (void)vna_setScrollState:(NSDictionary*)state {
     NSValue* rectValue = state[@"VisibleRect"];
-    if (!rectValue)
+    if (!rectValue) {
         return;
+    }
 
     [self scrollPoint:rectValue.rectValue.origin];
 }
@@ -313,8 +317,9 @@
 
     for (id wanted in newSelection) {
         NSInteger index = [self rowForItem:wanted];
-        if (index < 0)
+        if (index < 0) {
             continue;
+        }
 
         [indexes addIndex:index];
     }

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -155,8 +155,7 @@ static void *ObserverContext = &ObserverContext;
 -(void)reloadDatabase:(NSArray *)stateArray
 {
 	[self.rootNode removeChildren];
-	if (![self loadTree:[[Database sharedManager] arrayOfFolders:VNAFolderTypeRoot] rootNode:self.rootNode])
-	{
+	if (![self loadTree:[[Database sharedManager] arrayOfFolders:VNAFolderTypeRoot] rootNode:self.rootNode]) {
 		[[Preferences standardPreferences] setFoldersTreeSortMethod:VNAFolderSortByName];
 		[self.rootNode removeChildren];
 		[self loadTree:[[Database sharedManager] arrayOfFolders:VNAFolderTypeRoot] rootNode:self.rootNode];
@@ -183,14 +182,12 @@ static void *ObserverContext = &ObserverContext;
 	NSInteger count = self.outlineView.numberOfRows;
 	NSInteger index;
 
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		TreeNode * node = (TreeNode *)[self.outlineView itemAtRow:index];
 		BOOL isItemExpanded = [self.outlineView isItemExpanded:node];
 		BOOL isItemSelected = [self.outlineView isRowSelected:index];
 
-		if (isItemExpanded || isItemSelected)
-		{
+		if (isItemExpanded || isItemSelected) {
 			NSDictionary * newDict = [NSMutableDictionary dictionary];
 			[newDict setValue:@(node.nodeId) forKey:@"NodeID"];
 			[newDict setValue:@(isItemExpanded) forKey:@"ExpandedState"];
@@ -207,21 +204,18 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)unarchiveState:(NSArray *)stateArray
 {
-	for (NSDictionary * dict in stateArray)
-	{
+	for (NSDictionary * dict in stateArray) {
 		NSInteger folderId = [[dict valueForKey:@"NodeID"] integerValue];
 		TreeNode * node = [self.rootNode nodeFromID:folderId];
-		if (node != nil)
-		{
+		if (node != nil) {
 			BOOL doExpandItem = [[dict valueForKey:@"ExpandedState"] boolValue];
 			BOOL doSelectItem = [[dict valueForKey:@"SelectedState"] boolValue];
-			if ([self.outlineView isExpandable:node] && doExpandItem)
+			if ([self.outlineView isExpandable:node] && doExpandItem) {
 				[self.outlineView expandItem:node];
-			if (doSelectItem)
-			{
+			}
+			if (doSelectItem) {
 				NSInteger row = [self.outlineView rowForItem:node];
-				if (row >= 0)
-				{
+				if (row >= 0) {
 					NSIndexSet * indexes = [NSIndexSet indexSetWithIndex:(NSUInteger)row];
 					[self.outlineView selectRowIndexes:indexes byExtendingSelection:YES];
 				}
@@ -237,31 +231,26 @@ static void *ObserverContext = &ObserverContext;
 -(BOOL)loadTree:(NSArray *)listOfFolders rootNode:(TreeNode *)node
 {
 	Folder * folder;
-	if ([Preferences standardPreferences].foldersTreeSortMethod != VNAFolderSortManual)
-	{
-		for (folder in listOfFolders)
-		{
+	if ([Preferences standardPreferences].foldersTreeSortMethod != VNAFolderSortManual) {
+		for (folder in listOfFolders) {
 			NSInteger itemId = folder.itemId;
 			NSArray * listOfSubFolders = [[[Database sharedManager] arrayOfFolders:itemId] sortedArrayUsingSelector:@selector(folderNameCompare:)];
 			NSInteger count = listOfSubFolders.count;
 			TreeNode * subNode;
 
 			subNode = [[TreeNode alloc] init:node atIndex:-1 folder:folder canHaveChildren:(count > 0)];
-			if (count)
+			if (count) {
 				[self loadTree:listOfSubFolders rootNode:subNode];
+			}
 
 		}
-	}
-	else
-	{
+	} else {
 		NSArray * listOfFolderIds = [listOfFolders valueForKey:@"itemId"];
 		NSUInteger index = 0;
 		NSInteger nextChildId = (node == self.rootNode) ? [Database sharedManager].firstFolderId : node.folder.firstChildId;
-		while (nextChildId > 0)
-		{
+		while (nextChildId > 0) {
 			NSUInteger  listIndex = [listOfFolderIds indexOfObject:@(nextChildId)];
-			if (listIndex == NSNotFound)
-			{
+			if (listIndex == NSNotFound) {
 				NSLog(@"Cannot find child with id %ld for folder with id %ld", (long)nextChildId, (long)node.nodeId);
 				return NO;
 			}
@@ -271,18 +260,15 @@ static void *ObserverContext = &ObserverContext;
 			TreeNode * subNode;
 			
 			subNode = [[TreeNode alloc] init:node atIndex:index folder:folder canHaveChildren:(count > 0)];
-			if (count)
-			{
-				if (![self loadTree:listOfSubFolders rootNode:subNode])
-				{
+			if (count) {
+				if (![self loadTree:listOfSubFolders rootNode:subNode]) {
 					return NO;
 				}
 			}
 			nextChildId = folder.nextSiblingId;
 			++index;
 		}
-		if (index < listOfFolders.count)
-		{
+		if (index < listOfFolders.count) {
 			NSLog(@"Missing children for folder with id %ld, %ld", (long)nextChildId, (long)node.nodeId);
 			return NO;
 		}
@@ -308,8 +294,7 @@ static void *ObserverContext = &ObserverContext;
 		[array addObject:node.folder];
     }
 	node = node.firstChild;
-	while (node != nil)
-	{
+	while (node != nil) {
 		[array addObjectsFromArray:[self folders:node.nodeId]];
 		node = node.nextSibling;
 	}
@@ -325,13 +310,13 @@ static void *ObserverContext = &ObserverContext;
 	NSMutableArray * array = [NSMutableArray array];
 	TreeNode * node;
 
-	if (!folderId)
+	if (!folderId) {
 		node = self.rootNode;
-	else
+	} else {
 		node = [self.rootNode nodeFromID:folderId];
+	}
 	node = node.firstChild;
-	while (node != nil)
-	{
+	while (node != nil) {
 		[array addObject:node.folder];
 		node = node.nextSibling;
 	}
@@ -345,16 +330,15 @@ static void *ObserverContext = &ObserverContext;
 -(void)updateAlternateMenuTitle
 {
 	NSMenuItem * mainMenuItem = menuItemWithAction(@selector(viewSourceHomePageInAlternateBrowser:));
-	if (mainMenuItem == nil)
+	if (mainMenuItem == nil) {
 		return;
+	}
 	NSString * menuTitle = mainMenuItem.title;
 	NSInteger index;
 	NSMenu * folderMenu = self.outlineView.menu;
-	if (folderMenu != nil)
-	{
+	if (folderMenu != nil) {
 		index = [folderMenu indexOfItemWithTarget:nil andAction:@selector(viewSourceHomePageInAlternateBrowser:)];
-		if (index >= 0)
-		{
+		if (index >= 0) {
 			NSMenuItem * contextualItem = [folderMenu itemAtIndex:index];
 			contextualItem.title = menuTitle;
 		}
@@ -368,13 +352,10 @@ static void *ObserverContext = &ObserverContext;
 -(void)updateFolder:(NSInteger)folderId recurseToParents:(BOOL)recurseToParents
 {
 	TreeNode * node = [self.rootNode nodeFromID:folderId];
-	if (node != nil)
-	{
+	if (node != nil) {
 		[self.outlineView reloadItem:node];
-		if (recurseToParents)
-		{
-			while (node.parentNode != self.rootNode)
-			{
+		if (recurseToParents) {
+			while (node.parentNode != self.rootNode) {
 				node = node.parentNode;
 				[self.outlineView reloadItem:node];
 			}
@@ -387,11 +368,9 @@ static void *ObserverContext = &ObserverContext;
  */
 -(BOOL)canDeleteFolderAtRow:(NSInteger)row
 {
-	if (row >= 0)
-	{
+	if (row >= 0) {
 		TreeNode * node = [self.outlineView itemAtRow:row];
-		if (node != nil)
-		{
+		if (node != nil) {
 			Folder * folder = [[Database sharedManager] folderFromID:node.nodeId];
 			return folder && folder.type != VNAFolderTypeSearch && folder.type != VNAFolderTypeTrash && ![Database sharedManager].readOnly && self.outlineView.window.visible;
 		}
@@ -406,14 +385,14 @@ static void *ObserverContext = &ObserverContext;
 -(BOOL)selectFolder:(NSInteger)folderId
 {
 	TreeNode * node = [self.rootNode nodeFromID:folderId];
-	if (!node)
+	if (!node) {
 		return NO;
+	}
 
 	// Walk up to our parent
 	[self expandToParent:node];
 	NSInteger rowIndex = [self.outlineView rowForItem:node];
-	if (rowIndex >= 0)
-	{
+	if (rowIndex >= 0) {
 		self.blockSelectionHandler = YES;
 		[self.outlineView selectRowIndexes:[NSIndexSet indexSetWithIndex:(NSUInteger)rowIndex] byExtendingSelection:NO];
 		[self.outlineView scrollRowToVisible:rowIndex];
@@ -431,8 +410,7 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)expandToParent:(TreeNode *)node
 {
-	if (node.parentNode)
-	{
+	if (node.parentNode) {
 		[self expandToParent:node.parentNode];
 		[self.outlineView expandItem:node.parentNode];
 	}
@@ -446,33 +424,35 @@ static void *ObserverContext = &ObserverContext;
 {
     // keep track of parent (or grandparent) of starting node
     TreeNode * parentOfStartingNode = startingNode;
-    while (parentOfStartingNode != nil && parentOfStartingNode.parentNode != self.rootNode)
-    {
+    while (parentOfStartingNode != nil && parentOfStartingNode.parentNode != self.rootNode) {
         parentOfStartingNode = parentOfStartingNode.parentNode;
     }
 	TreeNode * node = startingNode;
 
-	while (node != nil)
-	{
+	while (node != nil) {
 		TreeNode * nextNode = nil;
 		TreeNode * parentNode = node.parentNode;
-		if ((node.folder.childUnreadCount > 0) && [self.outlineView isItemExpanded:node])
+		if ((node.folder.childUnreadCount > 0) && [self.outlineView isItemExpanded:node]) {
 			nextNode = node.firstChild;
-		if (nextNode == nil)
+		}
+		if (nextNode == nil) {
 			nextNode = node.nextSibling;
-		while (nextNode == nil && parentNode != nil)
-		{
+		}
+		while (nextNode == nil && parentNode != nil) {
 			nextNode = parentNode.nextSibling;
 			parentNode = parentNode.parentNode;
 		}
-		if (nextNode == nil)
+		if (nextNode == nil) {
 			nextNode = self.rootNode.firstChild;
+		}
 
-		if ((nextNode.folder.childUnreadCount) && ![self.outlineView isItemExpanded:nextNode])
+		if ((nextNode.folder.childUnreadCount) && ![self.outlineView isItemExpanded:nextNode]) {
 			return nextNode.nodeId;
+		}
 		
-		if (nextNode.folder.unreadCount)
+		if (nextNode.folder.unreadCount) {
 			return nextNode.nodeId;
+		}
 
 		// If we've gone full circle and not found
 		// anything, we're out of unread articles
@@ -607,20 +587,16 @@ static void *ObserverContext = &ObserverContext;
     Database *dbManager = [Database sharedManager];
 	
 	NSInteger count = node.countOfChildren;
-	if (count > 0)
-	{
-		
+	if (count > 0) {
         [dbManager setFirstChild:[node childByIndex:0].nodeId forFolder:folderId];
 		[self setManualSortOrderForNode:[node childByIndex:0]];
 		NSInteger index;
-		for (index = 1; index < count; ++index)
-		{
+		for (index = 1; index < count; ++index) {
 			[dbManager setNextSibling:[node childByIndex:index].nodeId forFolder:[node childByIndex:index - 1].nodeId];
 			[self setManualSortOrderForNode:[node childByIndex:index]];
 		}
 		[dbManager setNextSibling:0 forFolder:[node childByIndex:index - 1].nodeId];
-	}
-    else {
+	} else {
 		[dbManager setFirstChild:0 forFolder:folderId];
     }
 }
@@ -632,8 +608,7 @@ static void *ObserverContext = &ObserverContext;
 {
 	NSInteger selectedFolderId = self.actualSelection;
 	
-	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual)
-	{
+	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual) {
         [self setManualSortOrderForNode:self.rootNode];
 	}
 	
@@ -660,14 +635,12 @@ static void *ObserverContext = &ObserverContext;
 {
     TreeNode * node = [self.outlineView itemAtRow:self.outlineView.selectedRow];
 
-	if (node.folder.type == VNAFolderTypeRSS || node.folder.type == VNAFolderTypeOpenReader)
-	{
+	if (node.folder.type == VNAFolderTypeRSS || node.folder.type == VNAFolderTypeOpenReader) {
 		NSString * urlString = node.folder.homePage;
         if (urlString && !urlString.vna_isBlank) {
 			[APPCONTROLLER openURLFromString:urlString inPreferredBrowser:YES];
         }
-	}
-	else if (node.folder.type == VNAFolderTypeSmart) {
+	} else if (node.folder.type == VNAFolderTypeSmart) {
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_EditFolder" object:node];
 	}
 }
@@ -685,13 +658,13 @@ static void *ObserverContext = &ObserverContext;
 	TreeNode * nextNode;
 
 	// First find the next node we'll select
-	if (thisNode.nextSibling != nil)
+	if (thisNode.nextSibling != nil) {
 		nextNode = thisNode.nextSibling;
-	else
-	{
+	} else {
 		nextNode = thisNode.parentNode;
-		if (nextNode.countOfChildren > 1)
+		if (nextNode.countOfChildren > 1) {
 			nextNode = [nextNode childByIndex:nextNode.countOfChildren - 2];
+		}
 	}
 
 	// Ask our parent to delete us
@@ -702,8 +675,7 @@ static void *ObserverContext = &ObserverContext;
 	// Send the selection notification ourselves because if we're deleting at the end of
 	// the folder list, the selection won't actually change and outlineViewSelectionDidChange
 	// won't get tripped.
-	if (currentFolderId == folderId)
-	{
+	if (currentFolderId == folderId) {
 		self.blockSelectionHandler = YES;
 		[self selectFolder:nextNode.nodeId];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_FolderSelectionChange" object:nextNode];
@@ -723,15 +695,14 @@ static void *ObserverContext = &ObserverContext;
 
 	BOOL moveSelection = (folderId == self.actualSelection);
 
-	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortByName)
+	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortByName) {
 		[parentNode sortChildren:VNAFolderSortByName];
+	}
 
 	[self reloadFolderItem:parentNode reloadChildren:YES];
-	if (moveSelection)
-	{
+	if (moveSelection) {
 		NSInteger row = [self.outlineView rowForItem:node];
-		if (row >= 0)
-		{
+		if (row >= 0) {
 			self.blockSelectionHandler = YES;
 			NSIndexSet * indexes = [NSIndexSet indexSetWithIndex:(NSUInteger)row];
 			[self.outlineView selectRowIndexes:indexes byExtendingSelection:NO];
@@ -748,10 +719,11 @@ static void *ObserverContext = &ObserverContext;
 -(void)handleFolderUpdate:(NSNotification *)nc
 {
 	NSInteger folderId = ((NSNumber *)nc.object).integerValue;
-	if (folderId == 0)
+	if (folderId == 0) {
 		[self reloadFolderItem:self.rootNode reloadChildren:YES];
-	else
+	} else {
 		[self updateFolder:folderId recurseToParents:YES];
+	}
 }
 
 /* handleFolderAdded
@@ -764,18 +736,18 @@ static void *ObserverContext = &ObserverContext;
 
 	NSInteger parentId = newFolder.parentId;
 	TreeNode * node = (parentId == VNAFolderTypeRoot) ? self.rootNode : [self.rootNode nodeFromID:parentId];
-	if (!node.canHaveChildren)
+	if (!node.canHaveChildren) {
 		[node setCanHaveChildren:YES];
+	}
 	
 	NSInteger childIndex = -1;
-	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual)
-	{
+	if ([Preferences standardPreferences].foldersTreeSortMethod == VNAFolderSortManual) {
 		NSInteger nextSiblingId = newFolder.nextSiblingId;
-		if (nextSiblingId > 0)
-		{
+		if (nextSiblingId > 0) {
 			TreeNode * nextSibling = [node nodeFromID:nextSiblingId];
-			if (nextSibling != nil)
+			if (nextSibling != nil) {
 				childIndex = [node indexOfChild:nextSibling];
+			}
 		}
 	}
 	
@@ -789,9 +761,9 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)reloadFolderItem:(id)node reloadChildren:(BOOL)flag
 {
-	if (node == self.rootNode)
-		[self.outlineView reloadData];
-    else {
+    if (node == self.rootNode) {
+        [self.outlineView reloadData];
+    } else {
         [self.outlineView reloadItem:node reloadChildren:flag];
     }
 }
@@ -812,8 +784,7 @@ static void *ObserverContext = &ObserverContext;
 	TreeNode * node = [self.rootNode nodeFromID:folderId];
 	NSInteger rowIndex = [self.outlineView rowForItem:node];
 		
-	if (rowIndex != -1)
-	{
+	if (rowIndex != -1) {
         if (self.fieldEditor && self.fieldEditor.delegate) {
             NSTextField *textField = (NSTextField *)self.fieldEditor.delegate;
             [textField abortEditing];
@@ -856,8 +827,7 @@ static void *ObserverContext = &ObserverContext;
 
 	// Create an array of NSNumber objects containing the selected folder IDs.
 	NSInteger countOfItems = 0;
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		TreeNode * node = items[index];
 		Folder * folder = node.folder;
 
@@ -885,10 +855,8 @@ static void *ObserverContext = &ObserverContext;
 			[stringDragData appendFormat:@"%@\n", feedURL];
 			
 			NSURL * safariURL = [NSURL URLWithString:feedURL];
-			if (safariURL != nil && !safariURL.fileURL)
-			{
-				if (![@"feed" isEqualToString:safariURL.scheme])
-				{
+			if (safariURL != nil && !safariURL.fileURL) {
+				if (![@"feed" isEqualToString:safariURL.scheme]) {
 					feedURL = [NSString stringWithFormat:@"feed:%@", safariURL.resourceSpecifier];
 				}
 				[arrayOfURLs addObject:feedURL];
@@ -934,8 +902,7 @@ static void *ObserverContext = &ObserverContext;
 	Database * dbManager = [Database sharedManager];
 	BOOL autoSort = [Preferences standardPreferences].foldersTreeSortMethod != VNAFolderSortManual;
 
-	while (index < count)
-	{
+	while (index < count) {
 		NSInteger folderId = [array[index++] integerValue];
 		NSInteger newParentId = [array[index++] integerValue];
 		NSInteger newPredecessorId = [array[index++] integerValue];
@@ -948,12 +915,12 @@ static void *ObserverContext = &ObserverContext;
 		NSInteger oldPredecessorId = (oldChildIndex > 0) ? [oldParent childByIndex:(oldChildIndex - 1)].nodeId : 0;
 		TreeNode * newParent = [self.rootNode nodeFromID:newParentId];
 		TreeNode * newPredecessor = [newParent nodeFromID:newPredecessorId];
-		if ((newPredecessor == nil) || (newPredecessor == newParent))
+		if ((newPredecessor == nil) || (newPredecessor == newParent)) {
 			newPredecessorId = 0;
+		}
 		NSInteger newChildIndex = (newPredecessorId > 0) ? ([newParent indexOfChild:newPredecessor] + 1) : 0;
         
-		if (newParentId == oldParentId)
-		{
+		if (newParentId == oldParentId) {
 			// With automatic sorting, moving under the same parent is impossible.
             if (autoSort) {
 				continue;
@@ -967,15 +934,12 @@ static void *ObserverContext = &ObserverContext;
                 --newChildIndex;
             }
 				
-		}
-		else
-		{
-			if (!newParent.canHaveChildren)
+		} else {
+			if (!newParent.canHaveChildren) {
 				[newParent setCanHaveChildren:YES];
-			if ([dbManager setParent:newParentId forFolder:folderId])
-			{
-				if (sync && folder.type == VNAFolderTypeOpenReader)
-				{
+			}
+			if ([dbManager setParent:newParentId forFolder:folderId]) {
+				if (sync && folder.type == VNAFolderTypeOpenReader) {
 					OpenReader * myReader = [OpenReader sharedManager];
 					// remove old label
 					NSString * folderName = [dbManager folderFromID:oldParentId].name;
@@ -986,22 +950,20 @@ static void *ObserverContext = &ObserverContext;
 					    [myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
 					}
 				}
-			}
-			else
+			} else {
 				continue;
+			}
 		}
 		
-		if (!autoSort)
-		{
-			if (oldPredecessorId > 0)
-			{
-				if (![dbManager setNextSibling:folder.nextSiblingId forFolder:oldPredecessorId])
+		if (!autoSort) {
+			if (oldPredecessorId > 0) {
+				if (![dbManager setNextSibling:folder.nextSiblingId forFolder:oldPredecessorId]) {
 					continue;
-			}
-			else
-			{
-				if (![dbManager setFirstChild:folder.nextSiblingId forFolder:oldParentId])
+				}
+			} else {
+				if (![dbManager setFirstChild:folder.nextSiblingId forFolder:oldParentId]) {
 					continue;
+				}
 			}
 		}
 		
@@ -1013,29 +975,25 @@ static void *ObserverContext = &ObserverContext;
 		[undoArray insertObject:@(oldParentId) atIndex:1u];
 		[undoArray insertObject:@(oldPredecessorId) atIndex:2u];
 		
-		if (!autoSort)
-		{
-			if (newPredecessorId > 0)
-			{
+		if (!autoSort) {
+			if (newPredecessorId > 0) {
 				if (![dbManager setNextSibling:[dbManager folderFromID:newPredecessorId].nextSiblingId
                                      forFolder:folderId]) {
 					continue;
                 }
 				[dbManager setNextSibling:folderId forFolder:newPredecessorId];
-			}
-			else
-			{
+			} else {
 				NSInteger oldFirstChildId = (newParent == self.rootNode) ? dbManager.firstFolderId : newParent.folder.firstChildId;
-				if (![dbManager setNextSibling:oldFirstChildId forFolder:folderId])
+				if (![dbManager setNextSibling:oldFirstChildId forFolder:folderId]) {
 					continue;
+				}
 				[dbManager setFirstChild:folderId forFolder:newParentId];
 			}
 		}
 	}
 	
 	// If undo array is empty, then nothing has been moved.
-	if (undoArray.count == 0u)
-	{
+	if (undoArray.count == 0u) {
 		return NO;
 	}
 	
@@ -1048,14 +1006,13 @@ static void *ObserverContext = &ObserverContext;
 	[self.outlineView reloadData];
 
 	// If any parent was a collapsed group, expand it now
-	for (index = 0; index < count; index += 2)
-	{
+	for (index = 0; index < count; index += 2) {
 		NSInteger newParentId = [array[++index] integerValue];
-		if (newParentId != VNAFolderTypeRoot)
-		{
+		if (newParentId != VNAFolderTypeRoot) {
 			TreeNode * parentNode = [self.rootNode nodeFromID:newParentId];
-			if (![self.outlineView isItemExpanded:parentNode] && [self.outlineView isExpandable:parentNode])
+			if (![self.outlineView isItemExpanded:parentNode] && [self.outlineView isExpandable:parentNode]) {
 				[self.outlineView expandItem:parentNode];
+			}
 		}
 	}
 	
@@ -1063,8 +1020,7 @@ static void *ObserverContext = &ObserverContext;
 	// refresh so that rowForItem returns the new positions.
 	NSMutableIndexSet * selIndexSet = [[NSMutableIndexSet alloc] init];
 	NSInteger selRowIndex = 9999;
-	for (index = 0; index < count; index += 2)
-	{
+	for (index = 0; index < count; index += 2) {
 		NSInteger folderId = [array[index++] integerValue];
 		NSInteger rowIndex = [self.outlineView rowForItem:[self.rootNode nodeFromID:folderId]];
 		selRowIndex = MIN(selRowIndex, rowIndex);
@@ -1154,8 +1110,9 @@ static void *ObserverContext = &ObserverContext;
 -(BOOL)outlineView:(NSOutlineView *)outlineView isItemExpandable:(id)item
 {
     TreeNode * node = (TreeNode *)item;
-    if (node == nil)
+    if (node == nil) {
         node = self.rootNode;
+    }
     return node.canHaveChildren && node.countOfChildren > 0;
 }
 
@@ -1518,8 +1475,7 @@ static void *ObserverContext = &ObserverContext;
  */
 -(void)outlineViewSelectionDidChange:(NSNotification *)notification
 {
-    if (!self.blockSelectionHandler)
-    {
+    if (!self.blockSelectionHandler) {
         TreeNode * node = [self.outlineView itemAtRow:self.outlineView.selectedRow];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_FolderSelectionChange" object:node];
     }

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -31,11 +31,11 @@
  */
 -(void)keyDown:(NSEvent *)theEvent
 {
-	if (theEvent.characters.length == 1)
-	{
+	if (theEvent.characters.length == 1) {
 		unichar keyChar = [theEvent.characters characterAtIndex:0];
-		if ([APPCONTROLLER handleKeyDown:keyChar withFlags:theEvent.modifierFlags])
+		if ([APPCONTROLLER handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
 			return;
+		}
 	}
 	[super keyDown:theEvent];
 }
@@ -45,8 +45,7 @@
  */
 -(IBAction)copy:(id)sender
 {
-	if (self.selectedRow >= 0)
-	{
+	if (self.selectedRow >= 0) {
 		NSIndexSet * selectedRowIndexes = self.selectedRowIndexes;
 		[self.delegate copyTableSelection:selectedRowIndexes toPasteboard:NSPasteboard.generalPasteboard];
 	}
@@ -66,16 +65,13 @@
  */
 -(BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
-	if (menuItem.action == @selector(copy:))
-	{
+	if (menuItem.action == @selector(copy:)) {
 		return self.selectedRow >= 0;
 	}
-	if (menuItem.action == @selector(delete:))
-	{
+	if (menuItem.action == @selector(delete:)) {
         return [self.delegate canDeleteMessageAtRow:self.selectedRow];
 	}
-	if (menuItem.action == @selector(selectAll:))
-	{
+	if (menuItem.action == @selector(selectAll:)) {
 		return YES;
 	}
 	return NO;

--- a/Vienna/Sources/Main window/ProgressTextCell.m
+++ b/Vienna/Sources/Main window/ProgressTextCell.m
@@ -38,8 +38,7 @@
  */
 -(instancetype)init
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		inProgress = NO;
 		progressRow = NO_ROW;
 		currentRow = NO_ROW;
@@ -68,8 +67,9 @@
 -(void)setInProgress:(BOOL)newInProgress forRow:(NSInteger)row
 {
 	inProgress = newInProgress;
-	if (inProgress)
+	if (inProgress) {
 		progressRow = row;
+	}
 	currentRow = row;
 }
 
@@ -80,14 +80,11 @@
 - (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
 	// If this row is the current progress row.
-	if (currentRow == progressRow)
-	{
+	if (currentRow == progressRow) {
 		// If the cell has a progress indicator, ensure it's framed properly
 		// and then reduce cellFrame to keep from overlapping it.
-		if (inProgress)
-		{
-			if (!progressIndicator)
-			{
+		if (inProgress) {
+			if (!progressIndicator) {
 				// Compute the progress indicator frame on the right side of the cell frame
 				NSRect progressIndicatorFrame;
 				NSInteger cellHeight = cellFrame.size.height;
@@ -104,9 +101,7 @@
 				progressIndicator.usesThreadedAnimation = YES;
 				[controlView addSubview:progressIndicator];
 			}
-		}
-		else
-		{
+		} else {
 			// Stop the animation and remove from the superview.
 			[progressIndicator stopAnimation:self];
 			[progressIndicator.superview setNeedsDisplayInRect:progressIndicator.frame];

--- a/Vienna/Sources/Main window/TreeNode.m
+++ b/Vienna/Sources/Main window/TreeNode.m
@@ -31,15 +31,13 @@
  */
 -(instancetype)init:(TreeNode *)parent atIndex:(NSInteger)insertIndex folder:(Folder *)theFolder canHaveChildren:(BOOL)childflag
 {
-	if ((self = [super init]) != nil)
- 	{
+	if ((self = [super init]) != nil) {
 		NSInteger folderId = (theFolder ? theFolder.itemId : VNAFolderTypeRoot);
 		folder = theFolder;
 		parentNode = parent;
 		canHaveChildren = childflag;
 		nodeId = folderId;
-		if (parent != nil)
-		{
+		if (parent != nil) {
 			[parent addChild:self atIndex:insertIndex];
 		}
 		children = [NSMutableArray array];
@@ -64,27 +62,23 @@
 	NSUInteger count = children.count;
 	NSInteger sortMethod = [Preferences standardPreferences].foldersTreeSortMethod;
 
-	if (sortMethod != VNAFolderSortManual)
-	{
+	if (sortMethod != VNAFolderSortManual) {
 		insertIndex = 0;
 
-		while (insertIndex < count)
-		{
+		while (insertIndex < count) {
 			TreeNode * theChild = children[insertIndex];
-			if (sortMethod == VNAFolderSortByName)
-			{
-				if ([child folderNameCompare:theChild] == NSOrderedAscending)
+			if (sortMethod == VNAFolderSortByName) {
+				if ([child folderNameCompare:theChild] == NSOrderedAscending) {
 					break;
-			}
-			else
-			{
+				}
+			} else {
 				NSAssert1(TRUE, @"Unsupported folder sort method in addChild: %ld", (long)sortMethod);
 			}
 			++insertIndex;
 		}
-	}
-	else if ((insertIndex < 0) || (insertIndex > count))
+	} else if ((insertIndex < 0) || (insertIndex > count)) {
 		insertIndex = count;
+	}
 	
 	child.parentNode = self;
 	[children insertObject:child atIndex:insertIndex];
@@ -96,8 +90,9 @@
  */
 -(void)removeChild:(TreeNode *)child andChildren:(BOOL)removeChildrenFlag
 {
-	if (removeChildrenFlag)
+	if (removeChildrenFlag) {
 		[child removeChildren];
+	}
 	[children removeObject:child];
 }
 
@@ -106,8 +101,7 @@
  */
 -(void)sortChildren:(NSInteger)sortMethod
 {
-	switch (sortMethod)
-	{
+	switch (sortMethod) {
 	case VNAFolderSortManual:
 		// Do nothing
 		break;
@@ -153,15 +147,16 @@
  */
 -(TreeNode *)nodeFromID:(NSInteger)n
 {
-	if (self.nodeId == n)
+	if (self.nodeId == n) {
 		return self;
+	}
 	
 	TreeNode * theNode;
 	
-	for (TreeNode * node in children)
-	{
-		if ((theNode = [node nodeFromID:n]) != nil)
+	for (TreeNode * node in children) {
+		if ((theNode = [node nodeFromID:n]) != nil) {
 			return theNode;
+		}
 	}
 	return nil;
 }
@@ -171,10 +166,10 @@
  */
 -(TreeNode *)childByName:(NSString *)childName
 {
-	for (TreeNode * node in children)
-	{
-		if ([childName isEqual:node.nodeName])
+	for (TreeNode * node in children) {
+		if ([childName isEqual:node.nodeName]) {
 			return node;
+		}
 	}
 	return nil;
 }
@@ -218,8 +213,9 @@
 -(TreeNode *)nextSibling
 {
 	NSInteger childIndex = [parentNode indexOfChild:self];
-	if (childIndex == NSNotFound || ++childIndex >= parentNode.countOfChildren)
+	if (childIndex == NSNotFound || ++childIndex >= parentNode.countOfChildren) {
 		return nil;
+	}
 	return [parentNode childByIndex:childIndex];
 }
 
@@ -228,8 +224,9 @@
  */
 -(TreeNode *)firstChild
 {
-	if (children.count == 0)
+	if (children.count == 0) {
 		return nil;
+	}
 	return children[0];
 }
 

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -64,8 +64,7 @@
 -(instancetype)initWithFrame:(NSRect)frame
 {
     self= [super initWithFrame:frame];
-    if (self)
-	{
+    if (self) {
 		markReadTimer = nil;
 		rowHeightArray = [[NSMutableArray alloc] init];
     }
@@ -198,13 +197,10 @@
  */
 -(void)scrollToArticle:(NSString *)guid
 {
-	if (guid != nil)
-	{
+	if (guid != nil) {
 		NSInteger rowIndex = 0;
-		for (Article * thisArticle in self.controller.articleController.allArticles)
-		{
-			if ([thisArticle.guid isEqualToString:guid])
-			{
+		for (Article * thisArticle in self.controller.articleController.allArticles) {
+			if ([thisArticle.guid isEqualToString:guid]) {
 				[self makeRowSelectedAndVisible:rowIndex];
 				return;
 			}
@@ -234,17 +230,17 @@
 	[self.controller.articleController reloadArrayOfArticles];
 
 	// make sure to not change the mark read while searching
-    if (articleList.selectedRow < 0 && self.controller.articleController.allArticles.count > 0 )
-	{
+    if (articleList.selectedRow < 0 && self.controller.articleController.allArticles.count > 0 ) {
 		BOOL shouldSelectArticle = YES;
-		if ([Preferences standardPreferences].markReadInterval > 0.0f)
-		{
+		if ([Preferences standardPreferences].markReadInterval > 0.0f) {
 			Article * article = self.controller.articleController.allArticles[0u];
-			if (!article.read)
+			if (!article.read) {
 				shouldSelectArticle = NO;
+			}
 		}
-		if (shouldSelectArticle)
+		if (shouldSelectArticle) {
 			[self makeRowSelectedAndVisible:0];
+		}
 	}
 }
 
@@ -331,8 +327,7 @@
  */
 -(void)handleReadingPaneChange:(NSNotificationCenter *)nc
 {
-	if (self == self.controller.articleController.mainArticleView)
-	{
+	if (self == self.controller.articleController.mainArticleView) {
 		[articleList reloadData];
 	}
 }
@@ -343,12 +338,9 @@
  */
 -(void)makeRowSelectedAndVisible:(NSInteger)rowIndex
 {
-	if (self.controller.articleController.allArticles.count == 0u)
-	{
+	if (self.controller.articleController.allArticles.count == 0u) {
 		[articleList deselectAll:self];
-	}
-	else
-	{
+	} else {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
 		[articleList scrollRowToVisible:rowIndex];
 	}
@@ -369,17 +361,16 @@
  */
 -(BOOL)viewNextUnreadInCurrentFolder:(NSInteger)currentRow
 {
-	if (currentRow < 0)
+	if (currentRow < 0) {
 		currentRow = 0;
+	}
 
 	NSArray * allArticles = self.controller.articleController.allArticles;
 	NSInteger totalRows = allArticles.count;
 	Article * theArticle;
-	while (currentRow < totalRows)
-	{
+	while (currentRow < totalRows) {
 		theArticle = allArticles[currentRow];
-		if (!theArticle.read)
-		{
+		if (!theArticle.read) {
 			[self makeRowSelectedAndVisible:currentRow];
 			return YES;
 		}
@@ -395,11 +386,11 @@
 -(BOOL)selectFirstUnreadInFolder
 {
 	BOOL result = [self viewNextUnreadInCurrentFolder:-1];
-	if (!result)
-	{
+	if (!result) {
 		NSInteger count = self.controller.articleController.allArticles.count;
-		if (count > 0)
+		if (count > 0) {
 			[self makeRowSelectedAndVisible:0];
+		}
 	}
 	return result;
 }
@@ -456,8 +447,7 @@
 {
     Article * currentSelectedArticle = self.selectedArticle;
 
-    switch (refreshFlag)
-    {
+    switch (refreshFlag) {
         case VNARefreshRedrawList:
             break;
         case VNARefreshReapplyFilter:
@@ -478,8 +468,7 @@
  */
 -(void)startLoadIndicator
 {
-	if (progressIndicator == nil)
-	{
+	if (progressIndicator == nil) {
 		NSRect progressIndicatorFrame;
 		progressIndicatorFrame.size = NSMakeSize(articleList.visibleRect.size.width, PROGRESS_INDICATOR_DIMENSION);
 		progressIndicatorFrame.origin = articleList.visibleRect.origin;
@@ -506,8 +495,7 @@
 -(void)markCurrentRead:(NSTimer *)aTimer
 {
 	Article * theArticle = self.selectedArticle;
-	if (theArticle != nil && !theArticle.read && ![Database sharedManager].readOnly)
-	{
+	if (theArticle != nil && !theArticle.read && ![Database sharedManager].readOnly) {
 		[self.controller.articleController markReadByArray:@[theArticle] readFlag:YES];
 	}
 }
@@ -526,16 +514,13 @@
 
 - (CGFloat)tableView:(NSTableView *)aListView heightOfRow:(NSInteger)row
 {
-	if (row >= rowHeightArray.count)
-	{
+	if (row >= rowHeightArray.count) {
 		NSInteger toAdd = row - rowHeightArray.count + 1 ;
 		for (NSInteger i = 0 ; i < toAdd ; i++) {
 			[rowHeightArray addObject:@(0)];
 		}
 		return (CGFloat)DEFAULT_CELL_HEIGHT;
-	}
-	else
-	{
+	} else {
 		id object= rowHeightArray[row];
         CGFloat height = [object doubleValue];
         if (height > 0) {
@@ -551,13 +536,13 @@
  */
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
 {
-	if (![tableView isEqualTo:articleList])
+	if (![tableView isEqualTo:articleList]) {
 		return nil;
+	}
 
 	ArticleCellView *cellView = (ArticleCellView*)[tableView makeViewWithIdentifier:LISTVIEW_CELL_IDENTIFIER owner:self];
 
-	if (cellView == nil)
-	{
+	if (cellView == nil) {
 		cellView = [[ArticleCellView alloc] initWithFrame:NSMakeRect(
 		        XPOS_IN_CELL, YPOS_IN_CELL, tableView.bounds.size.width - XPOS_IN_CELL, DEFAULT_CELL_HEIGHT)];
 		cellView.identifier = LISTVIEW_CELL_IDENTIFIER;
@@ -568,8 +553,9 @@
 	}
 
 	NSArray * allArticles = self.controller.articleController.allArticles;
-	if (row < 0 || row >= allArticles.count)
+	if (row < 0 || row >= allArticles.count) {
 	    return nil;
+	}
 
 	Article * theArticle = allArticles[row];
 	NSInteger articleFolderId = theArticle.folderId;
@@ -596,11 +582,9 @@
 -(void)tableView:(ExtendedTableView *)tableView menuWillAppear:(NSEvent *)theEvent
 {
 	NSInteger row = [articleList rowAtPoint:[articleList convertPoint:theEvent.locationInWindow fromView:nil]];
-	if (row >= 0)
-	{
+	if (row >= 0) {
 		// Select the row under the cursor if it isn't already selected
-		if (articleList.numberOfSelectedRows <= 1)
-		{
+		if (articleList.numberOfSelectedRows <= 1) {
 			[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
 		}
 	}
@@ -652,8 +636,7 @@
 
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
-	while (msgIndex != NSNotFound)
-	{
+	while (msgIndex != NSNotFound) {
 		Article * thisArticle = self.controller.articleController.allArticles[msgIndex];
 		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
@@ -678,8 +661,7 @@
 		// Add HTML version too.
 		[fullHTMLText appendFormat:@"<a href=\"%@\">%@</a><br />%@<br /><br />", msgLink, msgTitle, msgText];
 
-		if (count == 1)
-		{
+		if (count == 1) {
 			[pboard setString:msgLink forType:VNAPasteboardTypeURL];
 			[pboard setString:msgTitle forType:VNAPasteboardTypeURLName];
 
@@ -734,16 +716,13 @@
  */
 -(BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
-	if (menuItem.action == @selector(copy:))
-	{
+	if (menuItem.action == @selector(copy:)) {
 		return (articleList.numberOfSelectedRows > 0);
 	}
-	if (menuItem.action == @selector(delete:))
-	{
+	if (menuItem.action == @selector(delete:)) {
         return [self canDeleteMessageAtRow:articleList.selectedRow];
 	}
-	if (menuItem.action == @selector(selectAll:))
-	{
+	if (menuItem.action == @selector(selectAll:)) {
 		return YES;
 	}
 	return NO;
@@ -755,14 +734,12 @@
 -(NSArray *)markedArticleRange
 {
 	NSMutableArray * articleArray = nil;
-	if (articleList.selectedRowIndexes.count > 0)
-	{
+	if (articleList.selectedRowIndexes.count > 0) {
 		NSIndexSet * rowIndexes = articleList.selectedRowIndexes;
 		NSUInteger  rowIndex = rowIndexes.firstIndex;
 
 		articleArray = [NSMutableArray arrayWithCapacity:rowIndexes.count];
-		while (rowIndex != NSNotFound)
-		{
+		while (rowIndex != NSNotFound) {
 			[articleArray addObject:self.controller.articleController.allArticles[rowIndex]];
 			rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
 		}
@@ -781,12 +758,9 @@
 -(BOOL)becomeFirstResponder
 {
     NSInteger currentSelectedRow = articleList.selectedRow;
-	if (currentSelectedRow >= 0 && currentSelectedRow < self.controller.articleController.allArticles.count)
-    {
+	if (currentSelectedRow >= 0 && currentSelectedRow < self.controller.articleController.allArticles.count) {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:currentSelectedRow] byExtendingSelection:NO];
-    }
-    else if (self.controller.articleController.allArticles.count != 0u)
-    {
+    } else if (self.controller.articleController.allArticles.count != 0u) {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
     }
 	[NSApp.mainWindow makeFirstResponder:articleList];
@@ -799,11 +773,11 @@
  */
 -(void)keyDown:(NSEvent *)theEvent
 {
-	if (theEvent.characters.length == 1)
-	{
+	if (theEvent.characters.length == 1) {
 		unichar keyChar = [theEvent.characters characterAtIndex:0];
-		if ([self.controller handleKeyDown:keyChar withFlags:theEvent.modifierFlags])
+		if ([self.controller handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
 			return;
+		}
 	}
 	[self interpretKeyEvents:@[theEvent]];
 }

--- a/Vienna/Sources/Models/Article.m
+++ b/Vienna/Sources/Models/Article.m
@@ -71,8 +71,7 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
  */
 -(instancetype)initWithGuid:(NSString *)theGuid
 {
-    if ((self = [self init]) != nil)
-    {
+    if ((self = [self init]) != nil) {
         self.guid = theGuid;
     }
     return self;
@@ -128,10 +127,11 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
 -(void)setEnclosure:(NSString *)enclosure
 {
     NSString *newEnclosure = [enclosure copy];
-    if (newEnclosure)
+    if (newEnclosure) {
         articleData[MA_Field_Enclosure] = newEnclosure;
-    else
+    } else {
         [articleData removeObjectForKey:MA_Field_Enclosure];
+    }
 }
 
 /* markEnclosureDownloaded
@@ -189,36 +189,22 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
  */
 -(id)valueForKeyPath:(NSString *)keyPath
 {
-    if ([keyPath hasPrefix:@"articleData."])
-    {
+    if ([keyPath hasPrefix:@"articleData."]) {
         NSString * key = [keyPath substringFromIndex:(@"articleData.").length];
-        if ([key isEqualToString:MA_Field_Date])
-        {
+        if ([key isEqualToString:MA_Field_Date]) {
             return self.date;
-        }
-        else if ([key isEqualToString:MA_Field_Author])
-        {
+        } else if ([key isEqualToString:MA_Field_Author]) {
             return self.author;
-        }
-        else if ([key isEqualToString:MA_Field_Subject])
-        {
+        } else if ([key isEqualToString:MA_Field_Subject]) {
             return self.title;
-        }
-        else if ([key isEqualToString:MA_Field_Link])
-        {
+        } else if ([key isEqualToString:MA_Field_Link]) {
             return self.link;
-        }
-        else if ([key isEqualToString:MA_Field_Summary])
-        {
+        } else if ([key isEqualToString:MA_Field_Summary]) {
             return self.summary;
-        }
-        else
-        {
+        } else {
             return [super valueForKeyPath:keyPath];
         }
-    }
-    else
-    {
+    } else {
         return [super valueForKeyPath:keyPath];
     }
 }
@@ -242,11 +228,11 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
 -(NSString *)summary
 {
     NSString * summary = articleData[MA_Field_Summary];
-    if (summary == nil)
-    {
+    if (summary == nil) {
         summary = [articleData[MA_Field_Text] vna_summaryTextFromHTML];
-        if (summary == nil)
+        if (summary == nil) {
             summary = @"";
+        }
         articleData[MA_Field_Summary] = summary;
     }
     return summary;
@@ -306,8 +292,7 @@ NSString * MA_Field_HasEnclosure = @"HasEnclosure";
 {
     Folder * folder = [[Database sharedManager] folderFromID:self.folderId];
     NSUInteger index = [folder indexOfArticle:self];
-    if (index != NSNotFound)
-    {
+    if (index != NSNotFound) {
         NSScriptObjectSpecifier * containerRef = folder.objectSpecifier;
         return [[NSIndexSpecifier allocWithZone:nil] initWithContainerClassDescription:(NSScriptClassDescription *)[Folder classDescription]
                                                                              containerSpecifier:containerRef

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -53,8 +53,7 @@ static NSArray * iconArray = nil;
  */
 -(instancetype)initWithId:(NSInteger)newId parentId:(NSInteger)newIdParent name:(NSString *)newName type:(VNAFolderType)newType
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		_itemId = newId;
 		_parentId = newIdParent;
 		_firstChildId = 0;
@@ -221,8 +220,7 @@ static NSArray * iconArray = nil;
 -(void)setImage:(NSImage *)image
 {
     NSImage *iconImage = [image copy];
-	if (self.feedURL != nil && iconImage != nil)
-	{
+	if (self.feedURL != nil && iconImage != nil) {
 		NSString * homePageSiteRoot;
 		homePageSiteRoot = self.homePage.vna_host.vna_convertStringToValidPath;
 		[[FolderImageCache defaultCache] addImage:iconImage forURL:homePageSiteRoot];
@@ -266,10 +264,10 @@ static NSArray * iconArray = nil;
  */
 -(NSString *)password
 {
-	if (!self.hasPassword)
-	{
-		if (self.username != nil && self.feedURL != nil)
+	if (!self.hasPassword) {
+		if (self.username != nil && self.feedURL != nil) {
 			[self.attributes setValue:[VNAKeychain getPasswordFromKeychain:self.username url:self.feedURL] forKey:@"Password"];
+		}
 		self.hasPassword = YES;
 	}
 	return [self.attributes valueForKey:@"Password"];
@@ -281,8 +279,9 @@ static NSArray * iconArray = nil;
 -(void)setPassword:(NSString *)password
 {
 	NSString *newPassword = [password copy];
-	if (self.username != nil && self.feedURL != nil)
+	if (self.username != nil && self.feedURL != nil) {
 		[VNAKeychain setPasswordInKeychain:newPassword username:self.username url:self.feedURL];
+	}
 	[self.attributes setValue:newPassword forKey:@"Password"];
 	self.hasPassword = YES;
 }
@@ -447,8 +446,7 @@ static NSArray * iconArray = nil;
  */
 -(NSUInteger)indexOfArticle:(Article *)article
 {
-    @synchronized(self)
-    {
+    @synchronized(self) {
         [self ensureCache];
         return [self.cachedGuids indexOfObject:article.guid];
     }
@@ -458,8 +456,7 @@ static NSArray * iconArray = nil;
  */
 -(Article *)articleFromGuid:(NSString *)guid
 {
-    @synchronized(self)
-    {
+    @synchronized(self) {
         [self ensureCache];
 	    return [self.cachedArticles objectForKey:guid];
 	}
@@ -474,8 +471,7 @@ static NSArray * iconArray = nil;
  */
 -(BOOL)createArticle:(Article *)article guidHistory:(NSArray *)guidHistory
 {
-@synchronized(self)
-  {
+@synchronized(self) {
     // Prime the article cache
     [self ensureCache];
 
@@ -487,62 +483,47 @@ static NSArray * iconArray = nil;
     // We're going to ignore here the problem of feeds re-using guids, which is very naughty! Bad feed!
     Article * existingArticle = [self.cachedArticles objectForKey:articleGuid];
 
-    if (existingArticle == nil)
-    {
-        if ([guidHistory containsObject:articleGuid])
+    if (existingArticle == nil) {
+        if ([guidHistory containsObject:articleGuid]) {
             return NO; // Article has been deleted and removed from database, so ignore
-        else
-        {
+        } else {
             // add the article as new
             BOOL success = [[Database sharedManager] addArticle:article toFolder:self.itemId];
-            if(success)
-            {
+            if (success) {
                 article.status = ArticleStatusNew;
                 // add to the cache
                 NSString * guid = article.guid;
 	            [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
 	            [self.cachedGuids addObject:guid];
-                if(!article.read)
+                if(!article.read) {
                     adjustment = 1;
-            }
-            else
+                }
+            } else {
                 return NO;
+            }
         }
-    }
-    else if (existingArticle.deleted)
-    {
+    } else if (existingArticle.deleted) {
         return NO;
-    }
-    else if (![[Preferences standardPreferences] boolForKey:MAPref_CheckForUpdatedArticles])
-    {
+    } else if (![[Preferences standardPreferences] boolForKey:MAPref_CheckForUpdatedArticles]) {
         return NO;
-    }
-    else
-    {
+    } else {
         BOOL success = [[Database sharedManager] updateArticle:existingArticle ofFolder:self.itemId withArticle:article];
-        if (success)
-        {
+        if (success) {
             // Update folder unread count if necessary
-            if (existingArticle.read)
-            {
+            if (existingArticle.read) {
                 adjustment = 1;
                 article.status = ArticleStatusNew;
                 [existingArticle markRead:NO];
-            }
-            else
-            {
+            } else {
                 article.status = ArticleStatusUpdated;
             }
-        }
-        else
-        {
+        } else {
             return NO;
         }
     }
 
     // Fix unread count on parent folders and Database manager
-    if (adjustment != 0)
-    {
+    if (adjustment != 0) {
 		[[Database sharedManager] setFolderUnreadCount:self adjustment:adjustment];
     }
     return YES;
@@ -572,8 +553,7 @@ static NSArray * iconArray = nil;
  */
 -(void)clearCache
 {
-    @synchronized(self)
-    {
+    @synchronized(self) {
 		[self.cachedArticles removeAllObjects];
 		[self.cachedGuids removeAllObjects];
 		self.isCached = NO;
@@ -586,8 +566,7 @@ static NSArray * iconArray = nil;
  */
 -(void)removeArticleFromCache:(NSString *)guid
 {
-    @synchronized(self)
-    {
+    @synchronized(self) {
         NSAssert(self.isCached, @"Folder's cache of articles should be initialized before removeArticleFromCache can be used");
         [self.cachedArticles removeObjectForKey:guid];
         [self.cachedGuids removeObject:guid];
@@ -599,14 +578,12 @@ static NSArray * iconArray = nil;
  */
 -(void)restoreArticleToCache:(Article *)article
 {
-    @synchronized(self)
-    {
+    @synchronized(self) {
         NSString * guid = article.guid;
         [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
         [self.cachedGuids addObject:guid];
         // note if article has incomplete data
-        if (article.createdDate == nil)
-        {
+        if (article.createdDate == nil) {
             self.containsBodies = NO;
         }
     }
@@ -628,11 +605,9 @@ static NSArray * iconArray = nil;
  */
  -(void)ensureCache
  {
-    if (!self.isCached)
-    {
+    if (!self.isCached) {
         NSArray * myArray = [[Database sharedManager] minimalCacheForFolder:self.itemId];
-        for (Article * myArticle in myArray)
-        {
+        for (Article * myArticle in myArray) {
             NSString * guid = myArticle.guid;
             [self.cachedArticles setObject:myArticle forKey:[NSString stringWithString:guid]];
             [self.cachedGuids addObject:guid];
@@ -656,22 +631,20 @@ static NSArray * iconArray = nil;
  */
 -(void)markArticlesInCacheRead
 {
-@synchronized(self)
-  {
+@synchronized(self) {
     NSInteger count = unreadCount;
     // Note the use of reverseObjectEnumerator
     // since the unread articles are likely to be clustered
     // with the most recent articles at the end of the array
     // so it makes the code slightly faster.
-    for (id obj in self.cachedGuids.reverseObjectEnumerator.allObjects)
-    {
+    for (id obj in self.cachedGuids.reverseObjectEnumerator.allObjects) {
         Article * article = [self.cachedArticles objectForKey:(NSString *)obj];
-        if (!article.read)
-        {
+        if (!article.read) {
             [article markRead:YES];
             count--;
-            if (count == 0)
+            if (count == 0) {
                 break;
+            }
         }
     }
   } // synchronized
@@ -682,27 +655,24 @@ static NSArray * iconArray = nil;
  */
 -(NSArray *)arrayOfUnreadArticlesRefs
 {
-@synchronized(self)
-  {
-    if (self.isCached)
-    {
+@synchronized(self) {
+    if (self.isCached) {
         NSInteger count = unreadCount;
         NSMutableArray * result = [NSMutableArray arrayWithCapacity:unreadCount];
-        for (id obj in self.cachedGuids.reverseObjectEnumerator.allObjects)
-        {
+        for (id obj in self.cachedGuids.reverseObjectEnumerator.allObjects) {
             Article * article = [self.cachedArticles objectForKey:(NSString *)obj];
-            if (!article.read)
-            {
+            if (!article.read) {
                 [result addObject:[ArticleReference makeReference:article]];
                 count--;
-                if (count == 0)
+                if (count == 0) {
                     break;
+                }
             }
         }
         return [result copy];
-    }
-    else
+    } else {
         return [[Database sharedManager] arrayOfUnreadArticlesRefs:self.itemId];
+    }
   } // synchronized
 }
 
@@ -711,8 +681,7 @@ static NSArray * iconArray = nil;
  */
 -(NSArray<Article *> *)articlesWithFilter:(NSString *)filterString
 {
-	if ([filterString isEqualToString:@""])
-	{
+	if ([filterString isEqualToString:@""]) {
 		if (self.type == VNAFolderTypeGroup) {
 			NSMutableArray * articles = [NSMutableArray array];
 			NSArray * subFolders = [[Database sharedManager] arrayOfFolders:self.itemId];
@@ -722,18 +691,15 @@ static NSArray * iconArray = nil;
 			return [articles copy];
 		}
 		@synchronized(self) {
-            if (self.isCached && self.containsBodies)
-            {
+            if (self.isCached && self.containsBodies) {
                 self.cachedArticles.evictsObjectsWithDiscardedContent = NO;
                 NSMutableArray * articles = [NSMutableArray arrayWithCapacity:self.cachedGuids.count];
-                for (id object in self.cachedGuids)
-                {
+                for (id object in self.cachedGuids) {
                     Article * theArticle = [self.cachedArticles objectForKey:object];
                     if (theArticle != nil) {
                         [articles addObject:theArticle];
-                    }
-                    else
-                    {   // some problem
+                    } else {
+                        // some problem
                         NSLog(@"Bug retrieving from cache in folder %li : after %lu insertions of %lu, guid %@",(long)self.itemId, (unsigned long)articles.count,(unsigned long)self.cachedGuids.count,object);
                         self.isCached = NO;
                         self.containsBodies = NO;
@@ -742,9 +708,7 @@ static NSArray * iconArray = nil;
                 }
                 self.cachedArticles.evictsObjectsWithDiscardedContent = YES;
                 return [articles copy];
-            }
-            else
-            {
+            } else {
                 NSArray * articles = [[Database sharedManager] arrayOfArticles:self.itemId filterString:filterString];
                 // Only feeds folders can be cached, as they are the only ones to guarantee
                 // bijection : one article <-> one guid
@@ -753,8 +717,7 @@ static NSArray * iconArray = nil;
                     self.containsBodies = NO;
                     [self.cachedArticles removeAllObjects];
                     [self.cachedGuids removeAllObjects];
-                    for (id object in articles)
-                    {
+                    for (id object in articles) {
                         NSString * guid = ((Article *)object).guid;
                         [self.cachedArticles setObject:object forKey:[NSString stringWithString:guid]];
                         [self.cachedGuids addObject:guid];
@@ -765,8 +728,7 @@ static NSArray * iconArray = nil;
                 return articles;
             }
         } // synchronized
-	}
-    else {
+	} else {
 	    return [[Database sharedManager] arrayOfArticles:self.itemId filterString:filterString];
     }
 }
@@ -784,8 +746,12 @@ static NSArray * iconArray = nil;
  */
 -(NSComparisonResult)folderIDCompare:(Folder *)otherObject
 {
-	if (self.itemId > otherObject.itemId) return NSOrderedAscending;
-	if (self.itemId < otherObject.itemId) return NSOrderedDescending;
+	if (self.itemId > otherObject.itemId) {
+		return NSOrderedAscending;
+	}
+	if (self.itemId < otherObject.itemId) {
+		return NSOrderedDescending;
+	}
 	return NSOrderedSame;
 }
 
@@ -809,8 +775,7 @@ static NSArray * iconArray = nil;
 {
 	NSArray * folders = APPCONTROLLER.folders;
 	NSUInteger index = [folders indexOfObjectIdenticalTo:self];
-	if (index != NSNotFound)
-	{
+	if (index != NSNotFound) {
 		NSScriptObjectSpecifier *containerRef = APPCONTROLLER.objectSpecifier;
 		return [[NSIndexSpecifier allocWithZone:nil] initWithContainerClassDescription:(NSScriptClassDescription *)NSApp.classDescription containerSpecifier:containerRef key:@"folders" index:index];
 	}
@@ -828,12 +793,10 @@ static NSArray * iconArray = nil;
 #pragma mark NSCacheDelegate
 -(void)cache:(NSCache *)cache willEvictObject:(id)obj
 {
-    @synchronized(self)
-    {
+    @synchronized(self) {
         Article * theArticle = ((Article *)obj);
         NSString * guid = theArticle.guid;
-        if (self.isCached && !theArticle.isDeleted)
-        {
+        if (self.isCached && !theArticle.isDeleted) {
             self.isCached = NO;
             self.containsBodies = NO;
         }

--- a/Vienna/Sources/Models/FolderImageCache.m
+++ b/Vienna/Sources/Models/FolderImageCache.m
@@ -29,8 +29,9 @@ static FolderImageCache * _folderImageCache = nil;
  */
 +(FolderImageCache *)defaultCache
 {
-    if (_folderImageCache == nil)
+    if (_folderImageCache == nil) {
         _folderImageCache = [[FolderImageCache alloc] init];
+    }
     return _folderImageCache;
 }
 
@@ -39,8 +40,7 @@ static FolderImageCache * _folderImageCache = nil;
  */
 -(instancetype)init
 {
-    if ((self = [super init]) != nil)
-    {
+    if ((self = [super init]) != nil) {
         imagesCacheFolder = nil;
         initializedFolderImagesArray = NO;
         folderImagesArray = [[NSMutableDictionary alloc] init];
@@ -58,8 +58,7 @@ static FolderImageCache * _folderImageCache = nil;
     folderImagesArray[baseURL] = image;
     
     // Save icon to disk here.
-    if (imagesCacheFolder != nil)
-    {
+    if (imagesCacheFolder != nil) {
         NSString * fullFilePath = [[imagesCacheFolder stringByAppendingPathComponent:baseURL] stringByAppendingPathExtension:@"tiff"];
         NSData *imageData = nil;
         @try {
@@ -69,8 +68,9 @@ static FolderImageCache * _folderImageCache = nil;
             imageData = nil;
             NSLog(@"tiff exception with %@", fullFilePath);
         }
-        if (imageData != nil)
+        if (imageData != nil) {
             [[NSFileManager defaultManager] createFileAtPath:fullFilePath contents:imageData attributes:nil];
+        }
     }
 }
 
@@ -90,8 +90,7 @@ static FolderImageCache * _folderImageCache = nil;
  */
 -(void)initFolderImagesArray
 {
-    if (!initializedFolderImagesArray)
-    {
+    if (!initializedFolderImagesArray) {
         NSFileManager * fileManager = [NSFileManager defaultManager];
         NSArray * listOfFiles;
         BOOL isDir;
@@ -103,10 +102,8 @@ static FolderImageCache * _folderImageCache = nil;
         NSURL *imagesURL = [appSupportURL URLByAppendingPathComponent:@"Images"
                                                           isDirectory:YES];
         imagesCacheFolder = imagesURL.path;
-        if (![fileManager fileExistsAtPath:imagesCacheFolder isDirectory:&isDir])
-        {
-            if (![fileManager createDirectoryAtPath:imagesCacheFolder withIntermediateDirectories:YES attributes:nil error:nil])
-            {
+        if (![fileManager fileExistsAtPath:imagesCacheFolder isDirectory:&isDir]) {
+            if (![fileManager createDirectoryAtPath:imagesCacheFolder withIntermediateDirectories:YES attributes:nil error:nil]) {
                 NSLog(@"Cannot create image cache at %@. Will not cache folder images in this session.", imagesCacheFolder);
                 imagesCacheFolder = nil;
             }
@@ -114,8 +111,7 @@ static FolderImageCache * _folderImageCache = nil;
             return;
         }
         
-        if (!isDir)
-        {
+        if (!isDir) {
             NSLog(@"The file at %@ is not a directory. Will not cache folder images in this session.", imagesCacheFolder);
             imagesCacheFolder = nil;
             initializedFolderImagesArray = YES;
@@ -125,19 +121,15 @@ static FolderImageCache * _folderImageCache = nil;
         // Remember - not every file we find may be a valid image file. We use the filename as
         // the key but check the extension too.
         listOfFiles = [fileManager contentsOfDirectoryAtPath:imagesCacheFolder error:nil];
-        if (listOfFiles != nil)
-        {
+        if (listOfFiles != nil) {
             NSString * fileName;
             
-            for (fileName in listOfFiles)
-            {
-                if ([fileName.pathExtension isEqualToString:@"tiff"])
-                {
+            for (fileName in listOfFiles) {
+                if ([fileName.pathExtension isEqualToString:@"tiff"]) {
                     NSString * fullPath = [imagesCacheFolder stringByAppendingPathComponent:fileName];
                     NSData * imageData = [fileManager contentsAtPath:fullPath];
                     NSImage * iconImage = [[NSImage alloc] initWithData:imageData];
-                    if (iconImage.valid)
-                    {
+                    if (iconImage.valid) {
                         iconImage.size = NSMakeSize(16, 16);
                         NSString * homePageSiteRoot = (fullPath.lastPathComponent.stringByDeletingPathExtension).vna_convertStringToValidPath;
                         folderImagesArray[homePageSiteRoot] = iconImage;

--- a/Vienna/Sources/Plug-ins/PluginManager.m
+++ b/Vienna/Sources/Plug-ins/PluginManager.m
@@ -38,8 +38,7 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
  */
 -(instancetype)init
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		allPlugins = nil;
 	}
 	return self;
@@ -65,10 +64,11 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 	NSString * pluginName;
 	NSString * path;
 
-	if (allPlugins == nil)
+	if (allPlugins == nil) {
 		allPlugins = [[NSMutableDictionary alloc] init];
-	else
+	} else {
 		[allPlugins removeAllObjects];
+	}
 	
 	pluginPaths = [[NSMutableDictionary alloc] init];
 	
@@ -78,8 +78,7 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 	path = PluginManager.plugInsDirectoryURL.path;
 	loadMapFromPath(path, pluginPaths, YES, nil);
 
-	for (pluginName in pluginPaths)
-	{
+	for (pluginName in pluginPaths) {
 		NSString * pluginPath = pluginPaths[pluginName];
 		[self loadPlugin:pluginPath];
 	}
@@ -97,10 +96,9 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 	
 	// If the info.plist is missing or corrupted, warn but then just move on and the user
 	// will have to figure it out.
-	if (pluginInfo == nil)
+	if (pluginInfo == nil) {
 		NSLog(@"Missing or corrupt info.plist in %@", pluginPath);
-	else
-	{
+	} else {
 		// We need to save the path to the plugin in the plugin object for later access to other
 		// resources in the plugin folder.
 		pluginInfo[@"Path"] = pluginPath;
@@ -120,8 +118,7 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
     for (NSDictionary *onePlugin in allPlugins.allValues) {
         // If it's a blog editor plugin, don't show it in the menu
         // if the app in question is not present on the system.
-        if ([onePlugin[@"Type"] isEqualToString:@"BlogEditor"])
-        {
+        if ([onePlugin[@"Type"] isEqualToString:@"BlogEditor"]) {
             NSString * bundleIdentifier = onePlugin[@"BundleIdentifier"];
 
             if (![NSWorkspace.sharedWorkspace URLForApplicationWithBundleIdentifier:bundleIdentifier]) {
@@ -131,8 +128,9 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 
         NSString * pluginName = onePlugin[@"Name"];
         NSString * menuPath = onePlugin[@"MenuPath"];
-        if (menuPath == nil)
+        if (menuPath == nil) {
             continue;
+        }
 
         // Parse off the shortcut key, if there is one. The format is a series of
         // control key specifiers: Cmd, Shift, Alt or Ctrl - specified in any
@@ -143,25 +141,23 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
         NSUInteger keyMod = 0;
         NSString * keyChar = @"";
 
-        if (menuKey != nil)
-        {
+        if (menuKey != nil) {
             NSArray * keyArray = [menuKey componentsSeparatedByString:@"+"];
             NSString * oneKey;
 
-            for (oneKey in keyArray)
-            {
-                if ([oneKey isEqualToString:@"Cmd"])
+            for (oneKey in keyArray) {
+                if ([oneKey isEqualToString:@"Cmd"]) {
                     keyMod |= NSEventModifierFlagCommand;
-                else if ([oneKey isEqualToString:@"Shift"])
+                } else if ([oneKey isEqualToString:@"Shift"]) {
                     keyMod |= NSEventModifierFlagShift;
-                else if ([oneKey isEqualToString:@"Alt"])
+                } else if ([oneKey isEqualToString:@"Alt"]) {
                     keyMod |= NSEventModifierFlagOption;
-                else if ([oneKey isEqualToString:@"Ctrl"])
+                } else if ([oneKey isEqualToString:@"Ctrl"]) {
                     keyMod |= NSEventModifierFlagControl;
-                else
-                {
-                    if (!keyChar.vna_isBlank)
+                } else {
+                    if (!keyChar.vna_isBlank) {
                         NSLog(@"Warning: malformed MenuKey found in info.plist for plugin %@", pluginName);
+                    }
                     keyChar = oneKey;
                 }
             }
@@ -192,10 +188,8 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 -(NSArray *)searchMethods
 {
 	NSMutableArray * searchMethods = [NSMutableArray arrayWithCapacity:allPlugins.count];
-	for (NSDictionary * plugin in allPlugins.allValues)
-	{
-		if ([[plugin valueForKey:@"Type"] isEqualToString:@"SearchEngine"])
-		{
+	for (NSDictionary * plugin in allPlugins.allValues) {
+		if ([[plugin valueForKey:@"Type"] isEqualToString:@"SearchEngine"]) {
 			SearchMethod * method = [[SearchMethod alloc] initWithDictionary:plugin];
 			[searchMethods addObject:method];
 		}
@@ -211,12 +205,12 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 	NSMutableArray * toolbarKeys = [NSMutableArray arrayWithCapacity:allPlugins.count];
 	NSString * pluginName;
 	NSString * pluginType;	
-	for (pluginName in allPlugins)
-	{
+	for (pluginName in allPlugins) {
 		NSDictionary * onePlugin = allPlugins[pluginName];
 		pluginType = onePlugin[@"Type"];
-		if (![pluginType isEqualToString:@"SearchEngine"])
+		if (![pluginType isEqualToString:@"SearchEngine"]) {
 			[toolbarKeys addObject:pluginName];
+		}
 	}
 	return [toolbarKeys copy];
 }
@@ -229,11 +223,11 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 	NSMutableArray * newArray = [NSMutableArray arrayWithCapacity:allPlugins.count];
 	NSString * pluginName;
 
-	for (pluginName in allPlugins)
-	{
+	for (pluginName in allPlugins) {
 		NSDictionary * onePlugin = allPlugins[pluginName];
-		if ([onePlugin[@"Default"] integerValue])
+		if ([onePlugin[@"Default"] integerValue]) {
 			[newArray addObject:pluginName];
+		}
 	}
 	return [newArray copy];
 }
@@ -250,10 +244,12 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 		NSString * tooltip = pluginItem[@"Tooltip"];
         NSString *imagePath = [NSString stringWithFormat:@"%@/%@.tiff", pluginItem[@"Path"], pluginItem[@"ButtonImage"]];
 
-		if (friendlyName == nil)
+		if (friendlyName == nil) {
 			friendlyName = itemIdentifier;
-		if (tooltip == nil)
+		}
+		if (tooltip == nil) {
 			tooltip = friendlyName;
+		}
 		
         item.label = friendlyName;
         item.paletteLabel = item.label;
@@ -276,9 +272,9 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 {
     id<Tab> activeBrowserTab = APPCONTROLLER.browser.activeTab;
 
-    if (activeBrowserTab)
+    if (activeBrowserTab) {
         return ((activeBrowserTab.tabUrl != nil) && NSApp.active);
-    else {
+    } else {
         Article * thisArticle = APPCONTROLLER.selectedArticle;
         return (thisArticle != nil && NSApp.active);
     }
@@ -291,9 +287,9 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 {
     id<Tab> activeBrowserTab = APPCONTROLLER.browser.activeTab;
 
-    if (activeBrowserTab)
+    if (activeBrowserTab) {
         return ((activeBrowserTab.tabUrl != nil) && NSApp.active);
-    else {
+    } else {
         Article * thisArticle = APPCONTROLLER.selectedArticle;
         return (thisArticle != nil && NSApp.active);
     }
@@ -314,65 +310,53 @@ static NSString * const VNAPlugInsDirectoryName = @"Plugins";
 		pluginItem = menuItem.representedObject;
 	}
 	
-	if (pluginItem != nil)
-	{
+	if (pluginItem != nil) {
 		// This is a link plugin. There should be a URL field which we invoke and possibly
 		// placeholders to be filled from the current article or website.
 
 		NSString * itemType = pluginItem[@"Type"];
-		if ([itemType isEqualToString:@"Link"])
-		{
+		if ([itemType isEqualToString:@"Link"]) {
 			NSMutableString * urlString  = [NSMutableString stringWithString:pluginItem[@"URL"]];
-			if (urlString == nil)
+			if (urlString == nil) {
 				return;
+			}
 
             id<Tab> activeBrowserTab = APPCONTROLLER.browser.activeTab;
 
 			// ...and do the following in case the user is currently looking at a website.
-			if (activeBrowserTab)
-			{	
+			if (activeBrowserTab) {
 				[urlString vna_replaceString:@"$ArticleTitle$" withString:activeBrowserTab.title];
 				[urlString vna_replaceString:@"$ArticleLink$" withString:[NSString vna_stringByCleaningURLString:activeBrowserTab.tabUrl.absoluteString]];
-			}
-			
 			// In case the user is currently looking at an article:
-			else
-			{
+			} else {
 				// We can only work on one article, so ignore selection range.
 				Article * currentMessage = APPCONTROLLER.selectedArticle;
 				[urlString vna_replaceString:@"$ArticleTitle$" withString: currentMessage.title];
                 [urlString vna_replaceString:@"$ArticleLink$" withString:[NSString vna_stringByCleaningURLString:currentMessage.link]];
 			}
 						
-			if (urlString != nil)
-			{
+			if (urlString != nil) {
 				NSURL * urlToLoad = cleanedUpUrlFromString(urlString);				
-				if (urlToLoad != nil)
+				if (urlToLoad != nil) {
 					(void)[APPCONTROLLER.browser createNewTab:urlToLoad inBackground:NO load:true];
-			}
-			else
-			{
+				}
+			} else {
 				// TODO: Implement real error-handling. Don't know how to go about it, yet.
 				NSBeep();
 				NSLog(@"Creation of the sharing URL failed!");
 			}
-		}
-		
-		else if ([itemType isEqualToString:@"Script"])
-		{
+		} else if ([itemType isEqualToString:@"Script"]) {
 			// This is a script plugin. There should be a Script field which specifies the
 			// filename of the script file in the same folder.
 			NSString * pluginPath = pluginItem[@"Path"];
 			NSString * scriptFile = [pluginPath stringByAppendingPathComponent:pluginItem[@"Script"]];
-			if (scriptFile == nil)
+			if (scriptFile == nil) {
 				return;
+			}
 
 			// Just run the script
 			[APPCONTROLLER runAppleScript:scriptFile];
-		}
-
-		else if ([itemType isEqualToString:@"BlogEditor"])
-		{
+		} else if ([itemType isEqualToString:@"BlogEditor"]) {
 			// This is a blog-editor plugin. Simply send the info to the application.
 			[APPCONTROLLER blogWithExternalEditor:pluginItem[@"BundleIdentifier"]];
 		}

--- a/Vienna/Sources/Preferences window/AppearancePreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/AppearancePreferencesViewController.m
@@ -75,8 +75,9 @@ static NSInteger const availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24
     
     NSUInteger i;
     [minimumFontSizes removeAllItems];
-    for (i = 0; i < countOfAvailableMinimumFontSizes; ++i)
+    for (i = 0; i < countOfAvailableMinimumFontSizes; ++i) {
         [minimumFontSizes addItemWithObjectValue:@(availableMinimumFontSizes[i])];
+    }
     minimumFontSizes.doubleValue = prefs.minimumFontSize;
 }
 

--- a/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
@@ -155,21 +155,20 @@
     // Next, add the list of all registered link handlers under the /Applications folder
     // except for the registered application.
     CFArrayRef cfArrayOfApps = LSCopyApplicationURLsForURL((__bridge CFURLRef)testURL, kLSRolesAll);
-    if (cfArrayOfApps != nil)
-    {
+    if (cfArrayOfApps != nil) {
         CFIndex count = CFArrayGetCount(cfArrayOfApps);
         NSInteger index;
         
-        for (index = 0; index < count; ++index)
-        {
+        for (index = 0; index < count; ++index) {
             NSURL * appURL = (NSURL *)CFArrayGetValueAtIndex(cfArrayOfApps, index);
-            if (appURL.fileURL && [appURL.path hasPrefix:@"/Applications/"])
-            {
+            if (appURL.fileURL && [appURL.path hasPrefix:@"/Applications/"]) {
                 NSString * appName = [[NSFileManager defaultManager] displayNameAtPath:appURL.path];
-                if ([appName isEqualToString:ourAppName])
+                if ([appName isEqualToString:ourAppName]) {
                     onTheList = YES;
-                if (appName != nil && ![appName isEqualToString:regAppName])
+                }
+                if (appName != nil && ![appName isEqualToString:regAppName]) {
                     [linksHandler addItemWithTitle:appName image:[[NSWorkspace sharedWorkspace] iconForFile:appURL.path]];
+                }
                 
                 [appToPathMap setValue:appURL forKey:appName];
             }
@@ -179,8 +178,7 @@
     
     // Were we on the list? If not, add ourselves
     // complete with our icon.
-    if (!onTheList)
-    {
+    if (!onTheList) {
         [linksHandler addItemWithTitle:ourAppName image:[[NSWorkspace sharedWorkspace] iconForFile:appBundle.bundlePath]];
         
         NSURL * fileURL = [[NSURL alloc] initFileURLWithPath:appBundle.bundlePath];
@@ -202,8 +200,9 @@
 -(IBAction)changeExpireDuration:(id)sender
 {
     NSMenuItem * selectedItem = expireDuration.selectedItem;
-    if (selectedItem != nil)
+    if (selectedItem != nil) {
         [Preferences standardPreferences].autoExpireDuration = selectedItem.tag;
+    }
 }
 
 /* changeOpenLinksInBackground
@@ -304,10 +303,8 @@
 -(IBAction)selectDefaultLinksHandler:(id)sender
 {
     NSMenuItem * selectedItem = linksHandler.selectedItem;
-    if (selectedItem != nil)
-    {
-        if (selectedItem.tag == -1)
-        {
+    if (selectedItem != nil) {
+        if (selectedItem.tag == -1) {
             [self handleLinkSelector:self];
             return;
         }
@@ -336,8 +333,9 @@
         [panel orderOut:self];
         [prefPaneWindow makeKeyAndOrderFront:self];
         
-        if (returnCode == NSModalResponseOK)
+        if (returnCode == NSModalResponseOK) {
             [self setDefaultApplicationForFeedScheme:panel.URL];
+        }
         [self refreshLinkHandler];
     }];
 }
@@ -389,12 +387,9 @@
 {
     Preferences * prefs = [Preferences standardPreferences];
     NSInteger currentNotificationValue = prefs.newArticlesNotification;
-    if ([sender state] == NSControlStateValueOn)
-    {
+    if ([sender state] == NSControlStateValueOn) {
         prefs.newArticlesNotification = currentNotificationValue | VNANewArticlesNotificationBounce;
-    }
-    else
-    {
+    } else {
         prefs.newArticlesNotification = currentNotificationValue & ~VNANewArticlesNotificationBounce;
     }
 }

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -65,8 +65,9 @@ static Preferences * _standardPreferences = nil;
  */
 +(Preferences *)standardPreferences
 {
-	if (_standardPreferences == nil)
+	if (_standardPreferences == nil) {
 		_standardPreferences = [[Preferences alloc] init];
+	}
 	return _standardPreferences;
 }
 
@@ -75,8 +76,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(instancetype)init
 {
-	if ((self = [super init]) != nil)
-	{
+	if ((self = [super init]) != nil) {
 		// Merge in the user preferences from the defaults.
 		NSDictionary * defaults = self.allocFactoryDefaults;
 		userPrefs = NSUserDefaults.standardUserDefaults;
@@ -139,20 +139,16 @@ static Preferences * _standardPreferences = nil;
 		//Sparkle autoupdate
         alwaysAcceptBetas = [self boolForKey:MAPref_AlwaysAcceptBetas];
 
-		if (shouldSaveFeedSource)
-		{
+		if (shouldSaveFeedSource) {
 			[self createFeedSourcesFolderIfNecessary];
 		}
 		
 		// Here is where we want to put any logic that depends on the last or highest version of Vienna that has been run.
 		NSString * bundleVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
-		if (bundleVersionString != nil)
-		{
+		if (bundleVersionString != nil) {
 			NSInteger bundleVersion = bundleVersionString.integerValue;
-			if (bundleVersion > 0)
-			{
-				if (bundleVersion > [self integerForKey:MAPref_HighestViennaVersionRun])
-				{
+			if (bundleVersion > 0) {
+				if (bundleVersion > [self integerForKey:MAPref_HighestViennaVersionRun]) {
 					[self setInteger:bundleVersion forKey:MAPref_HighestViennaVersionRun];
 				}
 				[self setInteger:bundleVersion forKey:MAPref_LastViennaVersionRun];
@@ -428,8 +424,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setDefaultDatabase:(NSString *)newDatabase
 {
-	if (defaultDatabase != newDatabase)
-	{
+	if (defaultDatabase != newDatabase) {
 		defaultDatabase = newDatabase;
 		[userPrefs setObject:newDatabase forKey:MAPref_DefaultDatabase];
 	}
@@ -464,8 +459,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setUseJavaScript:(BOOL)flag
 {
-	if (useJavaScript != flag)
-	{
+	if (useJavaScript != flag) {
 		useJavaScript = flag;
 		[self setBool:flag forKey:MAPref_UseJavaScript];
 		[[NSNotificationCenter defaultCenter] postNotificationName:kMA_Notify_UseJavaScriptChange
@@ -500,8 +494,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setMinimumFontSize:(NSInteger)newSize
 {
-	if (newSize != minimumFontSize)
-	{
+	if (newSize != minimumFontSize) {
 		minimumFontSize = newSize;
 		[self setInteger:minimumFontSize forKey:MAPref_MinimumFontSize];
 		[[NSNotificationCenter defaultCenter] postNotificationName:kMA_Notify_MinimumFontSizeChange
@@ -514,8 +507,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setEnableMinimumFontSize:(BOOL)flag
 {
-	if (enableMinimumFontSize != flag)
-	{
+	if (enableMinimumFontSize != flag) {
 		enableMinimumFontSize = flag;
 		[self setBool:flag forKey:MAPref_UseMinimumFontSize];
 		[[NSNotificationCenter defaultCenter] postNotificationName:kMA_Notify_MinimumFontSizeChange
@@ -536,8 +528,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setShowFolderImages:(BOOL)flag
 {
-	if (showFolderImages != flag)
-	{
+	if (showFolderImages != flag) {
 		showFolderImages = flag;
 		[self setBool:flag forKey:MAPref_ShowFolderImages];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ShowFolderImages" object:nil];
@@ -560,8 +551,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setAutoExpireDuration:(NSInteger)newDuration
 {
-	if (newDuration != autoExpireDuration)
-	{
+	if (newDuration != autoExpireDuration) {
 		autoExpireDuration = newDuration;
 		[self setInteger:newDuration forKey:MAPref_AutoExpireDuration];
 	}
@@ -580,8 +570,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setLayout:(NSInteger)newLayout
 {
-	if (layout != newLayout)
-	{
+	if (layout != newLayout) {
 		layout = newLayout;
 		[self setInteger:newLayout forKey:MAPref_Layout];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ReadingPaneChange" object:nil];
@@ -622,8 +611,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setRefreshFrequency:(NSInteger)newFrequency
 {
-	if (refreshFrequency != newFrequency)
-	{
+	if (refreshFrequency != newFrequency) {
 		refreshFrequency = newFrequency;
 		[self setInteger:newFrequency forKey:MAPref_CheckFrequency];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_CheckFrequencyChange" object:nil];
@@ -643,8 +631,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setRefreshOnStartup:(BOOL)flag
 {
-	if (flag != refreshOnStartup)
-	{
+	if (flag != refreshOnStartup) {
 		refreshOnStartup = flag;
 		[self setBool:flag forKey:MAPref_CheckForNewArticlesOnStartup];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -664,8 +651,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setAlwaysAcceptBetas:(BOOL)flag
 {
-	if (flag != alwaysAcceptBetas)
-	{
+	if (flag != alwaysAcceptBetas) {
 		alwaysAcceptBetas = flag;
 		[self setBool:flag forKey:MAPref_AlwaysAcceptBetas];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -687,8 +673,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setMarkReadInterval:(float)newInterval
 {
-	if (newInterval != markReadInterval)
-	{
+	if (newInterval != markReadInterval) {
 		markReadInterval = newInterval;
 		[self setObject:@((float)newInterval) forKey:MAPref_MarkReadInterval];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -708,8 +693,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setFilterMode:(NSInteger)newMode
 {
-	if (filterMode != newMode)
-	{
+	if (filterMode != newMode) {
 		filterMode = newMode;
 		[self setInteger:filterMode forKey:MAPref_FilterMode];
 	}
@@ -730,8 +714,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setOpenLinksInVienna:(BOOL)flag
 {
-	if (openLinksInVienna != flag)
-	{
+	if (openLinksInVienna != flag) {
 		openLinksInVienna = flag;
 		[self setBool:flag forKey:MAPref_OpenLinksInVienna];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -752,8 +735,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setOpenLinksInBackground:(BOOL)flag
 {
-	if (openLinksInBackground != flag)
-	{
+	if (openLinksInBackground != flag) {
 		openLinksInBackground = flag;
 		[self setBool:flag forKey:MAPref_OpenLinksInBackground];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -774,8 +756,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setMarkUpdatedAsNew:(BOOL)flag
 {
-	if (markUpdatedAsNew != flag)
-	{
+	if (markUpdatedAsNew != flag) {
 		markUpdatedAsNew = flag;
 		[self setBool:flag forKey:MAPref_CheckForUpdatedArticles];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -803,12 +784,12 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setDisplayStyle:(NSString *)newStyleName withNotification:(BOOL)flag
 {
-	if (![displayStyle isEqualToString:newStyleName])
-	{
+	if (![displayStyle isEqualToString:newStyleName]) {
 		displayStyle = newStyleName;
 		[self setString:displayStyle forKey:MAPref_ActiveStyleName];
-		if (flag)
+		if (flag) {
 			[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_StyleChange" object:nil];
+		}
 	}
 }
 
@@ -825,8 +806,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setTextSizeMultiplier:(CGFloat)newValue
 {
-	if (newValue != textSizeMultiplier)
-	{
+	if (newValue != textSizeMultiplier) {
 		textSizeMultiplier = newValue;
 		[self setObject:@(newValue) forKey:MAPref_ActiveTextSizeMultiplier];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_StyleChange" object:nil];
@@ -898,8 +878,7 @@ static Preferences * _standardPreferences = nil;
         return;
     }
 
-	if (![articleSortDescriptors isEqualToArray:newSortDescriptors])
-	{
+	if (![articleSortDescriptors isEqualToArray:newSortDescriptors]) {
 		articleSortDescriptors = [newSortDescriptors copy];
         NSData *archive = [NSKeyedArchiver vna_archivedDataWithRootObject:articleSortDescriptors
                                                     requiringSecureCoding:YES];
@@ -921,8 +900,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setFoldersTreeSortMethod:(NSInteger)newMethod
 {
-	if (foldersTreeSortMethod != newMethod)
-	{
+	if (foldersTreeSortMethod != newMethod) {
 		foldersTreeSortMethod = newMethod;
 		[self setInteger:newMethod forKey:MAPref_AutoSortFoldersTree];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_AutoSortFoldersTreeChange" object:nil];
@@ -942,8 +920,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setNewArticlesNotification:(NSInteger)newMethod
 {
-	if (newMethod != newArticlesNotification)
-	{
+	if (newMethod != newArticlesNotification) {
 		newArticlesNotification = newMethod;
 		[self setInteger:newArticlesNotification forKey:MAPref_NewArticlesNotification];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_PreferenceChange" object:nil];
@@ -963,8 +940,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setShowAppInStatusBar:(BOOL)show
 {
-	if (showAppInStatusBar != show)
-	{
+	if (showAppInStatusBar != show) {
 		showAppInStatusBar = show;
 		[self setBool:showAppInStatusBar forKey:MAPref_ShowAppInStatusBar];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_ShowAppInStatusBarChanged" object:nil];
@@ -984,8 +960,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setShowStatusBar:(BOOL)show
 {
-	if (showStatusBar != show)
-	{
+	if (showStatusBar != show) {
 		showStatusBar = show;
 		[self setBool:showStatusBar forKey:MAPref_ShowStatusBar];
 	}
@@ -1004,8 +979,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setShowFilterBar:(BOOL)show
 {
-	if (showFilterBar != show)
-	{
+	if (showFilterBar != show) {
 		showFilterBar = show;
 		[self setBool:showFilterBar forKey:MAPref_ShowFilterBar];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_FilterBarChanged" object:nil];
@@ -1033,11 +1007,9 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setShouldSaveFeedSource:(BOOL)shouldSave
 {
-	if (shouldSaveFeedSource != shouldSave)
-	{
+	if (shouldSaveFeedSource != shouldSave) {
 		shouldSaveFeedSource = shouldSave;
-		if (shouldSaveFeedSource)
-		{
+		if (shouldSaveFeedSource) {
 			[self createFeedSourcesFolderIfNecessary];
 		}
 		[self setBool:shouldSaveFeedSource forKey:MAPref_ShouldSaveFeedSource];
@@ -1048,16 +1020,12 @@ static Preferences * _standardPreferences = nil;
 -(void)createFeedSourcesFolderIfNecessary
 {	
 	BOOL isDirectory = NO;
-	if (![[NSFileManager defaultManager] fileExistsAtPath:feedSourcesFolder isDirectory:&isDirectory])
-	{
+	if (![[NSFileManager defaultManager] fileExistsAtPath:feedSourcesFolder isDirectory:&isDirectory]) {
 		NSError * error = nil;
-		if (![[NSFileManager defaultManager] createDirectoryAtPath:feedSourcesFolder withIntermediateDirectories:YES attributes:nil error:&error])
-		{
+		if (![[NSFileManager defaultManager] createDirectoryAtPath:feedSourcesFolder withIntermediateDirectories:YES attributes:nil error:&error]) {
 			NSLog(@"Could not create feed sources folder at path '%@'. Error: %@", feedSourcesFolder, error.localizedDescription);
 		}
-	}
-	else if (!isDirectory)
-	{
+	} else if (!isDirectory) {
 		// Huh, there's a Sources file there, but it's not a directory.
 		NSLog(@"Could not create feed sources folder, because a non-directory file already exists at path '%@'.", feedSourcesFolder);
 	}
@@ -1073,8 +1041,7 @@ static Preferences * _standardPreferences = nil;
 
 -(void)setSyncGoogleReader:(BOOL)flag 
 {
-    if (syncGoogleReader != flag) 
-    {
+    if (syncGoogleReader != flag) {
 		syncGoogleReader = flag;
 		[self setBool:syncGoogleReader forKey:MAPref_SyncGoogleReader];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_SyncGoogleReaderChange" object:nil];
@@ -1091,8 +1058,7 @@ static Preferences * _standardPreferences = nil;
 
 -(void)setPrefersGoogleNewSubscription:(BOOL)flag
 {
-	if (prefersGoogleNewSubscription != flag)
-	{
+	if (prefersGoogleNewSubscription != flag) {
 		prefersGoogleNewSubscription = flag;
 		[self setBool:prefersGoogleNewSubscription forKey:MAPref_GoogleNewSubscription];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_GoogleReaderNewSubscriptionChange" object:nil];
@@ -1109,8 +1075,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setSyncServer:(NSString *)newServer
 {
-	if (![syncServer isEqualToString:newServer])
-	{
+	if (![syncServer isEqualToString:newServer]) {
 		syncServer = [newServer copy];
 		[self setString:syncServer forKey:MAPref_SyncServer];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_SyncGoogleReaderChange" object:nil];
@@ -1127,8 +1092,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setSyncScheme:(NSString *)newScheme
 {
-    if (![syncScheme isEqualToString:newScheme])
-    {
+    if (![syncScheme isEqualToString:newScheme]) {
         syncScheme = [newScheme copy];
         [self setString:syncScheme forKey:MAPref_SyncScheme];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_SyncGoogleReaderChange" object:nil];
@@ -1145,8 +1109,7 @@ static Preferences * _standardPreferences = nil;
  */
 -(void)setSyncingUser:(NSString *)newUser
 {
-	if (![syncingUser isEqualToString:newUser])
-	{
+	if (![syncingUser isEqualToString:newUser]) {
 		syncingUser = [newUser copy];
 		[self setString:syncingUser forKey:MAPref_SyncingUser];
 		[[NSNotificationCenter defaultCenter] postNotificationName:@"MA_Notify_SyncGoogleReaderChange" object:nil];

--- a/Vienna/Sources/Preferences window/SyncingPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/SyncingPreferencesViewController.m
@@ -69,14 +69,14 @@ static NSString *syncingUser;
     }
     serverURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@", syncScheme, serverAndPath]];
     NSString * thePassword = [VNAKeychain getGenericPasswordFromKeychain:syncingUser serviceName:@"Vienna sync"];
-    if (!thePassword)
+    if (!thePassword) {
         thePassword=@"";
+    }
     username.stringValue = syncingUser;
     openReaderHost.stringValue = serverAndPath;
     password.stringValue = thePassword;
     
-    if(!prefs.syncGoogleReader)
-    {
+    if (!prefs.syncGoogleReader) {
         [openReaderSource setEnabled:NO];
         [openReaderHost setEnabled:NO];
         [username setEnabled:NO];
@@ -88,38 +88,32 @@ static NSString *syncingUser;
     // is a dictionary with display names which act as keys, host names and a help text
     // regarding credentials to enter. This allows us to support additional service
     // providers without having to write new code.
-    if (!sourcesDict)
-    {
+    if (!sourcesDict) {
         NSBundle *thisBundle = [NSBundle bundleForClass:[self class]];
         NSString * pathToPList = [thisBundle pathForResource:@"KnownSyncServers" ofType:@"plist"];
-        if (pathToPList != nil)
-        {
+        if (pathToPList != nil) {
             sourcesDict = [NSDictionary dictionaryWithContentsOfFile:pathToPList];
             [openReaderSource removeAllItems];
-            if (sourcesDict)
-            {
+            if (sourcesDict) {
                 [openReaderSource setEnabled:YES];
                 BOOL match = NO;
-                for (NSString * key in sourcesDict)
-                {
+                for (NSString * key in sourcesDict) {
                     [openReaderSource addItemWithTitle:key];
                     NSDictionary * itemDict = [sourcesDict valueForKey:key];
-                    if ([serverAndPath isEqualToString:[itemDict valueForKey:@"Address"]])
-                    {
+                    if ([serverAndPath isEqualToString:[itemDict valueForKey:@"Address"]]) {
                         [openReaderSource selectItemWithTitle:key];
                         [self changeSource:nil];
                         match = YES;
                     }
                 }
-                if (!match)
-                {
+                if (!match) {
                     [openReaderSource selectItemWithTitle:NSLocalizedString(@"Other", nil)];
                     openReaderHost.stringValue = serverURL.absoluteString;
                 }
             }
-        }
-        else
+        } else {
             [openReaderSource setEnabled:NO];
+        }
     }
     
 }
@@ -134,8 +128,7 @@ static NSString *syncingUser;
     prefs.syncScheme = syncScheme;
     prefs.syncServer = serverAndPath;
     prefs.syncingUser = syncingUser;
-    if(syncButton.state == NSControlStateValueOn && _credentialsChanged)
-    {
+    if (syncButton.state == NSControlStateValueOn && _credentialsChanged) {
         [[OpenReader sharedManager] resetAuthentication];
         [[OpenReader sharedManager] loadSubscriptions];
     }
@@ -155,8 +148,7 @@ static NSString *syncingUser;
         [username setEnabled:YES];
         [password setEnabled:YES];
         _credentialsChanged = YES;
-    }
-    else {
+    } else {
         [openReaderSource setEnabled:NO];
         [openReaderHost setEnabled:NO];
         [username setEnabled:NO];
@@ -171,15 +163,18 @@ static NSString *syncingUser;
     NSString * key = readerItem.title;
     NSDictionary * itemDict = [sourcesDict valueForKey:key];
     NSString* hostName = [itemDict valueForKey:@"Address"];
-    if (!hostName)
+    if (!hostName) {
         hostName=@"";
+    }
     NSString* hint = [itemDict valueForKey:@"Hint"];
-    if (!hint)
+    if (!hint) {
         hint=@"";
+    }
     openReaderHost.stringValue = hostName;
     credentialsInfoText.stringValue = hint;
-    if (sender != nil)	//user action
+    if (sender != nil) {	//user action
         [self handleServerTextDidChange:nil];
+    }
 }
 
 - (IBAction)visitWebsite:(id)sender
@@ -209,12 +204,10 @@ static NSString *syncingUser;
         serverAndPath = theString;
     }
     serverURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@", syncScheme, serverAndPath]];
-    if ( !((openReaderHost.stringValue).vna_isBlank || (username.stringValue).vna_isBlank) )
-    {
+    if ( !((openReaderHost.stringValue).vna_isBlank || (username.stringValue).vna_isBlank) ) {
         // can we get password via keychain ?
         NSString * thePass = [VNAKeychain getWebPasswordFromKeychain:username.stringValue url:[NSString stringWithFormat:@"%@://%@", syncScheme, serverURL.host]];
-        if (!thePass.vna_isBlank)
-        {
+        if (!thePass.vna_isBlank) {
             password.stringValue = thePass;
             [VNAKeychain setGenericPasswordInKeychain:thePass username:username.stringValue service:@"Vienna sync"];
         }
@@ -231,12 +224,10 @@ static NSString *syncingUser;
     _credentialsChanged = YES;
     Preferences *prefs = [Preferences standardPreferences];
     [VNAKeychain deleteGenericPasswordInKeychain:prefs.syncingUser service:@"Vienna sync"];
-    if ( !((openReaderHost.stringValue).vna_isBlank || (username.stringValue).vna_isBlank) )
-    {
+    if ( !((openReaderHost.stringValue).vna_isBlank || (username.stringValue).vna_isBlank) ) {
         // can we get password via keychain ?
         NSString * thePass = [VNAKeychain getWebPasswordFromKeychain:username.stringValue url:[NSString stringWithFormat:@"%@://%@", syncScheme, serverURL.host]];
-        if (!thePass.vna_isBlank)
-        {
+        if (!thePass.vna_isBlank) {
             password.stringValue = thePass;
             [VNAKeychain setGenericPasswordInKeychain:password.stringValue username:username.stringValue service:@"Vienna sync"];
         }
@@ -257,8 +248,7 @@ static NSString *syncingUser;
 
 -(void)handleGoogleAuthFailed:(NSNotification *)nc
 {    
-    if (self.view.window.visible)
-    {
+    if (self.view.window.visible) {
         NSAlert *alert = [NSAlert new];
         alert.messageText = NSLocalizedString(@"Open Reader Authentication Failed",nil);
         if (![nc.object isEqualToString:@""]) {

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -71,12 +71,12 @@ NSMenuItem * menuItemWithAction(SEL theSelector)
 	NSInteger count = arrayOfMenus.count;
 	NSInteger index;
 
-	for (index = 0; index < count; ++index)
-	{
+	for (index = 0; index < count; ++index) {
 		NSMenu * subMenu = [arrayOfMenus[index] submenu];
 		NSInteger itemIndex = [subMenu indexOfItemWithTarget:NSApp.delegate andAction:theSelector];
-		if (itemIndex >= 0)
+		if (itemIndex >= 0) {
 			return [subMenu itemAtIndex:itemIndex];
+		}
 	}
 	return nil;
 }
@@ -149,20 +149,19 @@ void loadMapFromPath(NSString * path, NSMutableDictionary * pathMappings, BOOL f
 {
 	NSFileManager * fileManager = [NSFileManager defaultManager];
 	NSArray * arrayOfFiles = [fileManager contentsOfDirectoryAtPath:path error:nil];
-	if (arrayOfFiles != nil)
-	{
-		if (validExtensions)
+	if (arrayOfFiles != nil) {
+		if (validExtensions) {
 			arrayOfFiles = [arrayOfFiles pathsMatchingExtensions:validExtensions];
+		}
 		
-		for (NSString * fileName in arrayOfFiles)
-		{
+		for (NSString * fileName in arrayOfFiles) {
 			NSString * fullPath = [path stringByAppendingPathComponent:fileName];
 			BOOL isDirectory;
 			
-			if ([fileManager fileExistsAtPath:fullPath isDirectory:&isDirectory] && (isDirectory == foldersOnly))
-			{
-				if ([fileName isEqualToString:@".DS_Store"])
+			if ([fileManager fileExistsAtPath:fullPath isDirectory:&isDirectory] && (isDirectory == foldersOnly)) {
+				if ([fileName isEqualToString:@".DS_Store"]) {
 					continue;
+				}
 
 				[pathMappings setValue:fullPath forKey:fileName.stringByDeletingPathExtension];
 			}
@@ -182,17 +181,17 @@ BOOL isAccessible(NSString * urlString)
 	NSURL * url = [NSURL URLWithString:urlString];
 
 	target = SCNetworkReachabilityCreateWithName(NULL, url.host.UTF8String);
-    if (target!= nil)
-    {
+    if (target!= nil) {
         ok = SCNetworkReachabilityGetFlags(target, &flags);
         CFRelease(target);
 
-        if (!ok)
+        if (!ok) {
             return NO;
+        }
         return (flags & kSCNetworkReachabilityFlagsReachable) && !(flags & kSCNetworkReachabilityFlagsConnectionRequired);
-    }
-    else
+    } else {
         return NO;
+    }
 }
 
 void runOKAlertPanelPlain(NSString * titleString, NSString * bodyText) {

--- a/Vienna/Sources/Shared/StringExtensions.m
+++ b/Vienna/Sources/Shared/StringExtensions.m
@@ -40,8 +40,9 @@
 -(void)vna_fixupRelativeImgTags:(NSString *)baseURL
 {
 	baseURL = [NSString vna_stringByCleaningURLString:baseURL];
-	if (baseURL == nil)
+	if (baseURL == nil) {
 		return;
+	}
 	NSURL * imgBaseURL = [NSURL URLWithString:baseURL];
 	
 	NSUInteger textLength = self.length;
@@ -49,29 +50,24 @@
 	
 	srchRange.location = 0;
 	srchRange.length = textLength;
-    while ((void)((srchRange = [self rangeOfString:@"<img" options:NSLiteralSearch range:srchRange])), srchRange.location != NSNotFound)
-    {
+    while ((void)((srchRange = [self rangeOfString:@"<img" options:NSLiteralSearch range:srchRange])), srchRange.location != NSNotFound) {
         srchRange.length = textLength - srchRange.location;
         NSRange srcRange = [self rangeOfString:@"src=\"" options:NSLiteralSearch range:srchRange];
-        if (srcRange.location != NSNotFound)
-        {
+        if (srcRange.location != NSNotFound) {
             // Find the src parameter range.
             NSUInteger index = srcRange.location + srcRange.length;
             srcRange.location += srcRange.length;
             srcRange.length = 0;
-            while (index < textLength && [self characterAtIndex:index] != '"')
-            {
+            while (index < textLength && [self characterAtIndex:index] != '"') {
                 ++index;
                 ++srcRange.length;
             }
             
             // Now extract the source parameter
             NSString * srcPath = [self substringWithRange:srcRange];
-            if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"] && ![srcPath hasPrefix:@"data:"])
-            {
+            if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"] && ![srcPath hasPrefix:@"data:"]) {
                 NSURL * imgURL = [NSURL URLWithString:srcPath relativeToURL:imgBaseURL];
-                if (imgURL != nil)
-                {
+                if (imgURL != nil) {
                     srcPath = imgURL.absoluteString;
                     [self replaceCharactersInRange:srcRange withString:srcPath];
                     textLength = self.length;
@@ -80,9 +76,9 @@
             
             // Start searching again from beyond the URL
             srchRange.location = srcRange.location + srcPath.length;
-        }
-        else
+        } else {
             ++srchRange.location;
+        }
         srchRange.length = textLength - srchRange.location;
     }
 }
@@ -94,8 +90,9 @@
 -(void)vna_fixupRelativeAnchorTags:(NSString *)baseURL
 {
 	baseURL = [NSString vna_stringByCleaningURLString:baseURL];
-	if (baseURL == nil)
+	if (baseURL == nil) {
 		return;
+	}
 	NSURL * anchorBaseURL = [NSURL URLWithString:baseURL];
 
 	NSUInteger textLength = self.length;
@@ -103,29 +100,24 @@
 
 	srchRange.location = 0;
 	srchRange.length = textLength;
-    while ((void)((srchRange = [self rangeOfString:@"<a " options:NSLiteralSearch range:srchRange])), srchRange.location != NSNotFound)
-	{
+    while ((void)((srchRange = [self rangeOfString:@"<a " options:NSLiteralSearch range:srchRange])), srchRange.location != NSNotFound) {
 		srchRange.length = textLength - srchRange.location;
 		NSRange srcRange = [self rangeOfString:@"href=\"" options:NSLiteralSearch range:srchRange];
-		if (srcRange.location != NSNotFound)
-		{
+		if (srcRange.location != NSNotFound) {
 			// Find the src parameter range.
 			NSUInteger index = srcRange.location + srcRange.length;
 			srcRange.location += srcRange.length;
 			srcRange.length = 0;
-			while (index < textLength && [self characterAtIndex:index] != '"')
-			{
+			while (index < textLength && [self characterAtIndex:index] != '"') {
 				++index;
 				++srcRange.length;
 			}
 
 			// Now extract the source parameter
 			NSString * srcPath = [self substringWithRange:srcRange];
-			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"] && ![srcPath hasPrefix:@"#"])
-			{
+			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"] && ![srcPath hasPrefix:@"#"]) {
                 NSURL * anchorURL = [NSURL URLWithString:srcPath relativeToURL:anchorBaseURL];
-                if (anchorURL != nil)
-                {
+                if (anchorURL != nil) {
                     srcPath = anchorURL.absoluteString;
                     [self replaceCharactersInRange:srcRange withString:srcPath];
                     textLength = self.length;
@@ -134,9 +126,9 @@
 
 			// Start searching again from beyond the URL
 			srchRange.location = srcRange.location + srcPath.length;
-		}
-		else
+		} else {
 			++srchRange.location;
+		}
 		srchRange.length = textLength - srchRange.location;
 	}
 }
@@ -148,8 +140,9 @@
 -(void)vna_fixupRelativeIframeTags:(NSString *)baseURL
 {
 	baseURL = [NSString vna_stringByCleaningURLString:baseURL];
-	if (baseURL == nil)
+	if (baseURL == nil) {
 		return;
+	}
 	NSURL * imgBaseURL = [NSURL URLWithString:baseURL];
 
 	NSUInteger textLength = self.length;
@@ -157,29 +150,24 @@
 
 	srchRange.location = 0;
 	srchRange.length = textLength;
-    while ((void)((srchRange = [self rangeOfString:@"<iframe" options:NSLiteralSearch range:srchRange])), srchRange.location != NSNotFound)
-	{
+    while ((void)((srchRange = [self rangeOfString:@"<iframe" options:NSLiteralSearch range:srchRange])), srchRange.location != NSNotFound) {
 		srchRange.length = textLength - srchRange.location;
 		NSRange srcRange = [self rangeOfString:@"src=\"" options:NSLiteralSearch range:srchRange];
-		if (srcRange.location != NSNotFound)
-		{
+		if (srcRange.location != NSNotFound) {
 			// Find the src parameter range.
 			NSUInteger index = srcRange.location + srcRange.length;
 			srcRange.location += srcRange.length;
 			srcRange.length = 0;
-			while (index < textLength && [self characterAtIndex:index] != '"')
-			{
+			while (index < textLength && [self characterAtIndex:index] != '"') {
 				++index;
 				++srcRange.length;
 			}
 
 			// Now extract the source parameter
 			NSString * srcPath = [self substringWithRange:srcRange];
-			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"])
-			{
+			if (![srcPath hasPrefix:@"http:"] && ![srcPath hasPrefix:@"https:"]) {
                 NSURL * iframeURL = [NSURL URLWithString:srcPath relativeToURL:imgBaseURL];
-                if (iframeURL != nil)
-                {
+                if (iframeURL != nil) {
                     srcPath = iframeURL.absoluteString;
                     [self replaceCharactersInRange:srcRange withString:srcPath];
                     textLength = self.length;
@@ -188,9 +176,9 @@
 
 			// Start searching again from beyond the URL
 			srchRange.location = srcRange.location + srcPath.length;
-		}
-		else
+		} else {
 			++srchRange.location;
+		}
 		srchRange.length = textLength - srchRange.location;
 	}
 }
@@ -210,17 +198,17 @@ static NSMutableDictionary * entityMap = nil;
 	NSInteger intValue = 0;
 	NSInteger index = 0;
 
-	while (index < count)
-	{
+	while (index < count) {
 		unichar ch = [self characterAtIndex:index];
-		if (ch >= '0' && ch <= '9')
+		if (ch >= '0' && ch <= '9') {
 			intValue = (intValue * 16) + (ch - '0');
-		else if (ch >= 'A' && ch <= 'F')
+		} else if (ch >= 'A' && ch <= 'F') {
 			intValue = (intValue * 16) + (ch - 'A' + 10);
-		else if (ch >= 'a' && ch <= 'f')
+		} else if (ch >= 'a' && ch <= 'f') {
 			intValue = (intValue * 16) + (ch - 'a' + 10);
-		else
+		} else {
 			break;
+		}
 		++index;
 	}
 	return intValue;
@@ -334,17 +322,15 @@ static NSMutableDictionary * entityMap = nil;
 	NSInteger length = string.length;
 	NSInteger index = 0;
 	
-	while (index < length)
-	{
+	while (index < length) {
 		unichar ch = [string characterAtIndex:index];
-		if (ch == '\r' || ch == '\n' || ch == '\t')
-		{
-			if (!isInWhitespace)
+		if (ch == '\r' || ch == '\n' || ch == '\t') {
+			if (!isInWhitespace) {
 				[string replaceCharactersInRange:NSMakeRange(index, 1) withString:@" "];
+			}
 			ch = ' ';
 		}
-		if (ch == ' ' && isInWhitespace)
-		{
+		if (ch == ' ' && isInWhitespace) {
 			[string deleteCharactersInRange:NSMakeRange(index, 1)];
 			--index;
 			--length;
@@ -367,22 +353,15 @@ static NSMutableDictionary * entityMap = nil;
 	
 	NSUInteger indexOfChr = 0;
 	NSUInteger length = self.length;
-	while (indexOfChr < length)
-	{
+	while (indexOfChr < length) {
 		unichar ch = [self characterAtIndex:indexOfChr];
-		if (ch == '\r' || ch == '\n')
-		{
-			if (hasNonEmptyChars)
-			{
+		if (ch == '\r' || ch == '\n') {
+			if (hasNonEmptyChars) {
 				break;
 			}
-		}
-		else
-		{
-			if (ch != ' ' && ch != '\t')
-			{
-				if (!hasNonEmptyChars)
-				{
+		} else {
+			if (ch != ' ' && ch != '\t') {
+				if (!hasNonEmptyChars) {
 					hasNonEmptyChars = YES;
 					indexOfFirstChr = indexOfChr;
 				}
@@ -404,13 +383,11 @@ static NSMutableDictionary * entityMap = nil;
 	NSInteger length = escapedString.length;
 	NSInteger index = 0;
 
-	while (index < length)
-	{
+	while (index < length) {
 		unichar ch = [escapedString characterAtIndex:index];
-		if (ch <= 127)
+		if (ch <= 127) {
 			++index;
-		else
-		{
+		} else {
 			NSString * escapedCharacter = [NSString stringWithFormat:@"&#%d;", ch];
 			[escapedString replaceCharactersInRange:NSMakeRange(index, 1) withString:escapedCharacter];
 			index += escapedCharacter.length;
@@ -431,11 +408,9 @@ static NSMutableDictionary * entityMap = nil;
 	NSUInteger entityEnd;
 	
 	entityStart = [processedString vna_indexOfCharacterInString:'&' afterIndex:0];
-	while (entityStart != NSNotFound)
-	{
+	while (entityStart != NSNotFound) {
 		entityEnd = [processedString vna_indexOfCharacterInString:';' afterIndex:entityStart + 1];
-		if (entityEnd != NSNotFound)
-		{
+		if (entityEnd != NSNotFound) {
 			NSRange entityRange = NSMakeRange(entityStart, (entityEnd - entityStart) + 1);
 			NSRange innerEntityRange = NSMakeRange(entityRange.location + 1, entityRange.length - 2);
 			NSString * entityString = [processedString substringWithRange:innerEntityRange];
@@ -453,8 +428,7 @@ static NSMutableDictionary * entityMap = nil;
  */
 +(NSString *)vna_mapEntityToString:(NSString *)entityString
 {
-	if (entityMap == nil)
-	{
+	if (entityMap == nil) {
 		entityMap = [@{
 					   @"lt":		@"<",
 					   @"gt":		@">",
@@ -567,13 +541,13 @@ static NSMutableDictionary * entityMap = nil;
 	}
 	
 	// Parse off numeric codes of the format #xxx
-	if (entityString.length > 1 && [entityString characterAtIndex:0] == '#')
-	{
+	if (entityString.length > 1 && [entityString characterAtIndex:0] == '#') {
 		NSInteger intValue;
-		if ([entityString characterAtIndex:1] == 'x')
+		if ([entityString characterAtIndex:1] == 'x') {
 			intValue = [entityString substringFromIndex:2].vna_hexValue;
-		else
+		} else {
 			intValue = [entityString substringFromIndex:1].integerValue;
+		}
 		return [NSString stringWithFormat:@"%C", (unsigned short)MAX(intValue, ' ')];
 	}
 	
@@ -590,12 +564,13 @@ static NSMutableDictionary * entityMap = nil;
 	NSUInteger length = self.length;
 	NSUInteger index;
 
-	if (startIndex < length - 1)
-		for (index = startIndex; index < length; ++index)
-		{
-			if ([self characterAtIndex:index] == ch)
+	if (startIndex < length - 1) {
+		for (index = startIndex; index < length; ++index) {
+			if ([self characterAtIndex:index] == ch) {
 				return index;
+			}
 		}
+	}
 	return NSNotFound;
 }
 

--- a/Vienna/Sources/Shared/SubscriptionModel.m
+++ b/Vienna/Sources/Shared/SubscriptionModel.m
@@ -39,8 +39,7 @@
     
     // OK. Now we're at the point where can't be reasonably sure that
     // the URL points to a feed. Time to look at the content.
-    if (rssFeedURL.scheme == nil)
-    {
+    if (rssFeedURL.scheme == nil) {
         rssFeedURL = [NSURL URLWithString:[@"http://" stringByAppendingString:rssFeedURL.absoluteString]];
     }
 

--- a/Vienna/Sources/Shared/TableViewExtensions.m
+++ b/Vienna/Sources/Shared/TableViewExtensions.m
@@ -35,8 +35,7 @@
  */
 -(void)setDelegate:(id)delegate
 {
-    if (delegate != self.delegate)
-	{
+    if (delegate != self.delegate) {
         super.delegate = delegate;
 		delegateImplementsShouldDisplayToolTips = ((delegate && [delegate respondsToSelector:@selector(tableViewShouldDisplayCellToolTips:)]) ? YES : NO);
 		delegateImplementsToolTip = ((delegate && [delegate respondsToSelector:@selector(tableView:toolTipForTableColumn:row:)]) ? YES : NO);
@@ -59,8 +58,7 @@
 -(void)resetCursorRects
 {
 	[self removeAllToolTips];
-    if (delegateImplementsShouldDisplayToolTips && [(id)self.delegate tableViewShouldDisplayCellToolTips:self])
-	{
+    if (delegateImplementsShouldDisplayToolTips && [(id)self.delegate tableViewShouldDisplayCellToolTips:self]) {
 		NSRect visibleRect = self.visibleRect;
 		NSIndexSet *columnIndexes = [self columnIndexesInRect:visibleRect];
 		NSRange rowRange = [self rowsInRect:visibleRect];
@@ -68,10 +66,8 @@
 		NSInteger col, row;
 		
 		col = columnIndexes.firstIndex;
-		while (col != NSNotFound)
-		{
-			for (row = rowRange.location; row < rowRange.location + rowRange.length; row++)
-			{
+		while (col != NSNotFound) {
+			for (row = rowRange.location; row < rowRange.location + rowRange.length; row++) {
 				frameOfCell = [self frameOfCellAtColumn:col row:row];
 				[self addToolTipRect:frameOfCell owner:self userData:NULL];
 			}
@@ -96,8 +92,9 @@
  */
 -(NSMenu *)menuForEvent:(NSEvent *)theEvent
 {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(tableView:menuWillAppear:)])
+    if (self.delegate && [self.delegate respondsToSelector:@selector(tableView:menuWillAppear:)]) {
         [(id)self.delegate tableView:self menuWillAppear:theEvent];
+    }
 	return self.selectedRow >= 0 ? self.menu : nil;
 }
 


### PR DESCRIPTION
- Adds braces to if/else statements (using ClangTidy)
- Puts else statements on the same indentation level
- Enables Clang Analyzer warnings for the aforementioned changes

Previously proposed here: #1397

It turns out that Xcode actually has had ClangTidy diagnostics built in all along, it's just hidden behind private configurations.