### PR TITLE
Add ObserverContext to KVO handlers

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -61,6 +61,8 @@
 
 #define VNA_LOG os_log_create("--", "AppController")
 
+static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
+
 @interface AppController () <InfoPanelControllerDelegate, ActivityPanelControllerDelegate, NSMenuItemValidation, NSToolbarItemValidation>
 
 -(void)installScriptsFolderWatcher;
@@ -295,7 +297,7 @@
     [self.pluginManager addObserver:self
                          forKeyPath:NSStringFromSelector(@selector(numberOfPlugins))
                             options:0
-                            context:nil];
+                            context:VNAAppControllerObserverContext];
 
 	// Load the styles into the main menu.
     [self populateStyleMenu];
@@ -1223,7 +1225,16 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 - (void)observeValueForKeyPath:(NSString *)keyPath
                       ofObject:(id)object
                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
-                       context:(void *)context {
+                       context:(void *)context
+{
+    if (context != VNAAppControllerObserverContext) {
+        [super observeValueForKeyPath:keyPath
+                             ofObject:object
+                               change:change
+                              context:context];
+        return;
+    }
+
     if ([keyPath isEqualToString:NSStringFromSelector(@selector(numberOfPlugins))]) {
         NSMenu *menu = ((ViennaApp *)NSApp).articleMenu;
 
@@ -3571,7 +3582,8 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)dealloc
 {
     [self.pluginManager removeObserver:self
-                            forKeyPath:NSStringFromSelector(@selector(numberOfPlugins))];
+                            forKeyPath:NSStringFromSelector(@selector(numberOfPlugins))
+                               context:VNAAppControllerObserverContext];
 
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -42,7 +42,7 @@
 // Shared defaults key
 NSString * const MAPref_ShowEnclosureBar = @"ShowEnclosureBar";
 
-static void *ObserverContext = &ObserverContext;
+static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverContext;
 
 @interface ArticleListView ()
 
@@ -182,11 +182,11 @@ static void *ObserverContext = &ObserverContext;
     [userDefaults addObserver:self
                    forKeyPath:MAPref_ShowEnclosureBar
                       options:NSKeyValueObservingOptionNew
-                      context:ObserverContext];
+                      context:VNAArticleListViewObserverContext];
     [userDefaults addObserver:self
                    forKeyPath:MAPref_ShowUnreadArticlesInBold
                       options:0
-                      context:ObserverContext];
+                      context:VNAArticleListViewObserverContext];
 }
 
 /* initTableView
@@ -1651,10 +1651,10 @@ static void *ObserverContext = &ObserverContext;
     NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
     [userDefaults removeObserver:self
                       forKeyPath:MAPref_ShowEnclosureBar
-                         context:ObserverContext];
+                         context:VNAArticleListViewObserverContext];
     [userDefaults removeObserver:self
                       forKeyPath:MAPref_ShowUnreadArticlesInBold
-                         context:ObserverContext];
+                         context:VNAArticleListViewObserverContext];
 	[splitView2 setDelegate:nil];
 	[articleList setDelegate:nil];
 }
@@ -1666,7 +1666,7 @@ static void *ObserverContext = &ObserverContext;
                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
                        context:(void *)context
 {
-    if (context != ObserverContext) {
+    if (context != VNAArticleListViewObserverContext) {
         [super observeValueForKeyPath:keyPath
                              ofObject:object
                                change:change

--- a/Vienna/Sources/Main window/FolderView.m
+++ b/Vienna/Sources/Main window/FolderView.m
@@ -33,8 +33,6 @@ VNAFeedListRowHeight const VNAFeedListRowHeightTiny = 20.0;
 VNAFeedListRowHeight const VNAFeedListRowHeightSmall = 24.0;
 VNAFeedListRowHeight const VNAFeedListRowHeightMedium = 28.0;
 
-static void *ObserverContext = &ObserverContext;
-
 @interface FolderView ()
 
 @property (weak, nonatomic) IBOutlet NSView *floatingResetButtonView;

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -37,7 +37,7 @@
 NSString * const MAPref_FeedListSizeMode = @"FeedListSizeMode";
 NSString * const MAPref_ShowFeedsWithUnreadItemsInBold = @"ShowFeedsWithUnreadItemsInBold";
 
-static void *ObserverContext = &ObserverContext;
+static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 
 @interface FoldersTree ()
 
@@ -122,11 +122,11 @@ static void *ObserverContext = &ObserverContext;
     [userDefaults addObserver:self
                    forKeyPath:MAPref_FeedListSizeMode
                       options:0
-                      context:ObserverContext];
+                      context:VNAFoldersTreeObserverContext];
     [userDefaults addObserver:self
                    forKeyPath:MAPref_ShowFeedsWithUnreadItemsInBold
                       options:0
-                      context:ObserverContext];
+                      context:VNAFoldersTreeObserverContext];
 }
 
 - (void)dealloc
@@ -136,10 +136,10 @@ static void *ObserverContext = &ObserverContext;
     NSUserDefaults *userDefaults;
     [userDefaults removeObserver:self
                       forKeyPath:MAPref_FeedListSizeMode
-                         context:ObserverContext];
+                         context:VNAFoldersTreeObserverContext];
     [userDefaults removeObserver:self
                       forKeyPath:MAPref_ShowFeedsWithUnreadItemsInBold
-                         context:ObserverContext];
+                         context:VNAFoldersTreeObserverContext];
 }
 
 -(void)handleOpenReaderFolderChange:(NSNotification *)nc
@@ -1105,7 +1105,7 @@ static void *ObserverContext = &ObserverContext;
                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
                        context:(void *)context
 {
-    if (context != ObserverContext) {
+    if (context != VNAFoldersTreeObserverContext) {
         [super observeValueForKeyPath:keyPath
                              ofObject:object
                                change:change

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -40,6 +40,8 @@
 #define YPOS_IN_CELL	2.0
 #define PROGRESS_INDICATOR_DIMENSION 16
 
+static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserverContext;
+
 @interface UnifiedDisplayView () <CustomWKHoverUIDelegate>
 
 @property (nonatomic) OverlayStatusBar *statusBar;
@@ -144,7 +146,7 @@
     [NSUserDefaults.standardUserDefaults addObserver:self
                                           forKeyPath:MAPref_ShowStatusBar
                                              options:NSKeyValueObservingOptionInitial
-                                             context:nil];
+                                             context:VNAUnifiedDisplayViewObserverContext];
 }
 
 /* dealloc
@@ -153,7 +155,8 @@
 -(void)dealloc
 {
     [NSUserDefaults.standardUserDefaults removeObserver:self
-                                             forKeyPath:MAPref_ShowStatusBar];
+                                             forKeyPath:MAPref_ShowStatusBar
+                                                context:VNAUnifiedDisplayViewObserverContext];
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[articleList setDataSource:nil];
 	[articleList setDelegate:nil];
@@ -813,7 +816,16 @@
 - (void)observeValueForKeyPath:(NSString *)keyPath
                       ofObject:(id)object
                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
-                       context:(void *)context {
+                       context:(void *)context
+{
+    if (context != VNAUnifiedDisplayViewObserverContext) {
+        [super observeValueForKeyPath:keyPath
+                             ofObject:object
+                               change:change
+                              context:context];
+        return;
+    }
+
     if ([keyPath isEqualToString:MAPref_ShowStatusBar]) {
         BOOL isStatusBarShown = [Preferences standardPreferences].showStatusBar;
         if (isStatusBarShown && !self.statusBar) {


### PR DESCRIPTION
Apple recommends using an address of a static variable as a context pointer to filter out unrelated observer callbacks. If the context is unrelated then the callback should be passed on to the super class.

https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/KeyValueObserving/Articles/KVOBasics.html