### PR TITLE
Update SecurityScopedBookmark code

### DIFF
--- a/Vienna/Sources/Download window/DownloadManager.m
+++ b/Vienna/Sources/Download window/DownloadManager.m
@@ -199,11 +199,24 @@
     NSData *data = [userDefaults dataForKey:MAPref_DownloadsFolderBookmark];
 
     if (data) {
-        NSError *error = nil;
-        VNASecurityScopedBookmark *bookmark = [[VNASecurityScopedBookmark alloc] initWithBookmarkData:data
-                                                                                                error:&error];
+        BOOL bookmarkDataIsStale = NO;
+        NSError *bookmarkInitError;
+        VNASecurityScopedBookmark *bookmark =
+            [[VNASecurityScopedBookmark alloc] initWithBookmarkData:data
+                                                bookmarkDataIsStale:&bookmarkDataIsStale
+                                                              error:&bookmarkInitError];
+        if (!bookmarkInitError) {
+            if (bookmarkDataIsStale) {
+                NSError *bookmarkResolveError;
+                NSData *bookmarkData =
+                    [VNASecurityScopedBookmark bookmarkDataFromFileURL:bookmark.resolvedURL
+                                                                 error:&bookmarkResolveError];
+                if (!bookmarkResolveError) {
+                    [userDefaults setObject:bookmarkData
+                                     forKey:MAPref_DownloadsFolderBookmark];
+                }
+            }
 
-        if (!error) {
             downloadFolderURL = bookmark.resolvedURL;
         }
     }

--- a/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
@@ -89,10 +89,24 @@
     NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
     NSData *data = [userDefaults dataForKey:MAPref_DownloadsFolderBookmark];
     if (data) {
-        NSError *error = nil;
-        VNASecurityScopedBookmark *bookmark = [[VNASecurityScopedBookmark alloc] initWithBookmarkData:data
-                                                                                                error:&error];
-        if (!error) {
+        BOOL bookmarkDataIsStale = NO;
+        NSError *bookmarkInitError;
+        VNASecurityScopedBookmark *bookmark =
+            [[VNASecurityScopedBookmark alloc] initWithBookmarkData:data
+                                                bookmarkDataIsStale:&bookmarkDataIsStale
+                                                              error:&bookmarkInitError];
+        if (!bookmarkInitError) {
+            if (bookmarkDataIsStale) {
+                NSError *bookmarkResolveError;
+                NSData *bookmarkData =
+                    [VNASecurityScopedBookmark bookmarkDataFromFileURL:bookmark.resolvedURL
+                                                                 error:&bookmarkResolveError];
+                if (!bookmarkResolveError) {
+                    [userDefaults setObject:bookmarkData
+                                     forKey:MAPref_DownloadsFolderBookmark];
+                }
+            }
+
             [self updateDownloadsPopUp:bookmark.resolvedURL.path];
         }
     }
@@ -260,8 +274,8 @@
                       completionHandler:^(NSInteger returnCode) {
         if (returnCode == NSModalResponseOK) {
             NSError *error = nil;
-            NSData *data = [VNASecurityScopedBookmark bookmark:openPanel.URL
-                                                         error:&error];
+            NSData *data = [VNASecurityScopedBookmark bookmarkDataFromFileURL:openPanel.URL
+                                                                        error:&error];
             if (!error) {
                 NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
                 [userDefaults setObject:data forKey:MAPref_DownloadsFolderBookmark];


### PR DESCRIPTION
This implements the `bookmarkDataIsStale` value of NSURL/URL. The NSURL documentation states that stale bookmark data should be refreshed. It neither indicates when bookmark data is "stale" nor what happens if stale bookmark data is used. This is a precaution.