### PR TITLE
Update DirectoryMonitor code

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -96,7 +96,7 @@
 @property (nonatomic) MainWindowController *mainWindowController;
 @property (weak, nonatomic) NSWindow *mainWindow;
 @property (nonatomic) ActivityPanelController *activityPanelController;
-@property (nonatomic) DirectoryMonitor *directoryMonitor;
+@property (nonatomic) VNADirectoryMonitor *directoryMonitor;
 @property (nonatomic) NSWindowController *preferencesWindowController;
 @property (weak, nonatomic) FolderView *outlineView;
 @property (weak, nonatomic) DisclosureView *filterDisclosureView;
@@ -200,13 +200,15 @@
  */
 - (void)installScriptsFolderWatcher {
     NSURL *path = NSFileManager.defaultManager.vna_applicationScriptsDirectory;
-    self.directoryMonitor = [[DirectoryMonitor alloc] initWithDirectories:@[path]];
-
-    NSError *error = nil;
+    self.directoryMonitor = [[VNADirectoryMonitor alloc] initWithDirectories:@[path]];
     typeof(self) __weak weakSelf = self;
-    [self.directoryMonitor startAndReturnError:&error eventHandler:^{
+    void (^handler)(void) = ^{
         [weakSelf initScriptsMenu];
-    }];
+    };
+    NSError *error;
+    [self.directoryMonitor startWithEventHandler:handler
+                                   dispatchQueue:dispatch_get_main_queue()
+                                           error:&error];
     if (error) {
         os_log_error(VNA_LOG, "Failed to watch scripts directory. Reason: %{public}@", error.localizedDescription);
     }


### PR DESCRIPTION
This replaces a deprecated function `FSEventStreamScheduleWithRunLoop(_:_:_:)` and fixes a logging issue.