### PR TITLE
Update ExtendedTableView code

### DIFF
--- a/Vienna/Sources/Download window/DownloadWindow.h
+++ b/Vienna/Sources/Download window/DownloadWindow.h
@@ -20,7 +20,9 @@
 
 @import Cocoa;
 
-@interface DownloadWindow : NSWindowController <NSWindowDelegate, NSMenuDelegate, NSTableViewDelegate, NSTableViewDataSource>
+#import "TableViewExtensions.h"
+
+@interface DownloadWindow : NSWindowController <NSWindowDelegate, NSMenuDelegate, ExtendedTableViewDelegate, NSTableViewDataSource>
 
 // Public functions
 -(IBAction)clearList:(id)sender;

--- a/Vienna/Sources/Download window/DownloadWindow.m
+++ b/Vienna/Sources/Download window/DownloadWindow.m
@@ -26,7 +26,6 @@
 #import "DownloadManager.h"
 #import "HelperFunctions.h"
 #import "ImageAndTextCell.h"
-#import "TableViewExtensions.h"
 #import "NSWorkspace+OpenWithMenu.h"
 
 @implementation DownloadWindow {

--- a/Vienna/Sources/Main window/ArticleListView.h
+++ b/Vienna/Sources/Main window/ArticleListView.h
@@ -25,7 +25,7 @@
 #import "ArticleViewDelegate.h"
 #import "MessageListView.h"
 
-@interface ArticleListView : NSView <BaseView, ArticleBaseView, ArticleViewDelegate, MessageListViewDelegate, NSTableViewDataSource, NSSplitViewDelegate>
+@interface ArticleListView : NSView <BaseView, ArticleBaseView, ArticleViewDelegate, MessageListViewDelegate, NSTableViewDataSource, ExtendedTableViewDelegate, NSSplitViewDelegate>
 
 // Public functions
 -(void)updateVisibleColumns;

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -480,19 +480,19 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
                                        accessibilityDescription:nil];
         enclImage = [enclImage imageWithSymbolConfiguration:config];
 
-        [articleList setHeaderImage:MA_Field_Read
-                              image:readImage];
-        [articleList setHeaderImage:MA_Field_Flagged
-                              image:flagImage];
-        [articleList setHeaderImage:MA_Field_HasEnclosure
-                              image:enclImage];
+        [articleList setTableColumnHeaderImage:readImage
+                       forColumnWithIdentifier:MA_Field_Read];
+        [articleList setTableColumnHeaderImage:flagImage
+                       forColumnWithIdentifier:MA_Field_Flagged];
+        [articleList setTableColumnHeaderImage:enclImage
+                       forColumnWithIdentifier:MA_Field_HasEnclosure];
     } else {
-        [articleList setHeaderImage:MA_Field_Read
-                              image:[NSImage imageNamed:@"unread_header"]];
-        [articleList setHeaderImage:MA_Field_Flagged
-                              image:[NSImage imageNamed:@"flagged_header"]];
-        [articleList setHeaderImage:MA_Field_HasEnclosure
-                              image:[NSImage imageNamed:@"enclosure_header"]];
+        [articleList setTableColumnHeaderImage:[NSImage imageNamed:@"unread_header"]
+                       forColumnWithIdentifier:MA_Field_Read];
+        [articleList setTableColumnHeaderImage:[NSImage imageNamed:@"flagged_header"]
+                       forColumnWithIdentifier:MA_Field_Flagged];
+        [articleList setTableColumnHeaderImage:[NSImage imageNamed:@"enclosure_header"]
+                       forColumnWithIdentifier:MA_Field_HasEnclosure];
     }
 
 	// Initialise the sort direction

--- a/Vienna/Sources/Main window/MessageListView.h
+++ b/Vienna/Sources/Main window/MessageListView.h
@@ -24,7 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol MessageListViewDelegate <NSTableViewDelegate>
+@protocol MessageListViewDelegate <ExtendedTableViewDelegate>
 
 - (BOOL)canDeleteMessageAtRow:(NSInteger)row;
 
@@ -38,7 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MessageListView : ExtendedTableView <NSMenuItemValidation>
 
-@property (weak, nullable) id <MessageListViewDelegate> delegate;
+// This property overrides a superclass property.
+@property (weak, nullable) id<MessageListViewDelegate> delegate;
 
 - (void)setTableColumnHeaderImage:(NSImage *)image
           forColumnWithIdentifier:(NSUserInterfaceItemIdentifier)identifier;

--- a/Vienna/Sources/Main window/MessageListView.h
+++ b/Vienna/Sources/Main window/MessageListView.h
@@ -40,6 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nullable) id <MessageListViewDelegate> delegate;
 
+- (void)setTableColumnHeaderImage:(NSImage *)image
+          forColumnWithIdentifier:(NSUserInterfaceItemIdentifier)identifier;
+
 - (void)keyDown:(NSEvent *)theEvent;
 
 @end

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -25,6 +25,17 @@
 
 @dynamic delegate;
 
+- (void)setTableColumnHeaderImage:(NSImage *)image
+          forColumnWithIdentifier:(NSUserInterfaceItemIdentifier)identifier
+{
+    NSTableColumn *tableColumn = [self tableColumnWithIdentifier:identifier];
+    NSTableHeaderCell *headerCell = tableColumn.headerCell;
+    headerCell.image = image;
+
+    NSImageCell *imageCell = [[NSImageCell alloc] init];
+    tableColumn.dataCell = imageCell;
+}
+
 /* keyDown
  * Here is where we handle special keys when the article list view
  * has the focus so we can do custom things.

--- a/Vienna/Sources/Main window/UnifiedDisplayView.h
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.h
@@ -24,7 +24,7 @@
 
 @class AppController;
 
-@interface UnifiedDisplayView : NSView <BaseView, ArticleBaseView, NSMenuItemValidation, MessageListViewDelegate, NSTableViewDataSource>
+@interface UnifiedDisplayView : NSView <BaseView, ArticleBaseView, NSMenuItemValidation, MessageListViewDelegate, NSTableViewDataSource, ExtendedTableViewDelegate>
 
 @property (weak, nonatomic) AppController *controller;
 

--- a/Vienna/Sources/Shared/TableViewExtensions.h
+++ b/Vienna/Sources/Shared/TableViewExtensions.h
@@ -25,11 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 @class ExtendedTableView;
 
 @protocol ExtendedTableViewDelegate <NSTableViewDelegate>
-@optional
-	// Note : toolTip here should not be interpreted as expansion tooltip
-	-(BOOL)tableViewShouldDisplayCellToolTips:(ExtendedTableView *)tableView;
-	-(NSString *)tableView:(ExtendedTableView *)tableView toolTipForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex;
-	-(void)tableView:(ExtendedTableView *)tableView menuWillAppear:(NSEvent *)theEvent;
+
+- (void)tableView:(ExtendedTableView *)tableView menuWillAppear:(NSEvent *)event;
+
 @end
 
 @interface ExtendedTableView : NSTableView

--- a/Vienna/Sources/Shared/TableViewExtensions.h
+++ b/Vienna/Sources/Shared/TableViewExtensions.h
@@ -22,8 +22,6 @@
 
 @interface ExtendedTableView : NSTableView
 
--(void)setHeaderImage:(NSString *)identifier image:(NSImage *)image;
-
 @end
 
 // extend protocol NSTableViewDelegate with optional methods

--- a/Vienna/Sources/Shared/TableViewExtensions.h
+++ b/Vienna/Sources/Shared/TableViewExtensions.h
@@ -20,11 +20,10 @@
 
 @import Cocoa;
 
-@interface ExtendedTableView : NSTableView
+NS_ASSUME_NONNULL_BEGIN
 
-@end
+@class ExtendedTableView;
 
-// extend protocol NSTableViewDelegate with optional methods
 @protocol ExtendedTableViewDelegate <NSTableViewDelegate>
 @optional
 	// Note : toolTip here should not be interpreted as expansion tooltip
@@ -33,4 +32,11 @@
 	-(void)tableView:(ExtendedTableView *)tableView menuWillAppear:(NSEvent *)theEvent;
 @end
 
+@interface ExtendedTableView : NSTableView
 
+// This property overrides a superclass property.
+@property (weak, nullable) id<ExtendedTableViewDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Shared/TableViewExtensions.m
+++ b/Vienna/Sources/Shared/TableViewExtensions.m
@@ -101,17 +101,4 @@
 	return self.selectedRow >= 0 ? self.menu : nil;
 }
 
-/* setHeaderImage
- * Set the image in the header for a column
- */
--(void)setHeaderImage:(NSString *)identifier image:(NSImage *)image
-{
-	NSTableColumn * tableColumn = [self tableColumnWithIdentifier:identifier];
-	NSTableHeaderCell * headerCell = tableColumn.headerCell;
-    headerCell.image = image;
-	
-	NSImageCell * imageCell = [[NSImageCell alloc] init];
-	tableColumn.dataCell = imageCell;
-}
-@end  
-
+@end

--- a/Vienna/Sources/Shared/TableViewExtensions.m
+++ b/Vienna/Sources/Shared/TableViewExtensions.m
@@ -20,32 +20,9 @@
 
 #import "TableViewExtensions.h"
 
-@implementation ExtendedTableView {
-    BOOL delegateImplementsShouldDisplayToolTips;
-    BOOL delegateImplementsToolTip;
-}
+@implementation ExtendedTableView
 
 @dynamic delegate;
-
-/* setDelegate
- * Override the setDelegate for NSTableView so that we record whether or not the
- * delegate supports tooltips:
- *
- * toolTipForTableColumn should be implemented by the delegate to return the tooltip string for a
- * specified row of the table.
- *
- * tableViewShouldDisplayCellToolTips should be implemented by the delegate to indicate whether or
- * not tooltips should be shown. This is provided separately from toolTipForTableColumn to allow the
- * delegate to selectively turn tooltips on or off based on user preferences.
- */
--(void)setDelegate:(id)delegate
-{
-    if (delegate != self.delegate) {
-        super.delegate = delegate;
-		delegateImplementsShouldDisplayToolTips = ((delegate && [delegate respondsToSelector:@selector(tableViewShouldDisplayCellToolTips:)]) ? YES : NO);
-		delegateImplementsToolTip = ((delegate && [delegate respondsToSelector:@selector(tableView:toolTipForTableColumn:row:)]) ? YES : NO);
-	}
-}
 
 /* reloadData
  * Override the reloadData for NSTableView to reset the tooltip cursor
@@ -63,33 +40,6 @@
 -(void)resetCursorRects
 {
 	[self removeAllToolTips];
-    if (delegateImplementsShouldDisplayToolTips && [(id)self.delegate tableViewShouldDisplayCellToolTips:self]) {
-		NSRect visibleRect = self.visibleRect;
-		NSIndexSet *columnIndexes = [self columnIndexesInRect:visibleRect];
-		NSRange rowRange = [self rowsInRect:visibleRect];
-		NSRect frameOfCell;
-		NSInteger col, row;
-		
-		col = columnIndexes.firstIndex;
-		while (col != NSNotFound) {
-			for (row = rowRange.location; row < rowRange.location + rowRange.length; row++) {
-				frameOfCell = [self frameOfCellAtColumn:col row:row];
-				[self addToolTipRect:frameOfCell owner:self userData:NULL];
-			}
-			col = [columnIndexes indexGreaterThanIndex:col];
-		}
-	}
-}
-
-/* stringForToolTip
- * Request the delegate to retrieve the string to be displayed in the tooltip.
- */
--(NSString *)view:(NSView *)view stringForToolTip:(NSToolTipTag)tag point:(NSPoint)point userData:(void *)matrix
-{
-	NSInteger rowIndex = [self rowAtPoint:point];
-	NSInteger columnIndex = [self columnAtPoint:point];
-	NSTableColumn *tableColumn = (columnIndex != -1) ? self.tableColumns[columnIndex] : nil;
-    return (columnIndex != -1) ? [(id)self.delegate tableView:self toolTipForTableColumn:tableColumn row:rowIndex] : @"";
 }
 
 /* menuForEvent

--- a/Vienna/Sources/Shared/TableViewExtensions.m
+++ b/Vienna/Sources/Shared/TableViewExtensions.m
@@ -24,24 +24,6 @@
 
 @dynamic delegate;
 
-/* reloadData
- * Override the reloadData for NSTableView to reset the tooltip cursor
- * rectangles.
- */
--(void)reloadData
-{
-	[super reloadData];
-	[self resetCursorRects];
-}
-
-/* resetCursorRects
- * Compute the tooltip cursor rectangles based on the height and position of the tableview rows.
- */
--(void)resetCursorRects
-{
-	[self removeAllToolTips];
-}
-
 /* menuForEvent
  * Handle menu by moving the selection.
  */

--- a/Vienna/Sources/Shared/TableViewExtensions.m
+++ b/Vienna/Sources/Shared/TableViewExtensions.m
@@ -25,6 +25,8 @@
     BOOL delegateImplementsToolTip;
 }
 
+@dynamic delegate;
+
 /* setDelegate
  * Override the setDelegate for NSTableView so that we record whether or not the
  * delegate supports tooltips:


### PR DESCRIPTION
This a partial fix for #1455. ExtendedTableView objects (e.g. the article list) always cleared the tool tips upon refresh of the table. However, for a split second the tool tip text changes to a different text when the table is reloaded and then changes back.