### PR TITLE
Replace NSBackgroundActivityScheduler with GCD alternative

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		F685D24C292460210097C0D3 /* Predicates.strings in Resources */ = {isa = PBXBuildFile; fileRef = F685D24A292460210097C0D3 /* Predicates.strings */; };
 		F68792872700A678009B7BB5 /* SecurityScopedBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68792862700A678009B7BB5 /* SecurityScopedBookmark.swift */; };
 		F689820A281DD62B0010F4C5 /* XMLFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = F6898209281DD62B0010F4C5 /* XMLFeed.m */; };
+		F68DEBF82A35091600421FAB /* DispatchTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68DEBF72A35091600421FAB /* DispatchTimer.swift */; };
 		F68FE3A6270F6DC700C89D16 /* UnarchiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68FE3A5270F6DC700C89D16 /* UnarchiverTests.swift */; settings = {COMPILER_FLAGS = "-Wno-deprecated-type -Wno-deprecated-declarations"; }; };
 		F69140E41E71B94200D51BFF /* AppController+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = F69140E31E71B94200D51BFF /* AppController+Notifications.m */; };
 		F692559A2572A32900D387D8 /* MMTabBarView in Frameworks */ = {isa = PBXBuildFile; productRef = F69255992572A32900D387D8 /* MMTabBarView */; };
@@ -709,6 +710,7 @@
 		F6898208281DD62B0010F4C5 /* XMLFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XMLFeed.h; sourceTree = "<group>"; };
 		F6898209281DD62B0010F4C5 /* XMLFeed.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XMLFeed.m; sourceTree = "<group>"; };
 		F6898213281EE7650010F4C5 /* Feed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Feed.h; sourceTree = "<group>"; };
+		F68DEBF72A35091600421FAB /* DispatchTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchTimer.swift; sourceTree = "<group>"; };
 		F68F724A1E2A0937007FADA5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		F68FE3A5270F6DC700C89D16 /* UnarchiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnarchiverTests.swift; sourceTree = "<group>"; };
 		F69140E21E71B94200D51BFF /* AppController+Notifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AppController+Notifications.h"; sourceTree = "<group>"; };
@@ -1463,6 +1465,7 @@
 				F69140E21E71B94200D51BFF /* AppController+Notifications.h */,
 				F69140E31E71B94200D51BFF /* AppController+Notifications.m */,
 				B856F8E025782F8100E91AC7 /* AppController+Sparkle.swift */,
+				F68DEBF72A35091600421FAB /* DispatchTimer.swift */,
 				4350288F165DE9DF0018EDB7 /* URLHandlerCommand.h */,
 				43502890165DE9DF0018EDB7 /* URLHandlerCommand.m */,
 				43502891165DE9DF0018EDB7 /* ViennaApp.h */,
@@ -2097,6 +2100,7 @@
 				2F88B2A62545BB450067EEA6 /* ArticleConverter.m in Sources */,
 				AA36CD7C06100692001E33A4 /* Field.m in Sources */,
 				F6B059E22961D0A800F6E31B /* JSONFeedItem.swift in Sources */,
+				F68DEBF82A35091600421FAB /* DispatchTimer.swift in Sources */,
 				F6C9DA70271BB3BB00FC3027 /* RSSFeed.m in Sources */,
 				0349813E1A206FD900014F29 /* GeneralPreferencesViewController.m in Sources */,
 				2F5AC4202198E1AA00A7EDDE /* TitleChangingTabViewItem.swift in Sources */,

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -93,7 +93,7 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 @property (nonatomic, getter=isFilterBarVisible, readonly) BOOL filterBarVisible;
 -(IBAction)cancelAllRefreshesToolbar:(id)sender;
 
-@property (nonatomic) NSBackgroundActivityScheduler *scheduler;
+@property (nonatomic) VNADispatchTimer *refreshTimer;
 
 @property (nonatomic) MainWindowController *mainWindowController;
 @property (weak, nonatomic) NSWindow *mainWindow;
@@ -178,9 +178,13 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 
 		[self.mainWindow makeFirstResponder:(previousArticleGuid != nil) ? ((NSView<BaseView> *)self.browser.primaryTab.view).mainView : self.foldersTree.mainView];
 
-		if (prefs.refreshOnStartup) {
-			[self refreshAllSubscriptions:self];
-		}
+        // 300s (5m) is the minimum refresh frequency.
+        if (prefs.refreshFrequency >= 300) {
+            [self scheduleRefreshWithFrequency:prefs.refreshFrequency
+                            refreshImmediately:prefs.refreshOnStartup];
+        } else if (prefs.refreshOnStartup) {
+            [self refreshAllSubscriptions];
+        }
 
 		doneSafeInit = YES;
 		
@@ -339,9 +343,6 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 
     // Notification Center delegate
     NSUserNotificationCenter.defaultUserNotificationCenter.delegate = self;
-
-    // Schedule the background refresh
-    [self scheduleBackgroundRefresh];
 
 	// Register to be notified when the scripts folder changes.
 	if (!hasOSScriptsMenu()) {
@@ -1618,40 +1619,15 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	[self showAppInStatusBar];
 }
 
-- (void)handleCheckFrequencyChange:(NSNotification *)nc {
-    if (self.scheduler) {
-        [self.scheduler invalidate];
-        self.scheduler = nil;
+- (void)handleCheckFrequencyChange:(NSNotification *)notification
+{
+    NSInteger frequency = Preferences.standardPreferences.refreshFrequency;
+    if (frequency >= 300) {
+        [self scheduleRefreshWithFrequency:frequency refreshImmediately:NO];
+    } else {
+        // The user disabled the automatic refresh.
+        self.refreshTimer = nil;
     }
-    [self scheduleBackgroundRefresh];
-}
-
-- (void)scheduleBackgroundRefresh {
-    NSInteger interval = [Preferences standardPreferences].refreshFrequency;
-
-    // NSBackgroundActivityScheduler requires an interval value >= 1. A value
-    // less than that raises an unhandled exception.
-    if (interval < 1) {
-        return;
-    }
-
-    self.scheduler = [[NSBackgroundActivityScheduler alloc] initWithIdentifier:@"com.vienna-rss.Vienna"];
-    self.scheduler.interval = interval;
-    self.scheduler.repeats = YES;
-    self.scheduler.qualityOfService = NSQualityOfServiceUtility;
-
-    typeof(self) __weak weakSelf = self;
-    [self.scheduler scheduleWithBlock:^(NSBackgroundActivityCompletionHandler completionHandler) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if ([RefreshManager sharedManager].isConnecting) {
-                completionHandler(NSBackgroundActivityResultDeferred);
-                return;
-            }
-
-            [weakSelf refreshAllSubscriptions:weakSelf];
-            completionHandler(NSBackgroundActivityResultFinished);
-        });
-    }];
 }
 
 /* doViewColumn
@@ -2871,6 +2847,39 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 
 #pragma mark Refresh Subscriptions
 
+// This method is run as a result of -applicationDidFinishLaunching: or by way
+// of -handleCheckFrequencyChange: after the user changed the refresh frequency.
+- (void)scheduleRefreshWithFrequency:(NSInteger)frequency
+                  refreshImmediately:(BOOL)refreshImmediately
+{
+    NSTimeInterval interval = (NSTimeInterval)frequency;
+    if (self.refreshTimer) {
+        [self.refreshTimer rescheduleWithInterval:interval
+                                  fireImmediately:refreshImmediately];
+    } else {
+        self.refreshTimer =
+            [[VNADispatchTimer alloc] initWithInterval:interval
+                                       fireImmediately:refreshImmediately
+                                         dispatchQueue:dispatch_get_main_queue()
+                                          eventHandler:^{
+                [self refreshAllSubscriptions];
+            }];
+    }
+}
+
+- (void)refreshAllSubscriptions
+{
+    if (self.connecting) {
+        return;
+    }
+
+    if (Preferences.standardPreferences.syncGoogleReader) {
+        [OpenReader.sharedManager loadSubscriptions];
+    }
+    [RefreshManager.sharedManager refreshSubscriptions:[self.foldersTree folders:0]
+                            ignoringSubscriptionStatus:NO];
+}
+
 /* refreshAllFolderIcons
  * Get new favicons from all subscriptions.
  */
@@ -2887,14 +2896,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)refreshAllSubscriptions:(id)sender
 {
-    if (!self.connecting) {
-        if ([Preferences standardPreferences].syncGoogleReader){
-            [[OpenReader sharedManager] loadSubscriptions];
-        }
-
-        // Kick off the refresh
-        [[RefreshManager sharedManager] refreshSubscriptions:[self.foldersTree folders:0]
-          ignoringSubscriptionStatus:NO];
+    if (self.refreshTimer) {
+        [self.refreshTimer fire];
+    } else {
+        [self refreshAllSubscriptions];
     }
 }
 

--- a/Vienna/Sources/Application/DispatchTimer.swift
+++ b/Vienna/Sources/Application/DispatchTimer.swift
@@ -1,0 +1,120 @@
+//
+//  DispatchTimer.swift
+//  Vienna
+//
+//  Copyright 2023 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Dispatch
+import Foundation
+import os.log
+
+@objc(VNADispatchTimer)
+class DispatchTimer: NSObject {
+
+    private var dispatchSource: DispatchSourceTimer
+
+    private(set) var interval: TimeInterval
+
+    /// The interval by which the system may delay firing the timer.
+    private(set) var leeway: DispatchTimeInterval
+
+    @objc
+    init(interval: TimeInterval, fireImmediately: Bool, dispatchQueue: DispatchQueue, eventHandler: @escaping () -> Void) {
+        dispatchSource = DispatchSource.makeTimerSource(queue: dispatchQueue)
+        self.interval = interval
+        leeway = DispatchTimeInterval.seconds(rounding: interval)
+        super.init()
+
+        dispatchSource.scheduleUsingWallClockTime(interval: interval, fireImmediately: fireImmediately, leeway: leeway)
+        dispatchSource.setEventHandler {
+            os_log("Event handler submitted to dispatch timer", log: .dispatchTimer, type: .debug)
+            eventHandler()
+        }
+        dispatchSource.setRegistrationHandler {
+            os_log("Dispatch timer registered with interval of %llds, firing immediately: %{public}@", log: .dispatchTimer, type: .debug, Int(interval), fireImmediately.description)
+        }
+        dispatchSource.activate()
+    }
+
+    deinit {
+        // The documentation does not explain what happens if the pointer to the
+        // dispatch source is set to nil, i.e. whether the system keeps a strong
+        // reference elsewhere, before cancel() was called.
+        dispatchSource.setCancelHandler {
+            os_log("Dispatch timer cancelled", log: .dispatchTimer, type: .debug)
+        }
+        dispatchSource.cancel()
+    }
+
+    /// Reschedules the timer with the given time interval, optionally firing
+    /// the timer immediately.
+    @objc
+    func reschedule(interval: TimeInterval, fireImmediately: Bool) {
+        // The documentation of dispatch_source_set_timer(), which is ultimately
+        // the source of schedule(wallDeadline:repeating:leeway:), sets out that
+        // it can be called again to reset the timer, as long as it has not been
+        // cancelled.
+        dispatchSource.suspend()
+        self.interval = interval
+        leeway = .seconds(rounding: interval)
+        dispatchSource.scheduleUsingWallClockTime(interval: interval, fireImmediately: fireImmediately, leeway: leeway)
+        dispatchSource.setRegistrationHandler {
+            os_log("Dispatch timer re-registered with interval of %llds, firing immediately: %{public}@", log: .dispatchTimer, type: .debug, Int(interval), fireImmediately.description)
+        }
+        dispatchSource.resume()
+    }
+
+    /// Fires the timer immediately and reschedules it, based on the current
+    /// value of `interval`.
+    @objc
+    func fire() {
+        reschedule(interval: interval, fireImmediately: true)
+    }
+
+}
+
+// MARK: - Private extensions
+
+private extension DispatchSourceTimer {
+
+    // Use "wall clock" time instead of Mach absolute time. The system might go
+    // to sleep or suspend apps before the timer fires. Although the timer will
+    // be paused as well, wall clock time ensures that the lapsed time is taken
+    // into account when resuming the timer.
+    func scheduleUsingWallClockTime(interval: TimeInterval, fireImmediately: Bool, leeway: DispatchTimeInterval) {
+        let deadline: DispatchWallTime = fireImmediately ? .now() : .now() + interval
+        self.schedule(wallDeadline: deadline, repeating: interval, leeway: leeway)
+    }
+
+}
+
+private extension DispatchTimeInterval {
+
+    // Apple recommends a leeway of 10% of the interval. See: "Energy Efficiency
+    // Guide for Mac Apps", section "Minimize Timer Usage".
+    // https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/Timers.html
+    static func seconds(rounding timeInterval: TimeInterval, fraction: Double = 0.1) -> Self {
+        let leeway = Int(timeInterval * fraction)
+        return .seconds(leeway)
+    }
+
+}
+
+private extension OSLog {
+
+    static let dispatchTimer = OSLog(subsystem: "--", category: "DispatchTimer")
+
+}


### PR DESCRIPTION
See #1591 for the reason.

Rather than reversing 03a58f0735d7be4ad0bd6edc0da1481767906ac4 and going back to NSTimer and IOKit, GCD provides an alternative. Unlike NSTimer, GCD can take into account sleep/idle time when the timer fires, whereas NSTimer will pause instead, thus needing an additional mechanism to respond to wake-ups (IOKit or NSWorkspace) and manipulate the timer. Both NSTimer and GCD can use similar power-saving measures as NSBackgroundActivityScheduler, e.g. additional delay of the timer depending on system conditions.

I have run a test version of this for a few hours and it seems to work as expected.

I put some of the code into a Swift class to avoid the ugly (IMO) C-style GCD code. Maybe it would have been better to create an extension for AppController, but I did not think of this before. There is the option to reduce the "leeway" property to 0 and pass `.strict` to `makeTimerSource(flags:queue:)` to stop the system from delaying the timer. This could be setting for the user.