### PR TITLE
Provide richer information when using NSSharingService

### DIFF
--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1478,7 +1478,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	[pboard declareTypes:@[VNAPasteboardTypeRSSItem, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML]
                    owner:self];
     if (count == 1) {
-        [pboard addTypes:@[VNAPasteboardTypeURL, VNAPasteboardTypeURLName, NSPasteboardTypeURL]
+        [pboard addTypes:@[NSPasteboardTypeURL, VNAPasteboardTypeURLName]
                    owner:self];
     }
 
@@ -1513,7 +1513,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		[fullHTMLText appendFormat:@"<a href=\"%@\">%@</a><br />%@<br /><br />", msgLink, msgTitle, msgText];
 		
 		if (count == 1) {
-			[pboard setString:msgLink forType:VNAPasteboardTypeURL];
+            [pboard setString:msgLink forType:NSPasteboardTypeURL];
 			[pboard setString:msgTitle forType:VNAPasteboardTypeURLName];
 			
 			// Write the link to the pastboard.

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1483,7 +1483,8 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
     }
 
 	// Open the HTML string
-	[fullHTMLText appendString:@"<html><body>"];
+	[fullHTMLText appendString:@"<html style=\"font-family:sans-serif;\">"
+                                "<head><meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\"></head><body>"];
 	
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
@@ -1507,10 +1508,11 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		[arrayOfArticles addObject:articleDict];
 
 		// Plain text
-		[fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, msgText];
+        [fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
 		
 		// Add HTML version too.
-		[fullHTMLText appendFormat:@"<a href=\"%@\">%@</a><br />%@<br /><br />", msgLink, msgTitle, msgText];
+		[fullHTMLText appendFormat:@"<div class=\"info\"><a href=\"%@\">%@</a><div>"
+                                    "<div class=\"articleBodyStyle\">%@</div><br>", msgLink, msgTitle, msgText];
 		
 		if (count == 1) {
             [pboard setString:msgLink forType:NSPasteboardTypeURL];

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -599,7 +599,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 	// Set up the pasteboard
 	[pboard declareTypes:@[VNAPasteboardTypeRSSItem, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML] owner:self];
     if (count == 1) {
-        [pboard addTypes:@[VNAPasteboardTypeURL, VNAPasteboardTypeURLName, NSPasteboardTypeURL]
+        [pboard addTypes:@[NSPasteboardTypeURL, VNAPasteboardTypeURLName]
                    owner:self];
     }
 
@@ -634,7 +634,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 		[fullHTMLText appendFormat:@"<a href=\"%@\">%@</a><br />%@<br /><br />", msgLink, msgTitle, msgText];
 
 		if (count == 1) {
-			[pboard setString:msgLink forType:VNAPasteboardTypeURL];
+			[pboard setString:msgLink forType:NSPasteboardTypeURL];
 			[pboard setString:msgTitle forType:VNAPasteboardTypeURLName];
 
 			// Write the link to the pastboard.

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -604,7 +604,8 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
     }
 
 	// Open the HTML string
-	[fullHTMLText appendString:@"<html><body>"];
+	[fullHTMLText appendString:@"<html style=\"font-family:sans-serif;\">"
+                                "<head><meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\"></head><body>"];
 
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
@@ -628,10 +629,11 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 		[arrayOfArticles addObject:articleDict];
 
 		// Plain text
-		[fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, msgText];
+        [fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
 
 		// Add HTML version too.
-		[fullHTMLText appendFormat:@"<a href=\"%@\">%@</a><br />%@<br /><br />", msgLink, msgTitle, msgText];
+		[fullHTMLText appendFormat:@"<div class=\"info\"><a href=\"%@\">%@</a><div>"
+                                    "<div class=\"articleBodyStyle\">%@</div><br>", msgLink, msgTitle, msgText];
 
 		if (count == 1) {
 			[pboard setString:msgLink forType:NSPasteboardTypeURL];

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -127,7 +127,6 @@ extern NSInteger const MA_Default_ConcurrentDownloads;
 extern NSPasteboardType const VNAPasteboardTypeRSSItem;
 extern NSPasteboardType const VNAPasteboardTypeFolderList;
 extern NSPasteboardType const VNAPasteboardTypeRSSSource;
-extern NSPasteboardType const VNAPasteboardTypeURL;
 extern NSPasteboardType const VNAPasteboardTypeURLName;
 extern NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles;
 

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -140,6 +140,5 @@ AEKeyword const DataItemSourceFeedURL = 'furl';
 NSPasteboardType const VNAPasteboardTypeFolderList = @"ViennaFolderType";
 NSPasteboardType const VNAPasteboardTypeRSSSource = @"CorePasteboardFlavorType 0x52535373";
 NSPasteboardType const VNAPasteboardTypeRSSItem = @"CorePasteboardFlavorType 0x52535369";
-NSPasteboardType const VNAPasteboardTypeURL = @"CorePasteboardFlavorType 0x75726C20";
-NSPasteboardType const VNAPasteboardTypeURLName = @"CorePasteboardFlavorType 0x75726C6E";
+NSPasteboardType const VNAPasteboardTypeURLName = @"public.url-name";
 NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles = @"WebURLsWithTitlesPboardType";


### PR DESCRIPTION
Provide title of article in addition to URL
Title is used as sharing service's subject

Unfortunately, NSSharingService is not yet smart enough to pass multiple types of content.

Fix issue #1678