### PR TITLE
Address several drawing issues with Xcode 15

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1743,7 +1743,7 @@
 				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = VNA;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = "Vienna project";
 				TargetAttributes = {
 					035B703419E0E4AE00197334 = {
@@ -1762,7 +1762,7 @@
 				};
 			};
 			buildConfigurationList = AA4F9AB60855422400C18279 /* Build configuration list for PBXProject "Vienna" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/Deployment.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/Deployment.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
+++ b/Vienna.xcodeproj/xcshareddata/xcschemes/Vienna.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1500"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vienna/Interfaces/BrowserTab.xib
+++ b/Vienna/Interfaces/BrowserTab.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -37,31 +37,31 @@
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rn-z0-yA2">
                                     <rect key="frame" x="0.0" y="-2" width="20.5" height="24.5"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="20" id="HLA-5B-V5x"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="recessed" bezelStyle="recessed" image="NSGoBackTemplate" imagePosition="only" alignment="center" inset="2" id="j5n-Oc-Vrp">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="systemBold" size="12"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="20" id="HLA-5B-V5x"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="back:" target="-2" id="qNx-fN-S3N"/>
                                     </connections>
                                 </button>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aeH-Zd-eUj">
-                                    <rect key="frame" x="23" y="-2" width="20" height="24.5"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="20" id="Qpb-UX-zNR"/>
-                                    </constraints>
+                                    <rect key="frame" x="23" y="-2" width="20.5" height="24.5"/>
                                     <buttonCell key="cell" type="recessed" bezelStyle="recessed" image="NSGoForwardTemplate" imagePosition="only" alignment="center" inset="2" id="0sn-QN-I23">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="systemBold" size="12"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="20" id="Qpb-UX-zNR"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="forward:" target="-2" id="w7v-U4-Rfp"/>
                                     </connections>
                                 </button>
-                                <textField horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="hfe-el-NfG">
+                                <textField focusRingType="none" horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="hfe-el-NfG">
                                     <rect key="frame" x="46" y="0.0" width="715" height="20"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="20" id="cth-7a-7OT"/>
@@ -75,20 +75,20 @@
                                         <action selector="loadPageFromAddressBar:" target="-2" id="kJy-ZN-1TI"/>
                                     </connections>
                                 </textField>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DXZ-Cm-yVX">
+                                <button clipsToBounds="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DXZ-Cm-yVX">
                                     <rect key="frame" x="764" y="0.0" width="39" height="19"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="39" id="0NG-eP-ikc"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="recessed" title="RSS" bezelStyle="recessed" alignment="center" state="on" borderStyle="border" imageScaling="axesIndependently" inset="2" id="R1b-bS-RKk">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="systemBold" size="12"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="39" id="0NG-eP-ikc"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="subscribe:" target="-2" id="4re-XI-zfu"/>
                                     </connections>
                                 </button>
-                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="HRc-ZN-msF">
+                                <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HRc-ZN-msF">
                                     <rect key="frame" x="806" y="0.0" width="30" height="20"/>
                                     <subviews>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oDE-XG-Zic">
@@ -107,7 +107,7 @@
                                         <constraint firstAttribute="width" constant="30" id="d6o-Yg-btU"/>
                                     </constraints>
                                 </customView>
-                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="5Tw-qL-uau">
+                                <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5Tw-qL-uau">
                                     <rect key="frame" x="839" y="0.0" width="30" height="20"/>
                                     <subviews>
                                         <button verticalHuggingPriority="751" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="u6u-kW-eOW">
@@ -178,9 +178,9 @@
         </designable>
     </designables>
     <resources>
-        <image name="NSGoBackTemplate" width="10" height="14"/>
-        <image name="NSGoForwardTemplate" width="10" height="14"/>
-        <image name="NSRefreshTemplate" width="14" height="16"/>
-        <image name="NSStopProgressTemplate" width="14" height="13"/>
+        <image name="NSGoBackTemplate" width="12" height="17"/>
+        <image name="NSGoForwardTemplate" width="12" height="17"/>
+        <image name="NSRefreshTemplate" width="18" height="21"/>
+        <image name="NSStopProgressTemplate" width="17" height="16"/>
     </resources>
 </document>

--- a/Vienna/Interfaces/BrowserTabWithLegacyAddressBar.xib
+++ b/Vienna/Interfaces/BrowserTabWithLegacyAddressBar.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -51,7 +51,7 @@
                                         <action selector="forward:" target="-2" id="w7v-U4-Rfp"/>
                                     </connections>
                                 </button>
-                                <textField horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="hfe-el-NfG">
+                                <textField focusRingType="none" horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="hfe-el-NfG">
                                     <rect key="frame" x="56" y="0.0" width="686" height="21"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="21" id="76y-gh-8oJ"/>
@@ -65,37 +65,34 @@
                                         <action selector="loadPageFromAddressBar:" target="-2" id="kJy-ZN-1TI"/>
                                     </connections>
                                 </textField>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m2a-jT-Jm2">
+                                <button clipsToBounds="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m2a-jT-Jm2">
                                     <rect key="frame" x="742" y="0.0" width="29" height="21"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="29" id="yiE-mL-DVV"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="CancelTemplate" imagePosition="only" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iWi-GA-9Xl">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="29" id="yiE-mL-DVV"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="cancel:" target="-2" id="co1-yJ-HHt"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="u6u-kW-eOW">
+                                <button clipsToBounds="YES" verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="u6u-kW-eOW">
                                     <rect key="frame" x="771" y="0.0" width="29" height="21"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="29" id="u7N-Cm-8cB"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="recessed" bezelStyle="recessed" image="browserRefreshButton" imagePosition="only" alignment="center" inset="2" id="RBR-fu-w5E">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="systemBold" size="12"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="29" id="u7N-Cm-8cB"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="reload:" target="-2" id="fgH-tf-FM6"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KeR-ow-lja">
-                                    <rect key="frame" x="800" y="-1" width="40" height="22"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="40" id="PoN-9V-QZr"/>
-                                    </constraints>
+                                <button clipsToBounds="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KeR-ow-lja">
+                                    <rect key="frame" x="800" y="0.0" width="40" height="21"/>
                                     <buttonCell key="cell" type="inline" bezelStyle="inline" image="browserRSSButton" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" inset="2" id="6e4-Mb-AuA">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystemBold"/>
@@ -103,6 +100,9 @@
                                             <action selector="subscribe:" target="-2" id="XdL-4d-wEL"/>
                                         </connections>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="40" id="PoN-9V-QZr"/>
+                                    </constraints>
                                 </button>
                             </subviews>
                             <constraints>
@@ -147,7 +147,7 @@
         </customView>
     </objects>
     <resources>
-        <image name="CancelTemplate" width="12" height="12"/>
+        <image name="CancelTemplate" width="19" height="12"/>
         <image name="browserNextButton" width="27" height="21"/>
         <image name="browserPreviousButton" width="29" height="21"/>
         <image name="browserRSSButton" width="31" height="21"/>

--- a/Vienna/Sources/Main window/EnclosureView.m
+++ b/Vienna/Sources/Main window/EnclosureView.m
@@ -150,7 +150,7 @@
  */
 - (void)drawRect:(NSRect)rect {
     [[NSColor colorNamed:@"AttachmentView"] setFill];
-	NSRectFill(rect);
+    NSRectFill(self.bounds);
 }
 
 /* dealloc


### PR DESCRIPTION
This addresses the drawing issues I found so far and mentioned in #1707. There could be more. 

In the browser UI, the RSS, cancel and reload buttons are hidden by setting layout constraints to zero (`updateAddressBarButtons()` in BrowserTab+Interface.swift). This causes the button icons to still be visible. This is addressed by enabling the `clipsToBounds` property in Interface Builder, which should be fully backwards compatible.

For the EnclosureView, the drawing is restricted to the view's `bounds` instead of `dirtyRect`.