### PR TITLE
Import translations from Crowdin

### DIFF
--- a/Vienna/Interfaces/da.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/da.lproj/MainMenu.strings
@@ -436,6 +436,9 @@
 /* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "RtQ-eP-bfk"; */
 "RtQ-eP-bfk.title" = "Smarte bindestreger";
 
+/* Class = "NSMenuItem"; title = "Share…"; ObjectID = "SSr-Ho-wep"; */
+"SSr-Ho-wep.title" = "Del…";
+
 /* Class = "NSMenuItem"; title = "All Articles"; ObjectID = "t1E-6n-jtA"; */
 "t1E-6n-jtA.title" = "Alle artikler";
 
@@ -450,6 +453,9 @@
 
 /* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "v3R-CV-0b9"; */
 "v3R-CV-0b9.title" = "Stort bogstav";
+
+/* Class = "NSMenuItem"; title = "Add to Safari Reading List"; ObjectID = "VQe-zs-ODh"; */
+"VQe-zs-ODh.title" = "Føj til læselisten";
 
 /* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "w4Q-ne-FPI"; */
 "w4Q-ne-FPI.title" = "Smarte henvisninger";

--- a/Vienna/Interfaces/da.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/da.lproj/MainWindowController.strings
@@ -250,6 +250,12 @@
 /* Class = "NSMenuItem"; title = "Last 48 Hours"; ObjectID = "yvh-qU-EAm"; */
 "yvh-qU-EAm.title" = "Sidste 48 timer";
 
+/* Class = "NSToolbarItem"; label = "Share"; ObjectID = "YVR-Ym-Do7"; */
+"YVR-Ym-Do7.label" = "Del";
+
+/* Class = "NSToolbarItem"; paletteLabel = "Share"; ObjectID = "YVR-Ym-Do7"; */
+"YVR-Ym-Do7.paletteLabel" = "Del";
+
 /* Class = "NSImageView"; ibShadowedToolTip = "An error occurred when this feed was last refreshed"; ObjectID = "Zar-1U-8CD"; */
 "Zar-1U-8CD.ibShadowedToolTip" = "En fejl opstod da dette feed sidst blev refreshet";
 

--- a/Vienna/Interfaces/da.lproj/Preferences.strings
+++ b/Vienna/Interfaces/da.lproj/Preferences.strings
@@ -43,6 +43,9 @@
 /* Class = "NSButtonCell"; title = "Select…"; ObjectID = "cbn-xq-UFr"; */
 "cbn-xq-UFr.title" = "Vælg…";
 
+/* Class = "NSMenuItem"; title = "Medium"; ObjectID = "ClO-ha-l48"; */
+"ClO-ha-l48.title" = "Medium";
+
 /* Class = "NSButtonCell"; title = "Show website icons in the feed list"; ObjectID = "dkm-xW-4If"; */
 "dkm-xW-4If.title" = "Vis hjemmesideikoner i feed-listen";
 
@@ -78,6 +81,9 @@
 
 /* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "haP-20-AwJ"; */
 "haP-20-AwJ.title" = "Tjek for nyere versioner af Vienna ved opstart";
+
+/* Class = "NSMenuItem"; title = "Small"; ObjectID = "hd4-wx-xuK"; */
+"hd4-wx-xuK.title" = "Lille";
 
 /* Class = "NSTextFieldCell"; title = "Erase deleted articles:"; ObjectID = "HH2-sh-rEx"; */
 "HH2-sh-rEx.title" = "Fjern slettede artikler:";
@@ -142,6 +148,9 @@
 /* Class = "NSMenuItem"; title = "After two days"; ObjectID = "sJE-bd-4mK"; */
 "sJE-bd-4mK.title" = "Efter to dage";
 
+/* Class = "NSTextFieldCell"; title = "Feed list font size:"; ObjectID = "Sxj-Uk-jhk"; */
+"Sxj-Uk-jhk.title" = "Feed-liste skriftstørrelse:";
+
 /* Class = "NSViewController"; title = "General"; ObjectID = "T2z-OK-VtO"; */
 "T2z-OK-VtO.title" = "Generelt";
 
@@ -165,6 +174,9 @@
 
 /* Class = "NSMenuItem"; title = "After one week"; ObjectID = "xfd-Vp-kJy"; */
 "xfd-Vp-kJy.title" = "Efter én uge";
+
+/* Class = "NSMenuItem"; title = "Large"; ObjectID = "xIg-ej-t3j"; */
+"xIg-ej-t3j.title" = "Stor";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "YG6-9k-gKH"; */
 "YG6-9k-gKH.title" = "Henvisning:";

--- a/Vienna/Interfaces/da.lproj/SearchFolder.strings
+++ b/Vienna/Interfaces/da.lproj/SearchFolder.strings
@@ -7,3 +7,6 @@
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "Afbryd";
 
+/* Class = "NSTextFieldCell"; title = "Hold down the Option key to add nested rules."; ObjectID = "caT-eg-dXm"; */
+"caT-eg-dXm.title" = "Hold Option-tasten nede for at tilføje regler i flere niveauer.";
+

--- a/Vienna/Interfaces/zh-Hant.lproj/FeedCredentials.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/FeedCredentials.strings
@@ -19,3 +19,9 @@
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "Lvs-Rd-GZy"; */
 "Lvs-Rd-GZy.title" = "URL：";
 
+/* Class = "NSTextFieldCell"; title = "Details"; ObjectID = "VkU-PT-7wf"; */
+"VkU-PT-7wf.title" = "詳細內容";
+
+/* Class = "NSTextFieldCell"; title = "Feed:"; ObjectID = "yIO-aF-1Qg"; */
+"yIO-aF-1Qg.title" = "源料";
+

--- a/Vienna/Interfaces/zh-Hant.lproj/MainMenu.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/MainMenu.strings
@@ -7,6 +7,9 @@
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
 "5.title" = "將此程式所有視窗移至最前";
 
+/* Class = "NSMenuItem"; title = "Show Enclosure Bar"; ObjectID = "5V8-N1-SQd"; */
+"5V8-N1-SQd.title" = "顯示附檔工具列";
+
 /* Class = "NSMenuItem"; title = "Refresh All Subscriptions"; ObjectID = "6yn-y8-lF1"; */
 "6yn-y8-lF1.title" = "重新整理所有訂閱頻道";
 
@@ -403,6 +406,9 @@
 /* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "kCi-pf-mkc"; */
 "kCi-pf-mkc.title" = "智慧引號";
 
+/* Class = "NSMenuItem"; title = "Hide Enclosure Bar"; ObjectID = "Ke1-zq-KLc"; */
+"Ke1-zq-KLc.title" = "隱藏附檔工具列";
+
 /* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "l8F-tb-7E0"; */
 "l8F-tb-7E0.title" = "拼字與文法";
 
@@ -430,6 +436,9 @@
 /* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "RtQ-eP-bfk"; */
 "RtQ-eP-bfk.title" = "智慧型劃線";
 
+/* Class = "NSMenuItem"; title = "Share…"; ObjectID = "SSr-Ho-wep"; */
+"SSr-Ho-wep.title" = "分享...";
+
 /* Class = "NSMenuItem"; title = "All Articles"; ObjectID = "t1E-6n-jtA"; */
 "t1E-6n-jtA.title" = "所有文章";
 
@@ -444,6 +453,9 @@
 
 /* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "v3R-CV-0b9"; */
 "v3R-CV-0b9.title" = "保持大寫";
+
+/* Class = "NSMenuItem"; title = "Add to Safari Reading List"; ObjectID = "VQe-zs-ODh"; */
+"VQe-zs-ODh.title" = "增加到 Safari 閱讀清單中";
 
 /* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "w4Q-ne-FPI"; */
 "w4Q-ne-FPI.title" = "智慧型連結";

--- a/Vienna/Interfaces/zh-Hant.lproj/MainWindowController.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/MainWindowController.strings
@@ -169,6 +169,9 @@
 /* Class = "NSMenuItem"; title = "Mark All Articles as Read"; ObjectID = "Qj9-p3-QXB"; */
 "Qj9-p3-QXB.title" = "將所有文章標示為已閱讀";
 
+/* Class = "NSButtonCell"; title = "Show All Feeds"; ObjectID = "Qqb-bF-tIg"; */
+"Qqb-bF-tIg.title" = "顯示所有源料";
+
 /* Class = "NSMenuItem"; title = "New Folder…"; ObjectID = "RaH-Yu-Ija"; */
 "RaH-Yu-Ija.title" = "新資料夾…";
 
@@ -246,6 +249,12 @@
 
 /* Class = "NSMenuItem"; title = "Last 48 Hours"; ObjectID = "yvh-qU-EAm"; */
 "yvh-qU-EAm.title" = "過去 48 小時";
+
+/* Class = "NSToolbarItem"; label = "Share"; ObjectID = "YVR-Ym-Do7"; */
+"YVR-Ym-Do7.label" = "分享";
+
+/* Class = "NSToolbarItem"; paletteLabel = "Share"; ObjectID = "YVR-Ym-Do7"; */
+"YVR-Ym-Do7.paletteLabel" = "分享";
 
 /* Class = "NSImageView"; ibShadowedToolTip = "An error occurred when this feed was last refreshed"; ObjectID = "Zar-1U-8CD"; */
 "Zar-1U-8CD.ibShadowedToolTip" = "最後一次更新此訂閱頻道時，發生錯誤";

--- a/Vienna/Interfaces/zh-Hant.lproj/Preferences.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/Preferences.strings
@@ -19,6 +19,9 @@
 /* Class = "NSMenuItem"; title = "Manually"; ObjectID = "7Za-ay-jlt"; */
 "7Za-ay-jlt.title" = "手動";
 
+/* Class = "NSButtonCell"; title = "Display feeds with unread articles with bold font"; ObjectID = "86e-38-zCh"; */
+"86e-38-zCh.title" = "以粗體字標示帶有未讀文章的源料";
+
 /* Class = "NSTextFieldCell"; title = "Mark current article read:"; ObjectID = "adB-qE-xKg"; */
 "adB-qE-xKg.title" = "將目前的文章標記為已閱讀：";
 
@@ -39,6 +42,9 @@
 
 /* Class = "NSButtonCell"; title = "Select…"; ObjectID = "cbn-xq-UFr"; */
 "cbn-xq-UFr.title" = "選取⋯";
+
+/* Class = "NSMenuItem"; title = "Medium"; ObjectID = "ClO-ha-l48"; */
+"ClO-ha-l48.title" = "中";
 
 /* Class = "NSButtonCell"; title = "Show website icons in the feed list"; ObjectID = "dkm-xW-4If"; */
 "dkm-xW-4If.title" = "在檔案夾列表中顯示檔案夾影像";
@@ -75,6 +81,9 @@
 
 /* Class = "NSButtonCell"; title = "Check for newer versions of Vienna on start up"; ObjectID = "haP-20-AwJ"; */
 "haP-20-AwJ.title" = "啟動時檢查是否有新版的 Vienna";
+
+/* Class = "NSMenuItem"; title = "Small"; ObjectID = "hd4-wx-xuK"; */
+"hd4-wx-xuK.title" = "小";
 
 /* Class = "NSTextFieldCell"; title = "Erase deleted articles:"; ObjectID = "HH2-sh-rEx"; */
 "HH2-sh-rEx.title" = "將刪除的文章清除：";
@@ -139,6 +148,9 @@
 /* Class = "NSMenuItem"; title = "After two days"; ObjectID = "sJE-bd-4mK"; */
 "sJE-bd-4mK.title" = "兩天後";
 
+/* Class = "NSTextFieldCell"; title = "Feed list font size:"; ObjectID = "Sxj-Uk-jhk"; */
+"Sxj-Uk-jhk.title" = "源料列表字體大小";
+
 /* Class = "NSViewController"; title = "General"; ObjectID = "T2z-OK-VtO"; */
 "T2z-OK-VtO.title" = "一般";
 
@@ -154,11 +166,17 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Visit the website"; ObjectID = "V12-Ua-skO"; */
 "V12-Ua-skO.ibShadowedToolTip" = "瀏覽網站";
 
+/* Class = "NSButtonCell"; title = "Display unread articles with bold font"; ObjectID = "VQH-xk-s5g"; */
+"VQH-xk-s5g.title" = "以粗體字標示未讀的文章";
+
 /* Class = "NSViewController"; title = "Updates"; ObjectID = "wyk-W1-xMh"; */
 "wyk-W1-xMh.title" = "更新";
 
 /* Class = "NSMenuItem"; title = "After one week"; ObjectID = "xfd-Vp-kJy"; */
 "xfd-Vp-kJy.title" = "一週後";
+
+/* Class = "NSMenuItem"; title = "Large"; ObjectID = "xIg-ej-t3j"; */
+"xIg-ej-t3j.title" = "大";
 
 /* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "YG6-9k-gKH"; */
 "YG6-9k-gKH.title" = "URL：";

--- a/Vienna/Interfaces/zh-Hant.lproj/SearchFolder.strings
+++ b/Vienna/Interfaces/zh-Hant.lproj/SearchFolder.strings
@@ -7,3 +7,6 @@
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "97"; */
 "97.title" = "取消";
 
+/* Class = "NSTextFieldCell"; title = "Hold down the Option key to add nested rules."; ObjectID = "caT-eg-dXm"; */
+"caT-eg-dXm.title" = "將 Opt 鍵按住後就可以增加較複雜的規則";
+

--- a/Vienna/Resources/cs.lproj/Localizable.strings
+++ b/Vienna/Resources/cs.lproj/Localizable.strings
@@ -343,7 +343,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Výsledky hledání";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Vybrat…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/da.lproj/Localizable.strings
+++ b/Vienna/Resources/da.lproj/Localizable.strings
@@ -460,7 +460,8 @@
 /* Label of a button on an open panel */
 "Select" = "Vælg";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Vælg…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/de.lproj/Localizable.strings
+++ b/Vienna/Resources/de.lproj/Localizable.strings
@@ -470,7 +470,8 @@
 /* Label of a button on an open panel */
 "Select" = "Auswählen";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Auswählen …";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/es.lproj/Localizable.strings
+++ b/Vienna/Resources/es.lproj/Localizable.strings
@@ -451,7 +451,8 @@
 /* Label of a button on an open panel */
 "Select" = "Seleccionar";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Seleccionar…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/es.lproj/Predicates.strings
+++ b/Vienna/Resources/es.lproj/Predicates.strings
@@ -1,8 +1,0 @@
-"%[Author,Subject,Text]@ %[contains,does not contain]@ %@" = "%1$[Autor,Asunto,Contenido]@ %2$[contiene,no contiene]@ %3$@";
-"%[Deleted,Flagged,HasEnclosure,Read]@ is %[No,Yes]@" = "%1$[Está eliminado,Está destacado,Tiene archivo adjunto,Está leído]@ %2$[No,Sí]@";
-"%[Author,Folder,Subject,Text]@ %[is,is not]@ %@" = "%1$[Autor,Carpeta,Asunto,Contenido]@ %2$[es,no es]@ %3$@";
-"%[Date]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Fecha]@ %2$[es,es anterior a,es anterior a o es]@ %3$[hoy]@";
-"%[Date]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Fecha]@ %2$[es,es posterior a o es,es anterior a,es anterior a o es]@ %3$[ayer]@";
-"%[Date]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Fecha]@ %2$[es,es posterior a,es posterior a o es,es anterior a,es anterior a o es]@ %3$[última semana]@";
-"%[All]@ of the following are true" = "Artículo cumple %1$[todas]@ las siguientes condiciones";
-"%[Any,None]@ of the following are true" = "Artículo cumple con %1$[alguna,ninguna]@ de las siguientes condiciones";

--- a/Vienna/Resources/eu.lproj/Localizable.strings
+++ b/Vienna/Resources/eu.lproj/Localizable.strings
@@ -283,7 +283,8 @@
 /* No comment provided by engineer. */
 "Retrieving folder image" = "Direktorioaren irudia jasotzen";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Aukeratu…";
 
 /* Title of a popup menu item */

--- a/Vienna/Resources/fr.lproj/Localizable.strings
+++ b/Vienna/Resources/fr.lproj/Localizable.strings
@@ -470,7 +470,8 @@
 /* Label of a button on an open panel */
 "Select" = "Sélectionner";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Sélectionner…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/gl.lproj/Localizable.strings
+++ b/Vienna/Resources/gl.lproj/Localizable.strings
@@ -406,7 +406,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Resultados da procura";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Seleccionar…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/it.lproj/Localizable.strings
+++ b/Vienna/Resources/it.lproj/Localizable.strings
@@ -319,7 +319,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Cerca nei Risultati";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Seleziona…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/ja.lproj/Localizable.strings
+++ b/Vienna/Resources/ja.lproj/Localizable.strings
@@ -256,7 +256,8 @@
 /* No comment provided by engineer. */
 "Retrieving folder image" = "フォルダイメージを取得中";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "選択…";
 
 /* Title of a popup menu item */

--- a/Vienna/Resources/ko.lproj/Localizable.strings
+++ b/Vienna/Resources/ko.lproj/Localizable.strings
@@ -259,7 +259,8 @@
 /* No comment provided by engineer. */
 "Retrieving folder image" = "구독 이미지 추가 중";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "선택…";
 
 /* Title of a popup menu item */

--- a/Vienna/Resources/lt.lproj/Localizable.strings
+++ b/Vienna/Resources/lt.lproj/Localizable.strings
@@ -406,7 +406,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Paieškos rezultatai";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Pasirinkti…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/nl.lproj/Localizable.strings
+++ b/Vienna/Resources/nl.lproj/Localizable.strings
@@ -470,7 +470,8 @@
 /* Label of a button on an open panel */
 "Select" = "Selecteer";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Selecteer…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/pt-BR.lproj/Localizable.strings
+++ b/Vienna/Resources/pt-BR.lproj/Localizable.strings
@@ -331,7 +331,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Pesquisar Resultados";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Selecionar…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/pt.lproj/Localizable.strings
+++ b/Vienna/Resources/pt.lproj/Localizable.strings
@@ -467,7 +467,8 @@
 /* Label of a button on an open panel */
 "Select" = "Seleccionar";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Seleccionar…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/pt.lproj/Predicates.strings
+++ b/Vienna/Resources/pt.lproj/Predicates.strings
@@ -1,9 +1,0 @@
-"%[Date]@ %[is less than,is less than or equal to]@ %[today]@" = "%1$[Date]@ %2$[é anterior a,é anterior ou igual a]@ %3$[today]@";
-"%[Date]@ %[is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Date]@ %2$[é posterior a,é posterior ou igual a,é anterior a,é anterior ou igual a]@ %3$[last week]@";
-"%[Date]@ %[is]@ %[last week,today,yesterday]@" = "%1$[Date]@ %2$[é igual a]@ %3$[semana passada,hoje,ontem]@";
-"%[Date]@ %[is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Date]@ %2$[é posterior ou igual a,é anterior a,é anterior ou igual a]@ %3$[yesterday]@";
-"%[Author,Folder,Subject,Text]@ %[is,is not]@ %@" = "%1$[Author,Pasta,Assunto,Conteúdo]@ %2$[é,não é]@ %3$@";
-"%[Author,Subject,Text]@ %[contains,does not contain]@ %@" = "%1$[Author,Assunto,Conteúdo]@ %2$[contém,não contém]@ %3$@";
-"%[Deleted,Flagged,HasEnclosure,Read]@ is %[No,Yes]@" = "%1$[Está apagado,Está assinalado,Tem invólucro,Lido]@ %2$[Não,Sim]@";
-"%[All]@ of the following are true" = "Artigo corresponde a %1$[todas]@ as seguintes condições";
-"%[Any,None]@ of the following are true" = "Artigo corresponde a %1$[quaisquer,nenhuma]@ das seguintes condições";

--- a/Vienna/Resources/ru.lproj/Localizable.strings
+++ b/Vienna/Resources/ru.lproj/Localizable.strings
@@ -448,7 +448,8 @@
 /* Label of a button on an open panel */
 "Select" = "Выбрать";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Выбрать…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/sv.lproj/Localizable.strings
+++ b/Vienna/Resources/sv.lproj/Localizable.strings
@@ -416,7 +416,8 @@
 /* Label of a button on an open panel */
 "Select" = "Välj";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Markera…";
 
 /* A formatted URL string with the mailto: URL scheme. */

--- a/Vienna/Resources/tr.lproj/Localizable.strings
+++ b/Vienna/Resources/tr.lproj/Localizable.strings
@@ -322,7 +322,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Arama Sonuçları";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Seç…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/uk.lproj/Localizable.strings
+++ b/Vienna/Resources/uk.lproj/Localizable.strings
@@ -355,7 +355,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "Результати пошуку";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "Виділити…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hans.lproj/Localizable.strings
@@ -385,7 +385,8 @@
 /* No comment provided by engineer. */
 "Search Results" = "搜索结果";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "选择…";
 
 /* No comment provided by engineer. */

--- a/Vienna/Resources/zh-Hant.lproj/InfoPlist.strings
+++ b/Vienna/Resources/zh-Hant.lproj/InfoPlist.strings
@@ -1,6 +1,9 @@
 /* A message that tells the user why Vienna is requesting the ability to send Apple events. */
 "NSAppleEventsUsageDescription" = "";
 
+/* A label for OPML (Outline Processor Markup Language) documents. This is shown in Finder's Get Info window, for example. */
+"OPML document" = "OPML 文件";
+
 /* A label for plug-in bundles. This is shown in Finder's Get Info window, for example. */
 "Vienna plug-in" = "Vienna 外掛";
 

--- a/Vienna/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Vienna/Resources/zh-Hant.lproj/Localizable.strings
@@ -31,6 +31,9 @@
 /* No comment provided by engineer. */
 "A new Vienna database cannot be created at \"%@\" because the folder is probably located on a remote network share and this version of Vienna cannot manage remote databases. Please choose an alternative folder that is located on your local machine." = "無法在“%@”建立新的 Vienna 資料庫，原因可能是這個檔案夾位在遠端網路分享空間中，而 Vienna 無法管理遠端的資料庫。請在您的本機電腦上，選擇其他的檔案夾。";
 
+/* Toolbar item palette label */
+"Add to Safari Reading List" = "增加到 Safari 閱讀清單中";
+
 /* No comment provided by engineer. */
 "AppleScript Error in '%@' script" = "在 %@ 腳本中發生 AppleScript 錯誤";
 
@@ -165,6 +168,10 @@
 /* Toolbar item tooltip */
 "Email a link to the current article or website" = "寄送目前文章或網站的連結";
 
+/* Toolbar item label
+   Toolbar item palette label */
+"Email Link" = "郵件連結";
+
 /* Title of a button on an alert */
 "Empty" = "清除";
 
@@ -182,6 +189,9 @@
 
 /* No comment provided by engineer. */
 "Error loading script '%@'" = "載入 script 時發生錯誤 %@";
+
+/* No comment provided by engineer. */
+"Error parsing data in feed" = "於解析源料內容時發生錯誤";
 
 /* No comment provided by engineer. */
 "Error retrieving RSS feed:" = "取得 RSS 內容發生錯誤：";
@@ -436,6 +446,15 @@
 /* A formatted URL string with the javascript: URL scheme. */
 "Run script “%@”" = "執行腳本 \"%@\"";
 
+/* Toolbar item label */
+"Safari Reading List" = "Safari 閱讀清單";
+
+/* Search panel title
+   Toolbar item label
+   Toolbar item palette label
+   Toolbar item tooltip */
+"Search" = "搜尋";
+
 /* Placeholder title of a search field */
 "Search all articles" = "搜尋所有文章";
 
@@ -451,7 +470,8 @@
 /* Label of a button on an open panel */
 "Select" = "選擇";
 
-/* Title of a popup menu item */
+/* Title of a menu item
+   Title of a popup menu item */
 "Select…" = "選取⋯";
 
 /* A formatted URL string with the mailto: URL scheme. */


### PR DESCRIPTION
I deleted the Spanish and Portuguese predicates files, because they aren't complete (which leads to problems with the NSPredicateEditor) and aren't tracked by Xcode right now. They can be re-added in the future once the translations are complete.

I have been trying to find a new workflow for Xcode's new String Catalog files, but I have run into several issues with Xcode and with Crowdin. It's too much of a hassle right now to switch to it.