### PR TITLE
Strip extended attributes during the creation of the release tar file

### DIFF
--- a/Scripts/Release-for-upload.sh
+++ b/Scripts/Release-for-upload.sh
@@ -26,13 +26,12 @@ esac
 pushd "${VIENNA_UPLOADS_DIR}"
 
 # Make the dSYM Bundle
-tar -a -cf "${dSYM_FILENAME}.tgz" --exclude '.DS_Store' -C "$ARCHIVE_DSYMS_PATH" .
+tar -c -f "${dSYM_FILENAME}.tgz" --format ustar --gzip --no-xattrs --exclude '.DS_Store' -C "$ARCHIVE_DSYMS_PATH" .
 
 # Zip up the app
 # Copy the app cleanly
 xcodebuild -exportNotarizedApp -archivePath "$ARCHIVE_PATH" -exportPath .
-xattr -c -r Vienna.app
-tar -a -cf "${TGZ_FILENAME}" --exclude '.DS_Store' Vienna.app
+tar -c -f "${TGZ_FILENAME}" --format ustar --gzip --no-xattrs --exclude '.DS_Store' Vienna.app
 rm -rf Vienna.app
 
 # Output the sparkle change log


### PR DESCRIPTION
Resolves #1726 (see also:  #1611)

- Adds `--no-xattrs` to `tar` command to strip attributes
- Replaces the `-a` (auto-compress) mode with explicit formats


