### PR TITLE
Restore delete key behavior on articles

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1949,7 +1949,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			if (self.mainWindow.firstResponder == self.foldersTree.mainView) {
 				[self deleteFolder:self];
 				return YES;
-			} else if (self.mainWindow.firstResponder == (self.articleController.mainArticleView).mainView) {
+			} else if (self.browser.activeTab == nil) { // make sure we are in the articles tab
 				[self deleteMessage:self];
 				return YES;
 			}


### PR DESCRIPTION
Make Delete key delete the article when focus is on the article content panel.

Fix issue #1735