### PR TITLE
Set NSURLSessionConfiguration to use URL cache 

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -105,7 +105,6 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         NSString * userAgent = [NSString stringWithFormat:MA_DefaultUserAgentString, name, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], osVersion];
         NSURLSessionConfiguration * config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.timeoutIntervalForResource = 300;
-        config.URLCache = nil;
         config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent};
         config.HTTPMaximumConnectionsPerHost = 6;
         config.HTTPShouldUsePipelining = YES;


### PR DESCRIPTION
Reverts commit a0f84f9 as it seems to be not needed anymore and it might lead to excessive hits on servers.
Issue #1733