### PR TITLE
Find swiftlint when it is in an alternate location

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1993,7 +1993,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --lenient\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=/opt/homebrew/bin:/sw/bin:/opt/local/bin:/usr/local/bin:${PATH}\n\nif which swiftlint >/dev/null; then\n    swiftlint --lenient\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F6B123401E474EC500973699 /* Index Help Book */ = {


### PR DESCRIPTION
SwiftLint was not found by Xcode when it is installed through Homebrew
on a Mac Silicon machine.