### PR TITLE
Keep focus on article list after click on article view

### DIFF
--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -109,6 +109,7 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
             let openInPreferredBrower = !navigationAction.modifierFlags.contains(.option)
             // TODO: maybe we need to add an api that opens a clicked link in foreground to the AppController
             NSApp.appController.open(navigationAction.request.url, inPreferredBrowser: openInPreferredBrower)
+            NSApp.mainWindow?.makeFirstResponder((NSApp.appController.articleListView).mainView)
         } else {
             decisionHandler(.allow)
         }


### PR DESCRIPTION
Solves issue  #1728 (up-down keys for navigating between articles disabled after clicking inside an article view) 
Might also help with issue #1762 (links in article view not clickable anymore until Vienna restart) by disambiguating responder designation.