### PR TITLE
Add "Date Published" sorting option and table column 

### DIFF
--- a/Vienna Tests/ArticleTests.swift
+++ b/Vienna Tests/ArticleTests.swift
@@ -81,20 +81,20 @@ class ArticleTests: XCTestCase {
         XCTAssertEqual(self.article.link, link)
     }
 
-    func testDate() {
+    func testLastUpdate() {
         let date = Date()
 
-        self.article.date = date
+        self.article.lastUpdate = date
 
-        XCTAssertEqual(self.article.date, date)
+        XCTAssertEqual(self.article.lastUpdate, date)
     }
 
-    func testDateCreated() {
+    func testPublicationDate() {
         let date = Date()
 
-        self.article.createdDate = date
+        self.article.publicationDate = date
 
-        XCTAssertEqual(self.article.createdDate, date)
+        XCTAssertEqual(self.article.publicationDate, date)
     }
 
     func testBody() {
@@ -193,9 +193,9 @@ class ArticleTests: XCTestCase {
 
     func testCompatibilityDate() {
         let date = Date()
-        let dateKeyPath = "articleData." + MA_Field_Date
+        let dateKeyPath = "articleData." + MA_Field_LastUpdate
 
-        self.article.date = date
+        self.article.lastUpdate = date
 
         XCTAssertEqual(self.article.value(forKeyPath: dateKeyPath) as? Date, date)
     }

--- a/Vienna Tests/VNAArticleTests.m
+++ b/Vienna Tests/VNAArticleTests.m
@@ -73,22 +73,22 @@ static NSString * const Body =
     XCTAssertEqualObjects(self.article.link, Link);
 }
 
-- (void)testDate
+- (void)testLastUpdate
 {
     NSDate *date = [NSDate date];
 
-    self.article.date = date;
+    self.article.lastUpdate = date;
 
-    XCTAssertEqualObjects(self.article.date, date);
+    XCTAssertEqualObjects(self.article.lastUpdate, date);
 }
 
-- (void)testDateCreated
+- (void)testPublicationDate
 {
     NSDate *date = [NSDate date];
 
-    self.article.createdDate = date;
+    self.article.publicationDate = date;
 
-    XCTAssertEqualObjects(self.article.createdDate, date);
+    XCTAssertEqualObjects(self.article.publicationDate, date);
 }
 
 - (void)testBody
@@ -201,9 +201,9 @@ static NSString * const Body =
 - (void)testCompatibilityDate
 {
     NSDate *date = [NSDate date];
-    NSString *dateKeyPath = [@"articleData." stringByAppendingString:MA_Field_Date];
+    NSString *dateKeyPath = [@"articleData." stringByAppendingString:MA_Field_LastUpdate];
 
-    self.article.date = date;
+    self.article.lastUpdate = date;
 
     XCTAssertEqualObjects([self.article valueForKeyPath:dateKeyPath], date);
 }

--- a/Vienna/Resources/Base.lproj/Predicates.strings
+++ b/Vienna/Resources/Base.lproj/Predicates.strings
@@ -1,8 +1,8 @@
 "%[All,Any,None]@ of the following are true" = "Article matches %1$[all,any,none]@ of the following conditions";
 "%[Author,Folder,Subject,Text]@ %[is,is not]@ %@" = "%1$[Author,Folder,Subject,Content]@ %2$[is,is not]@ %3$@";
 "%[Author,Subject,Text]@ %[contains,does not contain]@ %@" = "%1$[Author,Subject,Content]@ %2$[contains,does not contain]@ %3$@";
-"%[Date]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Date]@ %2$[is,is after or is,is before,is before or is]@ %3$[yesterday]@";
-"%[Date]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Date]@ %2$[is,is after,is after or is,is before,is before or is]@ %3$[last week]@";
-"%[Date]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Date]@ %2$[is,is before,is before or is]@ %3$[today]@";
-"%[Date]@ %[less than ago,more than ago]@ %[days,hours,minutes,months,weeks,years]@ %@" = "%1$[Date]@ %2$[is in the last,is not in the last]@ %4$@ %3$[days,hours,minutes,months,weeks,years]@";
+"%[Date]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Last update]@ %2$[is,is after or is,is before,is before or is]@ %3$[yesterday]@";
+"%[Date]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Last update]@ %2$[is,is after,is after or is,is before,is before or is]@ %3$[last week]@";
+"%[Date]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Last update]@ %2$[is,is before,is before or is]@ %3$[today]@";
+"%[Date]@ %[less than ago,more than ago]@ %[days,hours,minutes,months,weeks,years]@ %@" = "%1$[Last update]@ %2$[is in the last,is not in the last]@ %4$@ %3$[days,hours,minutes,months,weeks,years]@";
 "%[Deleted,Flagged,HasEnclosure,Read]@ is %[No,Yes]@" = "%1$[Is deleted,Is flagged,Has enclosure,Is read]@ %2$[No,Yes]@";

--- a/Vienna/Resources/Base.lproj/Predicates.strings
+++ b/Vienna/Resources/Base.lproj/Predicates.strings
@@ -1,8 +1,8 @@
 "%[All,Any,None]@ of the following are true" = "Article matches %1$[all,any,none]@ of the following conditions";
 "%[Author,Folder,Subject,Text]@ %[is,is not]@ %@" = "%1$[Author,Folder,Subject,Content]@ %2$[is,is not]@ %3$@";
 "%[Author,Subject,Text]@ %[contains,does not contain]@ %@" = "%1$[Author,Subject,Content]@ %2$[contains,does not contain]@ %3$@";
-"%[Date]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Last update]@ %2$[is,is after or is,is before,is before or is]@ %3$[yesterday]@";
-"%[Date]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Last update]@ %2$[is,is after,is after or is,is before,is before or is]@ %3$[last week]@";
-"%[Date]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Last update]@ %2$[is,is before,is before or is]@ %3$[today]@";
-"%[Date]@ %[less than ago,more than ago]@ %[days,hours,minutes,months,weeks,years]@ %@" = "%1$[Last update]@ %2$[is in the last,is not in the last]@ %4$@ %3$[days,hours,minutes,months,weeks,years]@";
+"%[Date, PublicationDate]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Last update, Date Published]@ %2$[is,is after or is,is before,is before or is]@ %3$[yesterday]@";
+"%[Date, PublicationDate]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Last update, Date Published]@ %2$[is,is after,is after or is,is before,is before or is]@ %3$[last week]@";
+"%[Date, PublicationDate]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Last update, Date Published]@ %2$[is,is before,is before or is]@ %3$[today]@";
+"%[Date, PublicationDate]@ %[less than ago,more than ago]@ %[days,hours,minutes,months,weeks,years]@ %@" = "%1$[Last update, Date Published]@ %2$[is in the last,is not in the last]@ %4$@ %3$[days,hours,minutes,months,weeks,years]@";
 "%[Deleted,Flagged,HasEnclosure,Read]@ is %[No,Yes]@" = "%1$[Is deleted,Is flagged,Has enclosure,Is read]@ %2$[No,Yes]@";

--- a/Vienna/Resources/Base.lproj/Predicates.strings
+++ b/Vienna/Resources/Base.lproj/Predicates.strings
@@ -1,8 +1,8 @@
 "%[All,Any,None]@ of the following are true" = "Article matches %1$[all,any,none]@ of the following conditions";
 "%[Author,Folder,Subject,Text]@ %[is,is not]@ %@" = "%1$[Author,Folder,Subject,Content]@ %2$[is,is not]@ %3$@";
 "%[Author,Subject,Text]@ %[contains,does not contain]@ %@" = "%1$[Author,Subject,Content]@ %2$[contains,does not contain]@ %3$@";
-"%[Date, PublicationDate]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Last update, Date Published]@ %2$[is,is after or is,is before,is before or is]@ %3$[yesterday]@";
-"%[Date, PublicationDate]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Last update, Date Published]@ %2$[is,is after,is after or is,is before,is before or is]@ %3$[last week]@";
-"%[Date, PublicationDate]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Last update, Date Published]@ %2$[is,is before,is before or is]@ %3$[today]@";
-"%[Date, PublicationDate]@ %[less than ago,more than ago]@ %[days,hours,minutes,months,weeks,years]@ %@" = "%1$[Last update, Date Published]@ %2$[is in the last,is not in the last]@ %4$@ %3$[days,hours,minutes,months,weeks,years]@";
+"%[Date,PublicationDate]@ %[is,is greater than or equal to,is less than,is less than or equal to]@ %[yesterday]@" = "%1$[Last update, Date Published]@ %2$[is,is after or is,is before,is before or is]@ %3$[yesterday]@";
+"%[Date,PublicationDate]@ %[is,is greater than,is greater than or equal to,is less than,is less than or equal to]@ %[last week]@" = "%1$[Last update,Date Published]@ %2$[is,is after,is after or is,is before,is before or is]@ %3$[last week]@";
+"%[Date,PublicationDate]@ %[is,is less than,is less than or equal to]@ %[today]@" = "%1$[Last update,Date Published]@ %2$[is,is before,is before or is]@ %3$[today]@";
+"%[Date,PublicationDate]@ %[less than ago,more than ago]@ %[days,hours,minutes,months,weeks,years]@ %@" = "%1$[Last update,Date Published]@ %2$[is in the last,is not in the last]@ %4$@ %3$[days,hours,minutes,months,weeks,years]@";
 "%[Deleted,Flagged,HasEnclosure,Read]@ is %[No,Yes]@" = "%1$[Is deleted,Is flagged,Has enclosure,Is read]@ %2$[No,Yes]@";

--- a/Vienna/Resources/Localizable.xcstrings
+++ b/Vienna/Resources/Localizable.xcstrings
@@ -6498,6 +6498,7 @@
     },
     "Date" : {
       "comment" : "Data field name visible in menu/article list/smart folder definition",
+      "extractionState" : "stale",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -6620,6 +6621,9 @@
           }
         }
       }
+    },
+    "Date Published" : {
+      "comment" : "Data field name visible in menu/article list/smart folder definition"
     },
     "Delete" : {
       "comment" : "Title of a button on an alert\n   Title of a menu item",
@@ -12851,6 +12855,9 @@
           }
         }
       }
+    },
+    "Last Update" : {
+      "comment" : "Data field name visible in menu/article list/smart folder definition"
     },
     "Link" : {
       "comment" : "Data field name visible in menu/article list",

--- a/Vienna/Sources/Alerts/SmartFolder.m
+++ b/Vienna/Sources/Alerts/SmartFolder.m
@@ -172,11 +172,14 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
 
     [rowTemplates addObject:[VNASeparatorPredicateEditorRowTemplate new]];
 
+
+    NSArray *dateLeftExpressions = @[
+        [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
+        [NSExpression expressionForConstantValue:MA_Field_PublicationDate]];
+
     // date < / > days / weeks / months / years old
     NSPredicateEditorRowTemplate *dateCompareTemplate = [[VNADateWithUnitPredicateEditorRowTemplate alloc] 
-                                                         initWithLeftExpressions:@[
-                                                            [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
-                                                            [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]];
+                                                         initWithLeftExpressions:dateLeftExpressions];
     [rowTemplates addObject:dateCompareTemplate];
 
     // date = / < / <= today / yesterday / lastWeek
@@ -189,9 +192,7 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         @(NSLessThanOrEqualToPredicateOperatorType),
     ];
     NSPredicateEditorRowTemplate *todayTemplate = [[NSPredicateEditorRowTemplate alloc]
-                                                   initWithLeftExpressions:@[
-                                                      [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
-                                                      [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]
+                                                  initWithLeftExpressions:dateLeftExpressions
                                                   rightExpressions:todayRightExpressions
                                                   modifier:NSDirectPredicateModifier
                                                   operators:todayOperators
@@ -209,9 +210,7 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         @(NSGreaterThanOrEqualToPredicateOperatorType)
     ];
     NSPredicateEditorRowTemplate *yesterdayTemplate = [[NSPredicateEditorRowTemplate alloc]
-                                                       initWithLeftExpressions:@[
-                                                           [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
-                                                           [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]
+                                                       initWithLeftExpressions:dateLeftExpressions
                                                        rightExpressions:yesterdayRightExpressions
                                                        modifier:NSDirectPredicateModifier
                                                        operators:yesterdayOperators
@@ -230,9 +229,7 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         @(NSLessThanOrEqualToPredicateOperatorType)
     ];
     NSPredicateEditorRowTemplate *dateTemplate = [[NSPredicateEditorRowTemplate alloc]
-                                                  initWithLeftExpressions:@[
-                                                      [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
-                                                      [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]
+                                                  initWithLeftExpressions:dateLeftExpressions
                                                   rightExpressions:weekRightExpressions
                                                   modifier:NSDirectPredicateModifier
                                                   operators:weekOperators

--- a/Vienna/Sources/Alerts/SmartFolder.m
+++ b/Vienna/Sources/Alerts/SmartFolder.m
@@ -173,7 +173,7 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
     [rowTemplates addObject:[VNASeparatorPredicateEditorRowTemplate new]];
 
     // date < / > days / weeks / months / years old
-    NSPredicateEditorRowTemplate *dateCompareTemplate = [[VNADateWithUnitPredicateEditorRowTemplate alloc] initWithLeftExpressions:@[[NSExpression expressionForConstantValue:MA_Field_Date]]];
+    NSPredicateEditorRowTemplate *dateCompareTemplate = [[VNADateWithUnitPredicateEditorRowTemplate alloc] initWithLeftExpressions:@[[NSExpression expressionForConstantValue:MA_Field_LastUpdate]]];
     [rowTemplates addObject:dateCompareTemplate];
 
     // date = / < / <= today / yesterday / lastWeek

--- a/Vienna/Sources/Alerts/SmartFolder.m
+++ b/Vienna/Sources/Alerts/SmartFolder.m
@@ -147,9 +147,9 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
 
     // subject / author / text contains / = / != <text>
     NSArray<NSExpression *> *textLeftExpressions = @[
-        [NSExpression expressionForConstantValue:@"Text"],
-        [NSExpression expressionForConstantValue:@"Author"],
-        [NSExpression expressionForConstantValue:@"Subject"]
+        [NSExpression expressionForConstantValue:MA_Field_Text],
+        [NSExpression expressionForConstantValue:MA_Field_Author],
+        [NSExpression expressionForConstantValue:MA_Field_Subject]
     ];
     NSPredicateEditorRowTemplate *textTemplate = [[NSPredicateEditorRowTemplate alloc]
                                                   initWithLeftExpressions:textLeftExpressions
@@ -173,7 +173,10 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
     [rowTemplates addObject:[VNASeparatorPredicateEditorRowTemplate new]];
 
     // date < / > days / weeks / months / years old
-    NSPredicateEditorRowTemplate *dateCompareTemplate = [[VNADateWithUnitPredicateEditorRowTemplate alloc] initWithLeftExpressions:@[[NSExpression expressionForConstantValue:MA_Field_LastUpdate]]];
+    NSPredicateEditorRowTemplate *dateCompareTemplate = [[VNADateWithUnitPredicateEditorRowTemplate alloc] 
+                                                         initWithLeftExpressions:@[
+                                                            [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
+                                                            [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]];
     [rowTemplates addObject:dateCompareTemplate];
 
     // date = / < / <= today / yesterday / lastWeek
@@ -186,7 +189,9 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         @(NSLessThanOrEqualToPredicateOperatorType),
     ];
     NSPredicateEditorRowTemplate *todayTemplate = [[NSPredicateEditorRowTemplate alloc]
-                                                  initWithLeftExpressions:@[[NSExpression expressionForConstantValue:@"Date"]]
+                                                   initWithLeftExpressions:@[
+                                                      [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
+                                                      [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]
                                                   rightExpressions:todayRightExpressions
                                                   modifier:NSDirectPredicateModifier
                                                   operators:todayOperators
@@ -204,11 +209,13 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         @(NSGreaterThanOrEqualToPredicateOperatorType)
     ];
     NSPredicateEditorRowTemplate *yesterdayTemplate = [[NSPredicateEditorRowTemplate alloc]
-                                                  initWithLeftExpressions:@[[NSExpression expressionForConstantValue:@"Date"]]
-                                                  rightExpressions:yesterdayRightExpressions
-                                                  modifier:NSDirectPredicateModifier
-                                                  operators:yesterdayOperators
-                                                  options:0];
+                                                       initWithLeftExpressions:@[
+                                                           [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
+                                                           [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]
+                                                       rightExpressions:yesterdayRightExpressions
+                                                       modifier:NSDirectPredicateModifier
+                                                       operators:yesterdayOperators
+                                                       options:0];
     [rowTemplates addObject:yesterdayTemplate];
 
     // date = / > / >= / < / <= last week
@@ -223,7 +230,9 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         @(NSLessThanOrEqualToPredicateOperatorType)
     ];
     NSPredicateEditorRowTemplate *dateTemplate = [[NSPredicateEditorRowTemplate alloc]
-                                                  initWithLeftExpressions:@[[NSExpression expressionForConstantValue:@"Date"]]
+                                                  initWithLeftExpressions:@[
+                                                      [NSExpression expressionForConstantValue:MA_Field_LastUpdate],
+                                                      [NSExpression expressionForConstantValue:MA_Field_PublicationDate]]
                                                   rightExpressions:weekRightExpressions
                                                   modifier:NSDirectPredicateModifier
                                                   operators:weekOperators
@@ -234,10 +243,10 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
 
     // read / flagged / deleted / has_enclosure = YES / NO
     NSArray<NSExpression *> *booleanLeftExpressions = @[
-        [NSExpression expressionForConstantValue:@"Read"],
-        [NSExpression expressionForConstantValue:@"Flagged"],
-        [NSExpression expressionForConstantValue:@"Deleted"],
-        [NSExpression expressionForConstantValue:@"HasEnclosure"]
+        [NSExpression expressionForConstantValue:MA_Field_Read],
+        [NSExpression expressionForConstantValue:MA_Field_Flagged],
+        [NSExpression expressionForConstantValue:MA_Field_Deleted],
+        [NSExpression expressionForConstantValue:MA_Field_HasEnclosure]
     ];
     NSArray<NSExpression *> *booleanRightExpressions = @[
         [NSExpression expressionForConstantValue:@"Yes"],
@@ -256,7 +265,7 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
     // folder is / is not
     NSArray<NSExpression *> *folders = [self fillFolderValueField:VNAFolderTypeRoot atIndent:0];
     NSPredicateEditorRowTemplate *folderTemplate = [[NSPredicateEditorRowTemplate alloc]
-        initWithLeftExpressions:@[[NSExpression expressionForConstantValue:@"Folder"]]
+        initWithLeftExpressions:@[[NSExpression expressionForConstantValue:MA_Field_Folder]]
                rightExpressions:folders
                        modifier:NSDirectPredicateModifier
                       operators:@[@(NSEqualToPredicateOperatorType), @(NSNotEqualToPredicateOperatorType)]

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1143,15 +1143,15 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	for (Field * field in [db arrayOfFields]) {
 		// Filter out columns we don't sort on. Later we should have an attribute in the
 		// field object itself based on which columns we can sort on.
-		if (field.tag != ArticleFieldIDParent &&
-			field.tag != ArticleFieldIDGUID &&
-			field.tag != ArticleFieldIDDeleted &&
-			field.tag != ArticleFieldIDHeadlines &&
-			field.tag != ArticleFieldIDSummary &&
-			field.tag != ArticleFieldIDLink &&
-			field.tag != ArticleFieldIDText &&
-			field.tag != ArticleFieldIDEnclosureDownloaded &&
-			field.tag != ArticleFieldIDEnclosure)
+		if (field.tag != VNAArticleFieldTagParent &&
+			field.tag != VNAArticleFieldTagGUID &&
+			field.tag != VNAArticleFieldTagDeleted &&
+			field.tag != VNAArticleFieldTagHeadlines &&
+			field.tag != VNAArticleFieldTagSummary &&
+			field.tag != VNAArticleFieldTagLink &&
+			field.tag != VNAArticleFieldTagText &&
+			field.tag != VNAArticleFieldTagEnclosureDownloaded &&
+			field.tag != VNAArticleFieldTagEnclosure)
 		{
 			NSMenuItem * menuItem = [[NSMenuItem alloc] initWithTitle:field.displayName action:@selector(doSortColumn:) keyEquivalent:@""];
 			menuItem.representedObject = field;
@@ -1184,12 +1184,12 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	for (Field * field in [db arrayOfFields]) {
 		// Filter out columns we don't view in the article list. Later we should have an attribute in the
 		// field object based on which columns are visible in the tableview.
-		if (field.tag != ArticleFieldIDText && 
-			field.tag != ArticleFieldIDGUID &&
-			field.tag != ArticleFieldIDDeleted &&
-			field.tag != ArticleFieldIDParent &&
-			field.tag != ArticleFieldIDHeadlines &&
-			field.tag != ArticleFieldIDEnclosureDownloaded)
+		if (field.tag != VNAArticleFieldTagText && 
+			field.tag != VNAArticleFieldTagGUID &&
+			field.tag != VNAArticleFieldTagDeleted &&
+			field.tag != VNAArticleFieldTagParent &&
+			field.tag != VNAArticleFieldTagHeadlines &&
+			field.tag != VNAArticleFieldTagEnclosureDownloaded)
 		{
 			NSMenuItem * menuItem = [[NSMenuItem alloc] initWithTitle:field.displayName action:@selector(doViewColumn:) keyEquivalent:@""];
 			menuItem.representedObject = field;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1764,10 +1764,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)handleRefreshStatusChange:(NSNotification *)nc
 {
 	if (self.connecting) {
-		// Save the date/time of this refresh so we do the right thing when
-		// we apply the filter.
-		[[Preferences standardPreferences] setObject:[NSDate date] forKey:MAPref_LastRefreshDate];
-		
 		// Toggle the refresh button
 		NSToolbarItem *item = [self toolbarItemWithIdentifier:@"Refresh"];
 		item.action = @selector(cancelAllRefreshesToolbar:);

--- a/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
+++ b/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
@@ -177,7 +177,7 @@ extension Criteria: PredicateConvertible {
                 fallback = true
                 criteriaOperator = .equalTo
             }
-        case MA_Field_LastUpdate:
+        case MA_Field_LastUpdate, MA_Field_PublicationDate:
             switch predicate.predicateOperatorType {
             case .lessThan:
                 criteriaOperator = .before
@@ -231,14 +231,15 @@ extension Criteria: PredicateConvertible {
         let value = self.value
         let operatorType = self.operatorType
 
-        if field == MA_Field_LastUpdate, let unit = DateUnit.allCases.first(where: { value.hasSuffix($0.rawValue) }) {
+        if field == MA_Field_LastUpdate || field == MA_Field_PublicationDate,
+           let unit = DateUnit.allCases.first(where: { value.hasSuffix($0.rawValue) }) {
             let countString = value
                 .replacingOccurrences(of: unit.rawValue, with: "")
                 .trimmingCharacters(in: CharacterSet.whitespaces)
             guard let count = UInt(countString) else {
                 fatalError("malformed criteria value \(value)")
             }
-            return DatePredicateWithUnit(field: MA_Field_LastUpdate, comparisonOperator: operatorType, count: count, unit: unit)
+            return DatePredicateWithUnit(field: field, comparisonOperator: operatorType, count: count, unit: unit)
         } else {
             return buildComparisonPredicate(field, value, operatorType)
         }
@@ -291,7 +292,8 @@ extension Criteria: PredicateConvertible {
         // TODO: constants for fixed criteria values also for Criteria+SQL,
         // e.g. YES, NO, yesterday, today, last week, ...
 
-        if field == MA_Field_LastUpdate && operatorType == .after && value == DateOffset.yesterday.rawValue {
+        if (field == MA_Field_LastUpdate || field == MA_Field_PublicationDate)
+            && operatorType == .after && value == DateOffset.yesterday.rawValue {
             // Use canonical "is today" instead of "is after yesterday"
             comparisonPredicate = NSComparisonPredicate(leftExpression: left, rightExpression: NSExpression(forConstantValue: DateOffset.today), modifier: .direct, type: .equalTo)
         } else if operatorType == .notEqualTo && (value == "No" || value == "Yes") {

--- a/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
+++ b/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
@@ -291,9 +291,9 @@ extension Criteria: PredicateConvertible {
         // TODO: constants for fixed criteria values also for Criteria+SQL,
         // e.g. YES, NO, yesterday, today, last week, ...
 
-        if field == MA_Field_LastUpdate && operatorType == .after && value == "yesterday" {
+        if field == MA_Field_LastUpdate && operatorType == .after && value == DateOffset.yesterday.rawValue {
             // Use canonical "is today" instead of "is after yesterday"
-            comparisonPredicate = NSComparisonPredicate(leftExpression: left, rightExpression: NSExpression(forConstantValue: "today"), modifier: .direct, type: .equalTo)
+            comparisonPredicate = NSComparisonPredicate(leftExpression: left, rightExpression: NSExpression(forConstantValue: DateOffset.today), modifier: .direct, type: .equalTo)
         } else if operatorType == .notEqualTo && (value == "No" || value == "Yes") {
             // Use canonical "is yes / is no" representation instead of allowing
             // ambiguous "is not yes - is no / is not no - is yes"

--- a/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
+++ b/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
@@ -177,7 +177,7 @@ extension Criteria: PredicateConvertible {
                 fallback = true
                 criteriaOperator = .equalTo
             }
-        case MA_Field_Date:
+        case MA_Field_LastUpdate:
             switch predicate.predicateOperatorType {
             case .lessThan:
                 criteriaOperator = .before
@@ -231,14 +231,14 @@ extension Criteria: PredicateConvertible {
         let value = self.value
         let operatorType = self.operatorType
 
-        if field == MA_Field_Date, let unit = DateUnit.allCases.first(where: { value.hasSuffix($0.rawValue) }) {
+        if field == MA_Field_LastUpdate, let unit = DateUnit.allCases.first(where: { value.hasSuffix($0.rawValue) }) {
             let countString = value
                 .replacingOccurrences(of: unit.rawValue, with: "")
                 .trimmingCharacters(in: CharacterSet.whitespaces)
             guard let count = UInt(countString) else {
                 fatalError("malformed criteria value \(value)")
             }
-            return DatePredicateWithUnit(field: MA_Field_Date, comparisonOperator: operatorType, count: count, unit: unit)
+            return DatePredicateWithUnit(field: MA_Field_LastUpdate, comparisonOperator: operatorType, count: count, unit: unit)
         } else {
             return buildComparisonPredicate(field, value, operatorType)
         }
@@ -291,7 +291,7 @@ extension Criteria: PredicateConvertible {
         // TODO: constants for fixed criteria values also for Criteria+SQL,
         // e.g. YES, NO, yesterday, today, last week, ...
 
-        if field == MA_Field_Date && operatorType == .after && value == "yesterday" {
+        if field == MA_Field_LastUpdate && operatorType == .after && value == "yesterday" {
             // Use canonical "is today" instead of "is after yesterday"
             comparisonPredicate = NSComparisonPredicate(leftExpression: left, rightExpression: NSExpression(forConstantValue: "today"), modifier: .direct, type: .equalTo)
         } else if operatorType == .notEqualTo && (value == "No" || value == "Yes") {

--- a/Vienna/Sources/Criteria/Criteria+SQL.swift
+++ b/Vienna/Sources/Criteria/Criteria+SQL.swift
@@ -89,11 +89,11 @@ extension Criteria: SQLConversion {
         let startOfToday = Calendar.current.startOfDay(for: Date())
 
         let startDate: Date?
-        if value == "today" {
+        if value == DateOffset.today.rawValue {
             startDate = startOfToday
-        } else if value == "yesterday" {
+        } else if value == DateOffset.yesterday.rawValue {
             startDate = Calendar.current.date(byAdding: .day, value: -1, to: startOfToday)
-        } else if value == "last week" {
+        } else if value == DateOffset.lastWeek.rawValue {
             startDate = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: startOfToday)
         } else {
             // Check for the pattern for date with unit criteria
@@ -142,10 +142,10 @@ extension Criteria: SQLConversion {
         guard operatorType == .equalTo || operatorType == .notEqualTo else {
             fatalError("Operator type \(operatorType) not applicable to flag field \(sqlFieldName)")
         }
-        let val: String
-        if value == "Yes" { val = "1" } else { val = "0" }
+        let sqlValue: String
+        if value == "Yes" { sqlValue = "1" } else { sqlValue = "0" }
         let sqlOperator = standardSqlOperator()
-        return "\(sqlFieldName) \(sqlOperator) \(val)"
+        return "\(sqlFieldName) \(sqlOperator) \(sqlValue)"
     }
 
     func folderSqlString(sqlFieldName: String, database: Database) -> String {

--- a/Vienna/Sources/Criteria/Criteria.swift
+++ b/Vienna/Sources/Criteria/Criteria.swift
@@ -45,40 +45,38 @@ enum CriteriaOperator: Int {
 
     // Workaround as long as this enum needs to be exposed to Objective-C and cannot have a string as raw value
     init?(rawValue: String) {
-        let criteriaOperator: CriteriaOperator
         switch rawValue {
         case "\(CriteriaOperator.equalTo)":
-            criteriaOperator = CriteriaOperator.equalTo
+            self = CriteriaOperator.equalTo
         case "\(CriteriaOperator.notEqualTo)":
-            criteriaOperator = CriteriaOperator.notEqualTo
+            self = CriteriaOperator.notEqualTo
         case "\(CriteriaOperator.lessThan)":
-            criteriaOperator = CriteriaOperator.lessThan
+            self = CriteriaOperator.lessThan
         case "\(CriteriaOperator.greaterThan)":
-            criteriaOperator = CriteriaOperator.greaterThan
+            self = CriteriaOperator.greaterThan
         case "\(CriteriaOperator.lessThanOrEqualTo)":
-            criteriaOperator = CriteriaOperator.lessThanOrEqualTo
+            self = CriteriaOperator.lessThanOrEqualTo
         case "\(CriteriaOperator.greaterThanOrEqualTo)":
-            criteriaOperator = CriteriaOperator.greaterThanOrEqualTo
+            self = CriteriaOperator.greaterThanOrEqualTo
         case "\(CriteriaOperator.contains)":
-            criteriaOperator = CriteriaOperator.contains
+            self = CriteriaOperator.contains
         case "\(CriteriaOperator.containsNot)":
-            criteriaOperator = CriteriaOperator.containsNot
+            self = CriteriaOperator.containsNot
         case "\(CriteriaOperator.before)":
-            criteriaOperator = CriteriaOperator.before
+            self = CriteriaOperator.before
         case "\(CriteriaOperator.after)":
-            criteriaOperator = CriteriaOperator.after
+            self = CriteriaOperator.after
         case "\(CriteriaOperator.onOrBefore)":
-            criteriaOperator = CriteriaOperator.onOrBefore
+            self = CriteriaOperator.onOrBefore
         case "\(CriteriaOperator.onOrAfter)":
-            criteriaOperator = CriteriaOperator.onOrAfter
+            self = CriteriaOperator.onOrAfter
         case "\(CriteriaOperator.under)":
-            criteriaOperator = CriteriaOperator.under
+            self = CriteriaOperator.under
         case "\(CriteriaOperator.notUnder)":
-            criteriaOperator = CriteriaOperator.notUnder
+            self = CriteriaOperator.notUnder
         default:
             return nil
         }
-        self.init(rawValue: criteriaOperator.rawValue)
     }
 
     var intValue: Int {

--- a/Vienna/Sources/Criteria/DatePredicateWithUnit.swift
+++ b/Vienna/Sources/Criteria/DatePredicateWithUnit.swift
@@ -19,6 +19,10 @@
 
 import Foundation
 
+enum DateOffset: String {
+    case today, yesterday, lastWeek = "last week"
+}
+
 enum DateUnit: String, CaseIterable {
     case minutes
     case hours

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -336,6 +336,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     [self addField:MA_Field_Subject type:VNAFieldTypeString tag:ArticleFieldIDSubject sqlField:@"title" visible:YES width:472];
     [self addField:MA_Field_Folder type:VNAFieldTypeFolder tag:ArticleFieldIDFolder sqlField:@"folder_id" visible:NO width:130];
     [self addField:MA_Field_Date type:VNAFieldTypeDate tag:ArticleFieldIDDate sqlField:@"date" visible:YES width:152];
+    [self addField:MA_Field_CreatedDate type:VNAFieldTypeDate tag:ArticleFieldIDCreatedDate sqlField:@"createddate" visible:NO width:152];
     [self addField:MA_Field_Parent type:VNAFieldTypeInteger tag:ArticleFieldIDParent sqlField:@"parent_id" visible:NO width:72];
     [self addField:MA_Field_Author type:VNAFieldTypeString tag:ArticleFieldIDAuthor sqlField:@"sender" visible:YES width:138];
     [self addField:MA_Field_Link type:VNAFieldTypeString tag:ArticleFieldIDLink sqlField:@"link" visible:NO width:138];
@@ -354,6 +355,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	[self fieldByName:MA_Field_Subject].displayName = NSLocalizedString(@"Subject", @"Data field name visible in menu/article list/smart folder definition");
 	[self fieldByName:MA_Field_Folder].displayName = NSLocalizedString(@"Folder", @"Data field name visible in menu/article list/smart folder definition");
 	[self fieldByName:MA_Field_Date].displayName = NSLocalizedString(@"Date", @"Data field name visible in menu/article list/smart folder definition");
+	[self fieldByName:MA_Field_CreatedDate].displayName = NSLocalizedString(@"Date Added", @"Data field name visible in menu/article list/smart folder definition");
 	[self fieldByName:MA_Field_Author].displayName = NSLocalizedString(@"Author", @"Data field name visible in menu/article list/smart folder definition");
 	[self fieldByName:MA_Field_Text].displayName = NSLocalizedString(@"Text", @"Data field name visible in smart folder definition");
 	[self fieldByName:MA_Field_Summary].displayName = NSLocalizedString(@"Summary", @"Pseudo field name visible in menu/article list");

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -1508,7 +1508,6 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     // Extract the article data from the dictionary.
     NSString * articleBody = article.body;
     NSString * articleTitle = article.title;
-    NSDate * lastUpdate = article.lastUpdate;
     NSString * articleLink = article.link.vna_trimmed;
     NSString * userName = article.author.vna_trimmed;
     NSString * articleEnclosure = article.enclosure.vna_trimmed;
@@ -1520,13 +1519,15 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     BOOL deleted_flag = article.deleted;
     BOOL hasenclosure_flag = article.hasEnclosure;
 
+    NSDate *currentDate = [NSDate date];
+
     // We set the publication date ourselves if it is not contained in the feed, and only once when the article is created
-    article.publicationDate = article.publicationDate == nil ? [NSDate date] : article.publicationDate;
+    NSDate *publicationDate = article.publicationDate ? article.publicationDate : currentDate;
+    article.publicationDate = publicationDate;
+
+    NSDate * lastUpdate = article.lastUpdate ? article.lastUpdate : currentDate;
 
     // Set some defaults
-    if (lastUpdate == nil) {
-        lastUpdate = [NSDate date];
-    }
     if (userName == nil) {
         userName = @"";
     }
@@ -1538,8 +1539,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
     // Dates are stored as time intervals
     NSTimeInterval lastUpdateIntervalSince1970 = lastUpdate.timeIntervalSince1970;
-    NSTimeInterval publicationIntervalSince1970 = 
-        (article.publicationDate == nil ? [NSDate date] : article.publicationDate).timeIntervalSince1970;
+    NSTimeInterval publicationIntervalSince1970 = publicationDate.timeIntervalSince1970;
 
     __block BOOL success;
     [queue inTransaction:^(FMDatabase *db,  BOOL *rollback) {
@@ -1594,17 +1594,17 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     // Extract the data from the new state of article
     NSString * articleBody = article.body;
     NSString * articleTitle = article.title;
-    NSDate * lastUpdate = article.lastUpdate;
     NSString * articleLink = article.link.vna_trimmed;
     NSString * userName = article.author.vna_trimmed;
     NSString * articleGuid = article.guid;
     NSInteger parentId = article.parentId;
     BOOL revised_flag = article.revised;
 
+    //keep last update date the same if not set in the current version of the article
+    NSDate * lastUpdate = article.lastUpdate ? article.lastUpdate : existingArticle.lastUpdate;
+    //we do not update the publication date ever after inserting the article into the DB
+
     // Set some defaults
-    if (lastUpdate == nil) {
-        lastUpdate = existingArticle.lastUpdate;
-    }
     if (userName == nil) {
         userName = @"";
     }

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -328,23 +328,23 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     self.fieldsByName = [[NSMutableDictionary alloc] init];
     self.fieldsOrdered = [[NSMutableArray alloc] init];
     
-    [self addField:MA_Field_Read type:VNAFieldTypeFlag tag:ArticleFieldIDRead sqlField:@"read_flag" visible:YES width:17];
-    [self addField:MA_Field_Flagged type:VNAFieldTypeFlag tag:ArticleFieldIDFlagged sqlField:@"marked_flag" visible:YES width:17];
-    [self addField:MA_Field_HasEnclosure type:VNAFieldTypeFlag tag:ArticleFieldIDHasEnclosure sqlField:@"hasenclosure_flag" visible:YES width:17];
-    [self addField:MA_Field_Deleted type:VNAFieldTypeFlag tag:ArticleFieldIDDeleted sqlField:@"deleted_flag" visible:NO width:15];
-    [self addField:MA_Field_GUID type:VNAFieldTypeInteger tag:ArticleFieldIDGUID sqlField:@"message_id" visible:NO width:72];
-    [self addField:MA_Field_Subject type:VNAFieldTypeString tag:ArticleFieldIDSubject sqlField:@"title" visible:YES width:472];
-    [self addField:MA_Field_Folder type:VNAFieldTypeFolder tag:ArticleFieldIDFolder sqlField:@"folder_id" visible:NO width:130];
-    [self addField:MA_Field_Date type:VNAFieldTypeDate tag:ArticleFieldIDDate sqlField:@"date" visible:YES width:152];
-    [self addField:MA_Field_CreatedDate type:VNAFieldTypeDate tag:ArticleFieldIDCreatedDate sqlField:@"createddate" visible:NO width:152];
-    [self addField:MA_Field_Parent type:VNAFieldTypeInteger tag:ArticleFieldIDParent sqlField:@"parent_id" visible:NO width:72];
-    [self addField:MA_Field_Author type:VNAFieldTypeString tag:ArticleFieldIDAuthor sqlField:@"sender" visible:YES width:138];
-    [self addField:MA_Field_Link type:VNAFieldTypeString tag:ArticleFieldIDLink sqlField:@"link" visible:NO width:138];
-    [self addField:MA_Field_Text type:VNAFieldTypeString tag:ArticleFieldIDText sqlField:@"text" visible:NO width:152];
-    [self addField:MA_Field_Summary type:VNAFieldTypeString tag:ArticleFieldIDSummary sqlField:@"summary" visible:NO width:152];
-    [self addField:MA_Field_Headlines type:VNAFieldTypeString tag:ArticleFieldIDHeadlines sqlField:@"" visible:NO width:100];
-    [self addField:MA_Field_Enclosure type:VNAFieldTypeString tag:ArticleFieldIDEnclosure sqlField:@"enclosure" visible:NO width:100];
-    [self addField:MA_Field_EnclosureDownloaded type:VNAFieldTypeFlag tag:ArticleFieldIDEnclosureDownloaded sqlField:@"enclosuredownloaded_flag" visible:NO width:100];
+    [self addField:MA_Field_Read type:VNAFieldTypeFlag tag:VNAArticleFieldTagRead sqlField:@"read_flag" visible:YES width:17];
+    [self addField:MA_Field_Flagged type:VNAFieldTypeFlag tag:VNAArticleFieldTagFlagged sqlField:@"marked_flag" visible:YES width:17];
+    [self addField:MA_Field_HasEnclosure type:VNAFieldTypeFlag tag:VNAArticleFieldTagHasEnclosure sqlField:@"hasenclosure_flag" visible:YES width:17];
+    [self addField:MA_Field_Deleted type:VNAFieldTypeFlag tag:VNAArticleFieldTagDeleted sqlField:@"deleted_flag" visible:NO width:15];
+    [self addField:MA_Field_GUID type:VNAFieldTypeInteger tag:VNAArticleFieldTagGUID sqlField:@"message_id" visible:NO width:72];
+    [self addField:MA_Field_Subject type:VNAFieldTypeString tag:VNAArticleFieldTagSubject sqlField:@"title" visible:YES width:472];
+    [self addField:MA_Field_Folder type:VNAFieldTypeFolder tag:VNAArticleFieldTagFolder sqlField:@"folder_id" visible:NO width:130];
+    [self addField:MA_Field_Date type:VNAFieldTypeDate tag:VNAArticleFieldTagDate sqlField:@"date" visible:YES width:152];
+    [self addField:MA_Field_CreatedDate type:VNAFieldTypeDate tag:VNAArticleFieldTagCreatedDate sqlField:@"createddate" visible:NO width:152];
+    [self addField:MA_Field_Parent type:VNAFieldTypeInteger tag:VNAArticleFieldTagParent sqlField:@"parent_id" visible:NO width:72];
+    [self addField:MA_Field_Author type:VNAFieldTypeString tag:VNAArticleFieldTagAuthor sqlField:@"sender" visible:YES width:138];
+    [self addField:MA_Field_Link type:VNAFieldTypeString tag:VNAArticleFieldTagLink sqlField:@"link" visible:NO width:138];
+    [self addField:MA_Field_Text type:VNAFieldTypeString tag:VNAArticleFieldTagText sqlField:@"text" visible:NO width:152];
+    [self addField:MA_Field_Summary type:VNAFieldTypeString tag:VNAArticleFieldTagSummary sqlField:@"summary" visible:NO width:152];
+    [self addField:MA_Field_Headlines type:VNAFieldTypeString tag:VNAArticleFieldTagHeadlines sqlField:@"" visible:NO width:100];
+    [self addField:MA_Field_Enclosure type:VNAFieldTypeString tag:VNAArticleFieldTagEnclosure sqlField:@"enclosure" visible:NO width:100];
+    [self addField:MA_Field_EnclosureDownloaded type:VNAFieldTypeFlag tag:VNAArticleFieldTagEnclosureDownloaded sqlField:@"enclosuredownloaded_flag" visible:NO width:100];
 
 	//set user friendly and localizable names for some fields
 	[self fieldByName:MA_Field_Read].displayName = NSLocalizedString(@"Read", @"Data field name visible in menu/smart folder definition");

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -568,7 +568,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
             NSMutableArray *articleArray = [NSMutableArray array];
 
             for (NSDictionary *newsItem in (NSArray *)subscriptionsDict[@"items"]) {
-                NSDate *articleDate = [NSDate dateWithTimeIntervalSince1970:[newsItem[@"published"] doubleValue]];
+                NSDate *publicationDate = [NSDate dateWithTimeIntervalSince1970:[newsItem[@"published"] doubleValue]];
+                NSDate *lastUpdate = [NSDate dateWithTimeIntervalSince1970:[newsItem[@"updated"] doubleValue]];
                 NSString *articleGuid = newsItem[@"id"];
                 Article *article = [[Article alloc] initWithGuid:articleGuid];
                 article.folderId = refreshedFolder.itemId;
@@ -611,7 +612,8 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                     article.link = refreshedFolder.feedURL;
                 }
 
-                article.date = articleDate;
+                article.publicationDate = publicationDate == nil ? lastUpdate : publicationDate;
+                article.lastUpdate = lastUpdate == nil ? publicationDate : lastUpdate;
 
                 if ([newsItem[@"enclosure"] count] != 0) {
                     article.enclosure = newsItem[@"enclosure"][0][@"href"];

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -611,21 +611,15 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
                     article.link = refreshedFolder.feedURL;
                 }
 
-                NSDate *currentDate = [NSDate date];
-
                 NSString *publishedField = newsItem[@"published"];
-                double publishedDate = [publishedField doubleValue];
-                NSDate *publicationDate = [NSDate dateWithTimeIntervalSince1970:publishedDate];
+                if (publishedField) {
+                    article.publicationDate = [NSDate dateWithTimeIntervalSince1970:[publishedField doubleValue]];
+                }
 
                 NSString * updatedField = newsItem[@"updated"];
-                //if we get no update date, use the publication date, if that does not exist either, use the current date.
-                NSDate *lastUpdate = updatedField
-                                        ? [NSDate dateWithTimeIntervalSince1970:[updatedField doubleValue]]
-                                        : (publicationDate ? publicationDate : [NSDate date]);
-
-                //fallback to currentDate for publicationDate; this will not be stored in the db in case of an update
-                article.publicationDate = publicationDate ? publicationDate : currentDate;
-                article.lastUpdate = lastUpdate;
+                if (updatedField) {
+                    article.lastUpdate = [NSDate dateWithTimeIntervalSince1970:[updatedField doubleValue]];
+                }
 
                 if ([newsItem[@"enclosure"] count] != 0) {
                     article.enclosure = newsItem[@"enclosure"][0][@"href"];

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -763,8 +763,8 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         // Parse off items.
 
         for (id<VNAFeedItem> newsItem in newFeed.items) {
-            NSDate * articleDate = newsItem.modificationDate;
-            NSDate * publicationDate = newsItem.publicationDate;
+            NSDate * articleDate = newsItem.publicationDate;
+            NSDate * modificationDate = newsItem.modificationDate;
 
             NSString * articleGuid = newsItem.guid;
 
@@ -838,8 +838,8 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
                 articleLink = feedLink;
             }
             article.link = articleLink;
-            article.lastUpdate = articleDate;
-            article.publicationDate = publicationDate;
+            article.publicationDate = articleDate;
+            article.lastUpdate = modificationDate;
             NSString * enclosureLink = newsItem.enclosure;
             if ([enclosureLink isNotEqualTo:@""] && ![enclosureLink hasPrefix:@"http:"] && ![enclosureLink hasPrefix:@"https:"]) {
                 enclosureLink = [NSURL URLWithString:enclosureLink relativeToURL:url].absoluteString;

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -755,7 +755,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         NSMutableArray *articleArray = [NSMutableArray array];
         NSMutableArray *articleGuidArray = [NSMutableArray array];
 
-        NSDate *itemAlternativeDate = newFeed.modifiedDate;
+        NSDate *itemAlternativeDate = newFeed.modificationDate;
         if (itemAlternativeDate == nil) {
             itemAlternativeDate = [NSDate date];
         }
@@ -763,7 +763,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         // Parse off items.
 
         for (id<VNAFeedItem> newsItem in newFeed.items) {
-            NSDate * articleDate = newsItem.modifiedDate;
+            NSDate * articleDate = newsItem.modificationDate;
 
             NSString * articleGuid = newsItem.guid;
 
@@ -795,7 +795,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
                     // first, hack the initial article (which is probably the first loaded / most recent one)
                     NSString * firstFoundArticleNewGuid =
                         [NSString stringWithFormat:@"%ld-%@-%@-%@", (long)folderId,
-                         [NSString stringWithFormat:@"%1.3f", firstFoundArticle.date.timeIntervalSince1970], firstFoundArticle.link,
+                         [NSString stringWithFormat:@"%1.3f", firstFoundArticle.lastUpdate.timeIntervalSince1970], firstFoundArticle.link,
                          firstFoundArticle.title];
                     firstFoundArticle.guid = firstFoundArticleNewGuid;
                     articleGuidArray[articleIndex] = firstFoundArticleNewGuid;
@@ -837,7 +837,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
                 articleLink = feedLink;
             }
             article.link = articleLink;
-            article.date = articleDate;
+            article.lastUpdate = articleDate;
             NSString * enclosureLink = newsItem.enclosure;
             if ([enclosureLink isNotEqualTo:@""] && ![enclosureLink hasPrefix:@"http:"] && ![enclosureLink hasPrefix:@"https:"]) {
                 enclosureLink = [NSURL URLWithString:enclosureLink relativeToURL:url].absoluteString;

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -764,6 +764,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
         for (id<VNAFeedItem> newsItem in newFeed.items) {
             NSDate * articleDate = newsItem.modificationDate;
+            NSDate * publicationDate = newsItem.publicationDate;
 
             NSString * articleGuid = newsItem.guid;
 
@@ -838,6 +839,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
             }
             article.link = articleLink;
             article.lastUpdate = articleDate;
+            article.publicationDate = publicationDate;
             NSString * enclosureLink = newsItem.enclosure;
             if ([enclosureLink isNotEqualTo:@""] && ![enclosureLink hasPrefix:@"http:"] && ![enclosureLink hasPrefix:@"https:"]) {
                 enclosureLink = [NSURL URLWithString:enclosureLink relativeToURL:url].absoluteString;

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -97,6 +97,10 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Date],
 										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
+								  MA_Field_CreatedDate: @{
+										  @"key": [@"articleData." stringByAppendingString:MA_Field_CreatedDate],
+										  @"selector": NSStringFromSelector(@selector(compare:))
+										  },
 								  MA_Field_Author: @{
 										  @"key": [@"articleData." stringByAppendingString:MA_Field_Author],
 										  @"selector": NSStringFromSelector(@selector(caseInsensitiveCompare:))
@@ -288,7 +292,10 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 		NSUInteger index = [[descriptors valueForKey:@"key"] indexOfObject:[specifier valueForKey:@"key"]];
 
 		if (index == NSNotFound) {
-			sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[specifier valueForKey:@"key"] ascending:YES selector:NSSelectorFromString([specifier valueForKey:@"selector"])];
+			// Date should be sorted in descending order.
+			// TODO: Add a key to articleSortSpecifiers for a default sort order
+			BOOL ascending = [columnName isEqualToString:MA_Field_CreatedDate] ? NO : YES;
+			sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[specifier valueForKey:@"key"] ascending:ascending selector:NSSelectorFromString([specifier valueForKey:@"selector"])];
 		} else {
 			sortDescriptor = descriptors[index];
 			[descriptors removeObjectAtIndex:index];

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -292,9 +292,9 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 		NSUInteger index = [[descriptors valueForKey:@"key"] indexOfObject:[specifier valueForKey:@"key"]];
 
 		if (index == NSNotFound) {
-			// Date should be sorted in descending order.
-			// TODO: Add a key to articleSortSpecifiers for a default sort order
-			BOOL ascending = [columnName isEqualToString:MA_Field_PublicationDate] ? NO : YES;
+			// Dates should be sorted initially in descending order
+			// MIGHT DO : Add a key to articleSortSpecifiers for a default sort order
+			BOOL ascending = [columnName isEqualToString:MA_Field_PublicationDate] || [columnName isEqualToString:MA_Field_LastUpdate] ? NO : YES;
 			sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[specifier valueForKey:@"key"] ascending:ascending selector:NSSelectorFromString([specifier valueForKey:@"selector"])];
 		} else {
 			sortDescriptor = descriptors[index];

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -93,12 +93,12 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 										  @"key": @"isFlagged",
 										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
-								  MA_Field_Date: @{
-										  @"key": [@"articleData." stringByAppendingString:MA_Field_Date],
+								  MA_Field_LastUpdate: @{
+										  @"key": [@"articleData." stringByAppendingString:MA_Field_LastUpdate],
 										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
-								  MA_Field_CreatedDate: @{
-										  @"key": [@"articleData." stringByAppendingString:MA_Field_CreatedDate],
+								  MA_Field_PublicationDate: @{
+										  @"key": [@"articleData." stringByAppendingString:MA_Field_PublicationDate],
 										  @"selector": NSStringFromSelector(@selector(compare:))
 										  },
 								  MA_Field_Author: @{
@@ -294,7 +294,7 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 		if (index == NSNotFound) {
 			// Date should be sorted in descending order.
 			// TODO: Add a key to articleSortSpecifiers for a default sort order
-			BOOL ascending = [columnName isEqualToString:MA_Field_CreatedDate] ? NO : YES;
+			BOOL ascending = [columnName isEqualToString:MA_Field_PublicationDate] ? NO : YES;
 			sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[specifier valueForKey:@"key"] ascending:ascending selector:NSSelectorFromString([specifier valueForKey:@"selector"])];
 		} else {
 			sortDescriptor = descriptors[index];
@@ -1021,19 +1021,19 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
         case VNAFilterUnread:
             return !article.read;
         case VNAFilterLastRefresh: {
-            NSDate *date = article.createdDate;
+            NSDate *date = article.publicationDate;
             Preferences *prefs = [Preferences standardPreferences];
             NSComparisonResult result = [date compare:[prefs objectForKey:MAPref_LastRefreshDate]];
             return result != NSOrderedAscending;
         }
         case VNAFilterToday:
-            return [NSCalendar.currentCalendar isDateInToday:article.date];
+            return [NSCalendar.currentCalendar isDateInToday:article.lastUpdate];
         case VNAFilterTime48h: {
             NSDate *twoDaysAgo = [NSCalendar.currentCalendar dateByAddingUnit:NSCalendarUnitDay
                                                                         value:-2
                                                                        toDate:[NSDate date]
                                                                       options:0];
-            return [article.date compare:twoDaysAgo] != NSOrderedAscending;
+            return [article.lastUpdate compare:twoDaysAgo] != NSOrderedAscending;
         }
         case VNAFilterFlagged:
             return article.flagged;

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -1021,10 +1021,7 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
         case VNAFilterUnread:
             return !article.read;
         case VNAFilterLastRefresh: {
-            NSDate *date = article.publicationDate;
-            Preferences *prefs = [Preferences standardPreferences];
-            NSComparisonResult result = [date compare:[prefs objectForKey:MAPref_LastRefreshDate]];
-            return result != NSOrderedAscending;
+            return article.status == ArticleStatusNew || article.status == ArticleStatusUpdated;
         }
         case VNAFilterToday:
             return [NSCalendar.currentCalendar isDateInToday:article.lastUpdate];

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -386,13 +386,13 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		// Handle which fields can be visible in the condensed (vertical) layout
 		// versus the report (horizontal) layout
 		if (tableLayout == VNALayoutReport) {
-			showField = field.visible && tag != ArticleFieldIDHeadlines;
+			showField = field.visible && tag != VNAArticleFieldTagHeadlines;
 		} else {
 			showField = NO;
-			if (tag == ArticleFieldIDRead || tag == ArticleFieldIDFlagged || tag == ArticleFieldIDHasEnclosure) {
+			if (tag == VNAArticleFieldTagRead || tag == VNAArticleFieldTagFlagged || tag == VNAArticleFieldTagHasEnclosure) {
 				showField = field.visible;
 			}
-			if (tag == ArticleFieldIDHeadlines) {
+			if (tag == VNAArticleFieldTagHeadlines) {
 				showField = YES;
 			}
 		}
@@ -430,7 +430,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 				column.dataCell = cell;
 			}
 
-			BOOL isResizable = (tag != ArticleFieldIDRead && tag != ArticleFieldIDFlagged && tag != ArticleFieldIDHasEnclosure);
+			BOOL isResizable = (tag != VNAArticleFieldTagRead && tag != VNAArticleFieldTagFlagged && tag != VNAArticleFieldTagHasEnclosure);
 			column.resizingMask = (isResizable ? NSTableColumnUserResizingMask : NSTableColumnNoResizing);
 			// the headline column is auto-resizable
 			column.resizingMask = column.resizingMask | ([column.identifier isEqualToString:MA_Field_Headlines] ? NSTableColumnAutoresizingMask : 0);

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1309,6 +1309,8 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	NSString * cellString;
 	if ([identifier isEqualToString:MA_Field_Date]) {
         cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.date];
+	} else if ([identifier isEqualToString:MA_Field_CreatedDate]) {
+		cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.createdDate];
 	} else if ([identifier isEqualToString:MA_Field_Folder]) {
 		Folder * folder = [db folderFromID:theArticle.folderId];
 		cellString = folder.name;

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -594,7 +594,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 	NSString * sortColumnIdentifier = self.controller.articleController.sortColumnIdentifier;
 
-    // FIXME: Sort out the order of initialization
     if (!sortColumnIdentifier) {
         sortColumnIdentifier = [Preferences.standardPreferences stringForKey:MAPref_SortColumn];
     }

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -571,7 +571,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		if ([db fieldByName:MA_Field_Subject].visible) {
 			++numberOfRowsInCell;
 		}
-		if ([db fieldByName:MA_Field_Folder].visible || [db fieldByName:MA_Field_Date].visible || [db fieldByName:MA_Field_Author].visible) {
+		if ([db fieldByName:MA_Field_Folder].visible || [db fieldByName:MA_Field_LastUpdate].visible || [db fieldByName:MA_Field_Author].visible) {
 			++numberOfRowsInCell;
 		}
 		if ([db fieldByName:MA_Field_Link].visible) {
@@ -1293,8 +1293,8 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 			[summaryString appendFormat:@"%@", folder.name];
 			delimiter = @" - ";
 		}
-		if ([db fieldByName:MA_Field_Date].visible) {
-			[summaryString appendFormat:@"%@%@", delimiter, [NSDateFormatter vna_relativeDateStringFromDate:theArticle.date]];
+		if ([db fieldByName:MA_Field_LastUpdate].visible) {
+			[summaryString appendFormat:@"%@%@", delimiter, [NSDateFormatter vna_relativeDateStringFromDate:theArticle.lastUpdate]];
 			delimiter = @" - ";
 		}
 		if ([db fieldByName:MA_Field_Author].visible) {
@@ -1313,10 +1313,10 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	}
 	
 	NSString * cellString;
-	if ([identifier isEqualToString:MA_Field_Date]) {
-        cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.date];
-	} else if ([identifier isEqualToString:MA_Field_CreatedDate]) {
-		cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.createdDate];
+	if ([identifier isEqualToString:MA_Field_LastUpdate]) {
+        cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.lastUpdate];
+	} else if ([identifier isEqualToString:MA_Field_PublicationDate]) {
+		cellString = [NSDateFormatter vna_relativeDateStringFromDate:theArticle.publicationDate];
 	} else if ([identifier isEqualToString:MA_Field_Folder]) {
 		Folder * folder = [db folderFromID:theArticle.folderId];
 		cellString = folder.name;

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -593,7 +593,12 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 -(void)showSortDirection
 {
 	NSString * sortColumnIdentifier = self.controller.articleController.sortColumnIdentifier;
-	
+
+    // FIXME: Sort out the order of initialization
+    if (!sortColumnIdentifier) {
+        sortColumnIdentifier = [Preferences.standardPreferences stringForKey:MAPref_SortColumn];
+    }
+
 	for (NSTableColumn * column in articleList.tableColumns) {
 		if ([column.identifier isEqualToString:sortColumnIdentifier]) {
 			// These NSImage names are available in AppKit, but not as constants.
@@ -990,6 +995,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
             break;
         case VNARefreshSortAndRedraw:
             [self.controller.articleController sortArticles];
+            [self showSortDirection];
             break;
     }
 

--- a/Vienna/Sources/Models/Article.h
+++ b/Vienna/Sources/Models/Article.h
@@ -29,7 +29,7 @@ extern NSString * const MA_Field_GUID;
 extern NSString * const MA_Field_Subject;
 extern NSString * const MA_Field_Author;
 extern NSString * const MA_Field_Link;
-extern NSString * const MA_Field_Date;
+extern NSString * const MA_Field_LastUpdate;
 extern NSString * const MA_Field_Read;
 extern NSString * const MA_Field_Flagged;
 extern NSString * const MA_Field_Deleted;
@@ -38,7 +38,7 @@ extern NSString * const MA_Field_Folder;
 extern NSString * const MA_Field_Parent;
 extern NSString * const MA_Field_Headlines;
 extern NSString * const MA_Field_Summary;
-extern NSString * const MA_Field_CreatedDate;
+extern NSString * const MA_Field_PublicationDate;
 extern NSString * const MA_Field_Enclosure;
 extern NSString * const MA_Field_EnclosureDownloaded;
 extern NSString * const MA_Field_HasEnclosure;
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSInteger, VNAArticleFieldTag) {
     VNAArticleFieldTagGUID = 400,
     VNAArticleFieldTagSubject,
     VNAArticleFieldTagAuthor,
-    VNAArticleFieldTagDate,
+    VNAArticleFieldTagLastUpdate,
     VNAArticleFieldTagParent,
     VNAArticleFieldTagRead,
     VNAArticleFieldTagFlagged,
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, VNAArticleFieldTag) {
     VNAArticleFieldTagHeadlines = 411,
     VNAArticleFieldTagDeleted,
     VNAArticleFieldTagSummary,
-    VNAArticleFieldTagCreatedDate,
+    VNAArticleFieldTagPublicationDate,
     VNAArticleFieldTagEnclosure,
     VNAArticleFieldTagEnclosureDownloaded,
     VNAArticleFieldTagHasEnclosure
@@ -84,8 +84,8 @@ typedef NS_ENUM(NSInteger, ArticleStatus) {
 @property (nullable, nonatomic, copy) NSString *link;
 @property (readonly, nullable, nonatomic) NSString *summary;
 @property (nullable, nonatomic, copy) NSString *enclosure;
-@property (nullable, nonatomic, copy) NSDate *date;
-@property (nullable, nonatomic, copy) NSDate *createdDate;
+@property (nullable, nonatomic) NSDate *lastUpdate;
+@property (nullable, nonatomic) NSDate *publicationDate;
 @property (nullable, nonatomic, readonly) Folder *containingFolder;
 @property (nonatomic) NSInteger folderId;
 @property (nonatomic, getter=isRead, readonly) BOOL read;

--- a/Vienna/Sources/Models/Article.h
+++ b/Vienna/Sources/Models/Article.h
@@ -61,8 +61,8 @@ typedef NS_ENUM(NSInteger, ArticleFieldID) {
     ArticleFieldIDHeadlines = 411,
     ArticleFieldIDDeleted,
     ArticleFieldIDSummary,
-    /* 414 was previously used */
-    ArticleFieldIDEnclosure = 415,
+    ArticleFieldIDCreatedDate,
+    ArticleFieldIDEnclosure,
     ArticleFieldIDEnclosureDownloaded,
     ArticleFieldIDHasEnclosure
 };

--- a/Vienna/Sources/Models/Article.h
+++ b/Vienna/Sources/Models/Article.h
@@ -45,27 +45,26 @@ extern NSString * const MA_Field_HasEnclosure;
 
 NS_ASSUME_NONNULL_END
 
-// Article field IDs
-typedef NS_ENUM(NSInteger, ArticleFieldID) {
-    ArticleFieldIDGUID = 400,
-    ArticleFieldIDSubject,
-    ArticleFieldIDAuthor,
-    ArticleFieldIDDate,
-    ArticleFieldIDParent,
-    ArticleFieldIDRead,
-    ArticleFieldIDFlagged,
-    ArticleFieldIDText,
-    ArticleFieldIDFolder,
-    ArticleFieldIDLink,
+typedef NS_ENUM(NSInteger, VNAArticleFieldTag) {
+    VNAArticleFieldTagGUID = 400,
+    VNAArticleFieldTagSubject,
+    VNAArticleFieldTagAuthor,
+    VNAArticleFieldTagDate,
+    VNAArticleFieldTagParent,
+    VNAArticleFieldTagRead,
+    VNAArticleFieldTagFlagged,
+    VNAArticleFieldTagText,
+    VNAArticleFieldTagFolder,
+    VNAArticleFieldTagLink,
     /* 410 was previously used */
-    ArticleFieldIDHeadlines = 411,
-    ArticleFieldIDDeleted,
-    ArticleFieldIDSummary,
-    ArticleFieldIDCreatedDate,
-    ArticleFieldIDEnclosure,
-    ArticleFieldIDEnclosureDownloaded,
-    ArticleFieldIDHasEnclosure
-};
+    VNAArticleFieldTagHeadlines = 411,
+    VNAArticleFieldTagDeleted,
+    VNAArticleFieldTagSummary,
+    VNAArticleFieldTagCreatedDate,
+    VNAArticleFieldTagEnclosure,
+    VNAArticleFieldTagEnclosureDownloaded,
+    VNAArticleFieldTagHasEnclosure
+} NS_SWIFT_NAME(Article.FieldTag);
 
 typedef NS_ENUM(NSInteger, ArticleStatus) {
     ArticleStatusEmpty = 0,

--- a/Vienna/Sources/Models/Article.m
+++ b/Vienna/Sources/Models/Article.m
@@ -31,7 +31,7 @@ NSString * const MA_Field_GUID = @"GUID";
 NSString * const MA_Field_Subject = @"Subject";
 NSString * const MA_Field_Author = @"Author";
 NSString * const MA_Field_Link = @"Link";
-NSString * const MA_Field_Date = @"Date";
+NSString * const MA_Field_LastUpdate = @"Date";
 NSString * const MA_Field_Read = @"Read";
 NSString * const MA_Field_Flagged = @"Flagged";
 NSString * const MA_Field_Deleted = @"Deleted";
@@ -40,7 +40,7 @@ NSString * const MA_Field_Folder = @"Folder";
 NSString * const MA_Field_Parent = @"Parent";
 NSString * const MA_Field_Headlines = @"Headlines";
 NSString * const MA_Field_Summary = @"Summary";
-NSString * const MA_Field_CreatedDate = @"CreatedDate";
+NSString * const MA_Field_PublicationDate = @"PublicationDate";
 NSString * const MA_Field_Enclosure = @"Enclosure";
 NSString * const MA_Field_EnclosureDownloaded = @"EnclosureDownloaded";
 NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
@@ -108,17 +108,17 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
 /* setDate
  * Sets the date when the article was published.
  */
--(void)setDate:(NSDate *)newDate
+-(void)setLastUpdate:(NSDate *)lastUpdate
 {
-    articleData[MA_Field_Date] = [newDate copy];
+    articleData[MA_Field_LastUpdate] = lastUpdate;
 }
 
-/* setCreatedDate
- * Sets the date when the article was first created in the database.
+/*
+ * Sets the date when the article was first published or added to the database.
  */
--(void)setCreatedDate:(NSDate *)newCreatedDate
+- (void)setPublicationDate:(NSDate *)publicationDate
 {
-    articleData[MA_Field_CreatedDate] = [newCreatedDate copy];
+    articleData[MA_Field_PublicationDate] = publicationDate;
 }
 
 /* setBody
@@ -198,10 +198,10 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
 {
     if ([keyPath hasPrefix:@"articleData."]) {
         NSString * key = [keyPath substringFromIndex:(@"articleData.").length];
-        if ([key isEqualToString:MA_Field_Date]) {
-            return self.date;
-        } else if ([key isEqualToString:MA_Field_CreatedDate]) {
-            return self.createdDate;
+        if ([key isEqualToString:MA_Field_LastUpdate]) {
+            return self.lastUpdate;
+        } else if ([key isEqualToString:MA_Field_PublicationDate]) {
+            return self.publicationDate;
         } else if ([key isEqualToString:MA_Field_Author]) {
             return self.author;
         } else if ([key isEqualToString:MA_Field_Subject]) {
@@ -245,8 +245,8 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
     }
     return summary;
 }
--(NSDate *)date					{ return articleData[MA_Field_Date]; }
--(NSDate *)createdDate			{ return articleData[MA_Field_CreatedDate]; }
+-(NSDate *)lastUpdate			{ return articleData[MA_Field_LastUpdate]; }
+-(NSDate *)publicationDate		{ return articleData[MA_Field_PublicationDate]; }
 -(NSString *)body				{ return articleData[MA_Field_Text]; }
 -(NSString *)enclosure			{ return articleData[MA_Field_Enclosure]; }
 
@@ -356,7 +356,7 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
  */
 -(NSString *)tagArticleDate
 {
-    return [NSDateFormatter vna_relativeDateStringFromDate:self.date];
+    return [NSDateFormatter vna_relativeDateStringFromDate:self.lastUpdate];
 }
 
 /* tagArticleEnclosureLink

--- a/Vienna/Sources/Models/Article.m
+++ b/Vienna/Sources/Models/Article.m
@@ -200,6 +200,8 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
         NSString * key = [keyPath substringFromIndex:(@"articleData.").length];
         if ([key isEqualToString:MA_Field_Date]) {
             return self.date;
+        } else if ([key isEqualToString:MA_Field_CreatedDate]) {
+            return self.createdDate;
         } else if ([key isEqualToString:MA_Field_Author]) {
             return self.author;
         } else if ([key isEqualToString:MA_Field_Subject]) {

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -76,7 +76,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, copy) NSString *feedDescription;
 @property (nonatomic, copy) NSString *homePage;
 @property (nonatomic, copy) NSString *feedURL;
-@property (nonatomic, copy) NSDate *lastUpdate;
+@property (nonatomic) NSDate *lastUpdate;
 @property (nonatomic, copy) NSString *lastUpdateString;
 @property (nonatomic, copy) NSString *username;
 @property (nonatomic, copy) NSString *password;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -585,7 +585,7 @@
         [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
         [self.cachedGuids addObject:guid];
         // note if article has incomplete data
-        if (article.createdDate == nil) {
+        if (article.publicationDate == nil) {
             self.containsBodies = NO;
         }
     }

--- a/Vienna/Sources/Parsing/AtomFeed.m
+++ b/Vienna/Sources/Parsing/AtomFeed.m
@@ -253,14 +253,20 @@
                 }
 
                 // Parse item date
-                if (isArticleElementAtomType && ([articleItemTag isEqualToString:@"modified"] || [articleItemTag isEqualToString:@"created"] || [articleItemTag isEqualToString:@"updated"])) {
+                if (isArticleElementAtomType && ([articleItemTag isEqualToString:@"modified"] || [articleItemTag isEqualToString:@"updated"])) {
                     NSString *dateString = itemChildElement.stringValue;
                     NSDate *newDate = [self dateWithXMLString:dateString];
                     if (newFeedItem.modificationDate == nil || [newDate isGreaterThan:newFeedItem.modificationDate]) {
                         newFeedItem.modificationDate = newDate;
                     }
+                    continue;
+                }
+
+                // Parse item date
+                if (isArticleElementAtomType && ([articleItemTag isEqualToString:@"created"] || [articleItemTag isEqualToString:@"published"])) {
+                    NSString *dateString = itemChildElement.stringValue;
+                    NSDate *newDate = [self dateWithXMLString:dateString];
                     if (newFeedItem.publicationDate == nil || [newDate isLessThan:newFeedItem.publicationDate]) {
-                        //publication date will only be registered once for each article, so later updates don´t matter
                         newFeedItem.publicationDate = newDate;
                     }
                     continue;

--- a/Vienna/Sources/Parsing/AtomFeed.m
+++ b/Vienna/Sources/Parsing/AtomFeed.m
@@ -121,17 +121,9 @@
         }
 
         // Parse the date when this feed was last updated
-        if (isAtomElement && [elementTag isEqualToString:@"updated"]) {
+        if (isAtomElement && ([elementTag isEqualToString:@"updated"] || [elementTag isEqualToString:@"modified"])) {
             NSString *dateString = atomChildElement.stringValue;
-            self.modifiedDate = [self dateWithXMLString:dateString];
-            success = YES;
-            continue;
-        }
-
-        // Parse the date when this feed was last updated
-        if (isAtomElement && [elementTag isEqualToString:@"modified"]) {
-            NSString *dateString = atomChildElement.stringValue;
-            self.modifiedDate = [self dateWithXMLString:dateString];
+            self.modificationDate = [self dateWithXMLString:dateString];
             success = YES;
             continue;
         }
@@ -261,31 +253,15 @@
                 }
 
                 // Parse item date
-                if (isArticleElementAtomType && [articleItemTag isEqualToString:@"modified"]) {
+                if (isArticleElementAtomType && ([articleItemTag isEqualToString:@"modified"] || [articleItemTag isEqualToString:@"created"] || [articleItemTag isEqualToString:@"updated"])) {
                     NSString *dateString = itemChildElement.stringValue;
                     NSDate *newDate = [self dateWithXMLString:dateString];
-                    if (newFeedItem.modifiedDate == nil || [newDate isGreaterThan:newFeedItem.modifiedDate]) {
-                        newFeedItem.modifiedDate = newDate;
+                    if (newFeedItem.modificationDate == nil || [newDate isGreaterThan:newFeedItem.modificationDate]) {
+                        newFeedItem.modificationDate = newDate;
                     }
-                    continue;
-                }
-
-                // Parse item date
-                if (isArticleElementAtomType && [articleItemTag isEqualToString:@"created"]) {
-                    NSString *dateString = itemChildElement.stringValue;
-                    NSDate *newDate = [self dateWithXMLString:dateString];
-                    if (newFeedItem.modifiedDate == nil || [newDate isGreaterThan:newFeedItem.modifiedDate]) {
-                        newFeedItem.modifiedDate = newDate;
-                    }
-                    continue;
-                }
-
-                // Parse item date
-                if (isArticleElementAtomType && [articleItemTag isEqualToString:@"updated"]) {
-                    NSString *dateString = itemChildElement.stringValue;
-                    NSDate *newDate = [self dateWithXMLString:dateString];
-                    if (newFeedItem.modifiedDate == nil || [newDate isGreaterThan:newFeedItem.modifiedDate]) {
-                        newFeedItem.modifiedDate = newDate;
+                    if (newFeedItem.publicationDate == nil || [newDate isLessThan:newFeedItem.publicationDate]) {
+                        //publication date will only be registered once for each article, so later updates don´t matter
+                        newFeedItem.publicationDate = newDate;
                     }
                     continue;
                 }

--- a/Vienna/Sources/Parsing/Feed.h
+++ b/Vienna/Sources/Parsing/Feed.h
@@ -29,7 +29,7 @@ NS_SWIFT_NAME(Feed)
 @property (copy, nonatomic) NSString *title;
 @property (nullable, copy, nonatomic) NSString *feedDescription;
 @property (nullable, copy, nonatomic) NSString *homePageURL;
-@property (nullable, nonatomic) NSDate *modifiedDate;
+@property (nullable, nonatomic) NSDate *modificationDate;
 @property (copy, nonatomic) NSArray<id<VNAFeedItem>> *items;
 
 @end

--- a/Vienna/Sources/Parsing/FeedItem.h
+++ b/Vienna/Sources/Parsing/FeedItem.h
@@ -28,7 +28,8 @@ NS_SWIFT_NAME(FeedItem)
 @property (nullable, copy, nonatomic) NSString *title;
 @property (nullable, copy, nonatomic) NSString *authors;
 @property (copy, nonatomic) NSString *content;
-@property (nullable, nonatomic) NSDate *modifiedDate;
+@property (nullable, nonatomic) NSDate *publicationDate;
+@property (nullable, nonatomic) NSDate *modificationDate;
 @property (nullable, copy, nonatomic) NSString *url;
 @property (nullable, copy, nonatomic) NSString *enclosure;
 

--- a/Vienna/Sources/Parsing/JSONFeed.swift
+++ b/Vienna/Sources/Parsing/JSONFeed.swift
@@ -32,7 +32,7 @@ class JSONFeed: NSObject, Feed, Decodable {
     var homePageURL: String?
 
     // JSON Feed has no key for this at the feed level.
-    var modifiedDate: Date?
+    var modificationDate: Date?
 
     // The `items` key is required (but the array may be empty).
     var items: [any FeedItem]
@@ -43,8 +43,8 @@ class JSONFeed: NSObject, Feed, Decodable {
         case title
         case feedDescription = "description"
         case homePageURL = "home_page_url"
-        case modifiedDate = "date_modified"
-        case publishedDate = "date_published"
+        case publicationDate = "date_published"
+        case modificationDate = "date_modified"
         case items
 
         // These keys are only used by JSONFeedItem

--- a/Vienna/Sources/Parsing/JSONFeedItem.swift
+++ b/Vienna/Sources/Parsing/JSONFeedItem.swift
@@ -39,9 +39,13 @@ class JSONFeedItem: NSObject, FeedItem, Decodable {
     // are mutually exclusive. At least one key must be present.
     var content: String
 
-    // JSON Feed has `date_published` and `date_modified` keys, neither is
-    // required. If present, they should be date strings in RFC 3339 format.
-    var modifiedDate: Date?
+    // JSON Feed has the `date_published` key, which is not required. If
+    // present, it should be a date string in RFC 3339 format.
+    var publicationDate: Date?
+
+    // JSON Feed has the `date_modified` key, which is not required. If present,
+    // it should be a date string in RFC 3339 format.
+    var modificationDate: Date?
 
     // The `url` key is optional. The `id` key might be a URL too, so it could
     // be a fallback.
@@ -59,8 +63,8 @@ class JSONFeedItem: NSObject, FeedItem, Decodable {
         case author
         case contentHTML = "content_html"
         case contentText = "content_text"
-        case modifiedDate = "date_modified"
-        case publishedDate = "date_published"
+        case publicationDate = "date_published"
+        case modificationDate = "date_modified"
         case url
         case attachments
     }
@@ -103,7 +107,8 @@ class JSONFeedItem: NSObject, FeedItem, Decodable {
             content = try container.decode(String.self, forKey: .contentText)
         }
 
-        modifiedDate = try container.decodeIfPresent(Date.self, forKey: .modifiedDate)
+        publicationDate = try container.decodeIfPresent(Date.self, forKey: .publicationDate)
+        modificationDate = try container.decodeIfPresent(Date.self, forKey: .modificationDate)
 
         do {
             url = try container.decode(URL.self, forKey: .url).absoluteString

--- a/Vienna/Sources/Parsing/RSSFeed.m
+++ b/Vienna/Sources/Parsing/RSSFeed.m
@@ -260,8 +260,19 @@
 
                 // Parse item date
                 if ((isRSSElement && [articleItemTag isEqualToString:@"pubDate"]) || ([itemChildElement.prefix isEqualToString:self.dcPrefix] && [articleItemTag isEqualToString:@"date"])) {
-                    NSString *dateString = itemChildElement.stringValue;
-                    newFeedItem.modificationDate = [self dateWithXMLString:dateString];
+                    NSDate *newDate = [self dateWithXMLString:itemChildElement.stringValue];
+                    if (newFeedItem.publicationDate == nil || [newDate isLessThan:newFeedItem.publicationDate]) {
+                        newFeedItem.publicationDate = newDate;
+                    }
+                    continue;
+                }
+
+                // Parse item modification date
+                if ([itemChildElement.prefix isEqualToString:self.dcPrefix] && [articleItemTag isEqualToString:@"modified"]) {
+                    NSDate *newDate = [self dateWithXMLString:itemChildElement.stringValue];
+                    if (newFeedItem.modificationDate == nil || [newDate isGreaterThan:newFeedItem.modificationDate]) {
+                        newFeedItem.modificationDate = newDate;
+                    }
                     continue;
                 }
 

--- a/Vienna/Sources/Parsing/RSSFeed.m
+++ b/Vienna/Sources/Parsing/RSSFeed.m
@@ -137,7 +137,8 @@
             (isRSSElement && [channelItemTag isEqualToString:@"pubDate"]) ||
             ([element.prefix isEqualToString:self.dcPrefix] && [channelItemTag isEqualToString:@"date"])) {
             NSString *dateString = element.stringValue;
-            self.modifiedDate = [self dateWithXMLString:dateString];
+            //publication date will be set to the current date in a later step, so we don´t set it here
+            self.modificationDate = [self dateWithXMLString:dateString];
             success = YES;
             continue;
         }
@@ -260,7 +261,7 @@
                 // Parse item date
                 if ((isRSSElement && [articleItemTag isEqualToString:@"pubDate"]) || ([itemChildElement.prefix isEqualToString:self.dcPrefix] && [articleItemTag isEqualToString:@"date"])) {
                     NSString *dateString = itemChildElement.stringValue;
-                    newFeedItem.modifiedDate = [self dateWithXMLString:dateString];
+                    newFeedItem.modificationDate = [self dateWithXMLString:dateString];
                     continue;
                 }
 

--- a/Vienna/Sources/Parsing/XMLFeed.h
+++ b/Vienna/Sources/Parsing/XMLFeed.h
@@ -31,7 +31,7 @@ NS_SWIFT_NAME(XMLFeed)
 @property (copy, nonatomic) NSString *title;
 @property (nullable, copy, nonatomic) NSString *feedDescription;
 @property (nullable, copy, nonatomic) NSString *homePageURL;
-@property (nonatomic) NSDate *modifiedDate;
+@property (nonatomic) NSDate *modificationDate;
 @property (copy, nonatomic) NSArray<id<VNAFeedItem>> *items;
 
 // MARK: Prefix handling

--- a/Vienna/Sources/Parsing/XMLFeedItem.swift
+++ b/Vienna/Sources/Parsing/XMLFeedItem.swift
@@ -26,7 +26,8 @@ class XMLFeedItem: NSObject, FeedItem {
     @objc var title: String?
     @objc var authors: String?
     @objc var content = ""
-    @objc var modifiedDate: Date?
+    @objc var publicationDate: Date?
+    @objc var modificationDate: Date?
     @objc var url: String?
     @objc var enclosure: String?
 

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -236,7 +236,6 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 	defaultValues[MAPref_FilterMode] = [NSNumber numberWithInt:VNAFilterAll];
 	defaultValues[MAPref_MinimumFontSize] = @(MA_Default_MinimumFontSize);
 	defaultValues[MAPref_AutoExpireDuration] = @(MA_Default_AutoExpireDuration);
-	defaultValues[MAPref_LastRefreshDate] = [NSDate distantPast];
 	defaultValues[MAPref_Layout] = [NSNumber numberWithInt:VNALayoutReport];
 	defaultValues[MAPref_NewArticlesNotification] = [NSNumber numberWithInt:0];
 	defaultValues[MAPref_EmptyTrashNotification] = [NSNumber numberWithInt:VNAEmptyTrashWithWarning];

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -210,7 +210,7 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 
 	NSFileManager *fileManager = NSFileManager.defaultManager;
 	NSString *appSupportPath = fileManager.vna_applicationSupportDirectory.path;
-    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[@"articleData." stringByAppendingString:MA_Field_Date]
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:[@"articleData." stringByAppendingString:MA_Field_LastUpdate]
                                                                    ascending:YES];
 
 	defaultValues[MAPref_DefaultDatabase] = [appSupportPath stringByAppendingPathComponent:MA_Database_Name];
@@ -218,7 +218,7 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 	defaultValues[MAPref_ShowUnreadArticlesInBold] = boolYes;
 	defaultValues[MAPref_CheckForNewArticlesOnStartup] = boolYes;
 	defaultValues[MAPref_CachedFolderID] = @1;
-	defaultValues[MAPref_SortColumn] = MA_Field_Date;
+	defaultValues[MAPref_SortColumn] = MA_Field_LastUpdate;
 	defaultValues[MAPref_CheckFrequency] = @(MA_Default_Check_Frequency);
 	defaultValues[MAPref_MarkReadInterval] = @((float)MA_Default_Read_Interval);
 	defaultValues[MAPref_ActiveStyleName] = MA_DefaultStyleName;

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -87,7 +87,6 @@ extern NSString * const MAPref_UseJavaScript;
 extern NSString * const MAPref_CachedArticleGUID;
 extern NSString * const MAPref_ArticleListSortOrders;
 extern NSString * const MAPref_FilterMode;
-extern NSString * const MAPref_LastRefreshDate;
 extern NSString * const MAPref_TabList;
 extern NSString * const MAPref_TabTitleDictionary;
 extern NSString * const MAPref_Layout;

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -87,7 +87,6 @@ NSString * const MAPref_UseJavaScript = @"UseJavaScript";
 NSString * const MAPref_CachedArticleGUID = @"CachedArticleGUID";
 NSString * const MAPref_ArticleListSortOrders = @"ArticleListSortOrders";
 NSString * const MAPref_FilterMode = @"FilterMode";
-NSString * const MAPref_LastRefreshDate = @"LastRefreshDate";
 NSString * const MAPref_TabList = @"TabList";
 NSString * const MAPref_TabTitleDictionary = @"TabTitleDict";
 NSString * const MAPref_Layout = @"Layout";


### PR DESCRIPTION
As suggested in #1749 the `createddate` SQL field is repurposed to show a "Date Published" option in the Sort By menu and add a new column for the horizontal layout. The existing "Date" sort option and column is renamed to "Last Update" to reflect its current purpose better. `createddate` was previously set to a current date when Vienna added the entry to the database. To keep it simple, I have not added the "Date Published" field to the vertical layout, since that would require more elaborate changes to the table-view cell.

While working on this I also stumbled on two bugs that caused the sort indicator in the column header not to show on app launch and when the user changes the sorting via the main menu. Both are fixed. The former bug is fixed with a band aid however, since the underlying cause is that ArticleListView is initialised before ArticleController, the latter which holds the property that determines the sorting order.