### PR TITLE
Make default application handler asynchronous

### DIFF
--- a/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
@@ -36,7 +36,6 @@
 // -(void)selectUserDefaultFont:(NSString *)name size:(int)size control:(NSPopUpButton *)control sizeControl:(NSComboBox *)sizeControl;
 // -(void)controlTextDidEndEditing:(NSNotification *)notification;
 -(void)refreshLinkHandler;
--(IBAction)handleLinkSelector:(id)sender;
 -(void)updateDownloadsPopUp:(NSString *)downloadFolderPath;
 
 @end
@@ -338,7 +337,7 @@
     NSMenuItem * selectedItem = linksHandler.selectedItem;
     if (selectedItem != nil) {
         if (selectedItem.tag == -1) {
-            [self handleLinkSelector:self];
+            [self handleLinkSelector];
             return;
         }
         typeof(self) __weak weakSelf = self;
@@ -356,7 +355,7 @@
  * file browser in the Applications folder and use that to add a new application to the
  * list.
  */
--(IBAction)handleLinkSelector:(id)sender
+- (void)handleLinkSelector
 {
     NSOpenPanel * panel = [NSOpenPanel openPanel];
     NSWindow * prefPaneWindow = linksHandler.window;

--- a/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
@@ -367,6 +367,7 @@
     } else {
         panel.allowedFileTypes = @[NSFileTypeForHFSTypeCode('APPL')];
     }
+    panel.prompt = NSLocalizedString(@"Select", @"Label of a button on an open panel");
     [panel beginSheetModalForWindow:prefPaneWindow completionHandler:^(NSInteger returnCode) {
         [panel orderOut:self];
         [prefPaneWindow makeKeyAndOrderFront:self];

--- a/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/GeneralPreferencesViewController.m
@@ -318,8 +318,7 @@
     
     downloadPathItem.title = [[NSFileManager defaultManager] displayNameAtPath:downloadFolderPath];
     downloadPathItem.image = pathImage;
-    downloadPathItem.state = NSControlStateValueOff;
-    
+
     [downloadFolder selectItemAtIndex:0];
 }
 


### PR DESCRIPTION
When the user selected a default application, the pop-up button selection was not always updated.