### PR TITLE
Improvements to folders tree (v2)

### DIFF
--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -915,7 +915,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 		NSInteger newPredecessorId = [array[index++] integerValue];
 		Folder * folder = [dbManager folderFromID:folderId];
 		NSInteger oldParentId = folder.parentId;
-		
+
 		TreeNode * node = [self.rootNode nodeFromID:folderId];
 		TreeNode * oldParent = [self.rootNode nodeFromID:oldParentId];
 		NSInteger oldChildIndex = [oldParent indexOfChild:node];
@@ -926,21 +926,21 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 			newPredecessorId = 0;
 		}
 		NSInteger newChildIndex = (newPredecessorId > 0) ? ([newParent indexOfChild:newPredecessor] + 1) : 0;
-        
+
 		if (newParentId == oldParentId) {
 			// With automatic sorting, moving under the same parent is impossible.
-            if (autoSort) {
+			if (autoSort) {
 				continue;
-            }
+			}
 			// No need to move if destination is the same as origin.
-            if (newPredecessorId == oldPredecessorId) {
+			if (newPredecessorId == oldPredecessorId) {
 				continue;
-            }
+			}
 			// Adjust the index for the removal of the old child.
-            if (newChildIndex > oldChildIndex) {
-                --newChildIndex;
-            }
-				
+			if (newChildIndex > oldChildIndex) {
+				--newChildIndex;
+			}
+
 		} else {
 			if ([dbManager setParent:newParentId forFolder:folderId]) {
 				if (sync && folder.type == VNAFolderTypeOpenReader) {
@@ -951,7 +951,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 					// add new label
 					folderName = [dbManager folderFromID:newParentId].name;
 					if (folderName) {
-					    [myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
+						[myReader setFolderLabel:folderName forFeed:folder.remoteId set:TRUE];
 					}
 				}
 			} else {
@@ -961,7 +961,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 				[newParent setCanHaveChildren:YES];
 			}
 		}
-		
+
 		if (!autoSort) {
 			if (oldPredecessorId > 0) {
 				if (![dbManager setNextSibling:folder.nextSiblingId forFolder:oldPredecessorId]) {
@@ -974,12 +974,13 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 			}
 			if (newPredecessorId > 0) {
 				if (![dbManager setNextSibling:[dbManager folderFromID:newPredecessorId].nextSiblingId
-                                     forFolder:folderId]) {
+									 forFolder:folderId]) {
 					continue;
-                }
+				}
 				[dbManager setNextSibling:folderId forFolder:newPredecessorId];
 			} else {
-				NSInteger oldFirstChildId = (newParent == self.rootNode) ? dbManager.firstFolderId : newParent.folder.firstChildId;
+				NSInteger oldFirstChildId = (newParent == self.rootNode) ? dbManager.firstFolderId
+																		 : newParent.folder.firstChildId;
 				if (![dbManager setNextSibling:oldFirstChildId forFolder:folderId]) {
 					continue;
 				}
@@ -995,17 +996,17 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 		[undoArray insertObject:@(oldParentId) atIndex:1u];
 		[undoArray insertObject:@(oldPredecessorId) atIndex:2u];
 	}
-	
+
 	// If undo array is empty, then nothing has been moved.
 	if (undoArray.count == 0u) {
 		return NO;
 	}
-	
+
 	// Set up to undo this action
 	NSUndoManager * undoManager = NSApp.mainWindow.undoManager;
 	[undoManager registerUndoWithTarget:self selector:@selector(moveFoldersUndo:) object:undoArray];
 	[undoManager setActionName:NSLocalizedString(@"Move Folders", nil)];
-	
+
 	// Make the outline control reload its data
 	[self.outlineView reloadData];
 
@@ -1019,7 +1020,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 			}
 		}
 	}
-	
+
 	// Properly set selection back to the original items. This has to be done after the
 	// refresh so that rowForItem returns the new positions.
 	NSMutableIndexSet * selIndexSet = [[NSMutableIndexSet alloc] init];
@@ -1033,7 +1034,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 	[self.outlineView scrollRowToVisible:selRowIndex];
 	[self.outlineView selectRowIndexes:selIndexSet byExtendingSelection:NO];
 	return YES;
-}
+} // moveFolders
 
 /* setSearch
  * Set string to filter nodes by name, description, url

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -972,9 +972,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 					continue;
 				}
 			}
-		}
-		
-		if (!autoSort) {
 			if (newPredecessorId > 0) {
 				if (![dbManager setNextSibling:[dbManager folderFromID:newPredecessorId].nextSiblingId
                                      forFolder:folderId]) {

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -255,6 +255,10 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 		NSInteger nextChildId = (node == self.rootNode) ? [Database sharedManager].firstFolderId : node.folder.firstChildId;
 		NSInteger predecessorId = 0;
 		while (nextChildId > 0) {
+			if ([self.rootNode nodeFromID:nextChildId]) { // already present in our tree ?
+				NSLog(@"Duplicate child with id %ld asked under folder with id %ld", (long)nextChildId, (long)node.nodeId);
+				return NO;
+			}
 			NSUInteger  listIndex = [listOfFolderIds indexOfObject:@(nextChildId)];
 			if (listIndex == NSNotFound) {
 				NSLog(@"Cannot find child with id %ld for folder with id %ld", (long)nextChildId, (long)node.nodeId);

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -942,9 +942,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
             }
 				
 		} else {
-			if (!newParent.canHaveChildren) {
-				[newParent setCanHaveChildren:YES];
-			}
 			if ([dbManager setParent:newParentId forFolder:folderId]) {
 				if (sync && folder.type == VNAFolderTypeOpenReader) {
 					OpenReader * myReader = [OpenReader sharedManager];
@@ -960,6 +957,9 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 			} else {
 				continue;
 			}
+			if (!newParent.canHaveChildren) {
+				[newParent setCanHaveChildren:YES];
+			}
 		}
 		
 		if (!autoSort) {
@@ -973,14 +973,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 				}
 			}
 		}
-		
-		[oldParent removeChild:node andChildren:NO];
-		[newParent addChild:node atIndex:newChildIndex];
-		
-		// Put at beginning of undoArray in order to undo moves in reverse order.
-		[undoArray insertObject:@(folderId) atIndex:0u];
-		[undoArray insertObject:@(oldParentId) atIndex:1u];
-		[undoArray insertObject:@(oldPredecessorId) atIndex:2u];
 		
 		if (!autoSort) {
 			if (newPredecessorId > 0) {
@@ -997,6 +989,14 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 				[dbManager setFirstChild:folderId forFolder:newParentId];
 			}
 		}
+
+		[oldParent removeChild:node andChildren:NO];
+		[newParent addChild:node atIndex:newChildIndex];
+
+		// Put at beginning of undoArray in order to undo moves in reverse order.
+		[undoArray insertObject:@(folderId) atIndex:0u];
+		[undoArray insertObject:@(oldParentId) atIndex:1u];
+		[undoArray insertObject:@(oldPredecessorId) atIndex:2u];
 	}
 	
 	// If undo array is empty, then nothing has been moved.

--- a/Vienna/Sources/Main window/TreeNode.m
+++ b/Vienna/Sources/Main window/TreeNode.m
@@ -180,11 +180,11 @@
 }
 
 /* childByIndex
- * Returns the TreeNode for the child at the specified index offset. (Note that we don't
- * assert index here. The objectAtIndex function will take care of that for us.)
+ * Returns the TreeNode for the child at the specified index offset.
  */
 -(TreeNode *)childByIndex:(NSInteger)index
 {
+	NSAssert(index>=0 && index < children.count, @"index beyond limits in childByIndex:");
 	return children[index];
 }
 


### PR DESCRIPTION
Replaces #1783, should help with issues #1768, #1779 and #1784.

I decided to revert PR #1754 (Improve handling of FoldersTree manual sort issues) and implement a better handling of siblings reported as missing in `-loadTree:rootNode:`

As in #1783, check `-setParent:forFolder:` and `-setNextSibling:folderFromID:forFolder:` success or failure before moving a tree node.
