### PR TITLE
Do not show warning sign on feeds without articles

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -731,7 +731,6 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
         if (newFeed.items.count == 0) {
             // Mark the feed as empty
-            [self setFolderErrorFlag:folder flag:YES];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [connectorItem setStatus:NSLocalizedString(@"No articles in feed", nil)];
             });


### PR DESCRIPTION
A situation where the feed is empty should not be considered an error, we just log the information as it might be useful for the user.

Fix issue #1790