### PR TITLE
Fix confusion between Article and ArticleReference

### DIFF
--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -24,6 +24,7 @@
 @class Folder;
 @class Field;
 @class Article;
+@class ArticleReference;
 @class CriteriaTree;
 
 typedef NS_OPTIONS(NSInteger, VNAQueryScope) {
@@ -109,8 +110,8 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 -(BOOL)addArticle:(Article *)article toFolder:(NSInteger)folderID;
 -(BOOL)updateArticle:(Article *)existingArticle ofFolder:(NSInteger)folderID withArticle:(Article *)article;
 -(BOOL)deleteArticle:(Article *)article;
--(NSArray *)arrayOfUnreadArticlesRefs:(NSInteger)folderId;
--(NSArray *)arrayOfArticles:(NSInteger)folderId filterString:(NSString *)filterString;
+-(NSArray<ArticleReference *> *)arrayOfUnreadArticlesRefs:(NSInteger)folderId;
+-(NSArray<Article *> *)arrayOfArticles:(NSInteger)folderId filterString:(NSString *)filterString;
 -(void)markArticleRead:(NSInteger)folderId guid:(NSString *)guid isRead:(BOOL)isRead;
 -(void)markArticleFlagged:(NSInteger)folderId guid:(NSString *)guid isFlagged:(BOOL)isFlagged;
 -(void)markArticleDeleted:(Article *)article isDeleted:(BOOL)isDeleted;

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -2171,7 +2171,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
  * articles in the specified folder.
  * Note : when possible, you should use the interface provided by the Folder class instead of this
  */
--(NSArray *)arrayOfUnreadArticlesRefs:(NSInteger)folderId
+-(NSArray<ArticleReference *> *)arrayOfUnreadArticlesRefs:(NSInteger)folderId
 {
 	Folder * folder = [self folderFromID:folderId];
 	if (folder != nil) {

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -21,6 +21,7 @@
 @import Cocoa;
 
 @class Article;
+@class ArticleReference;
 
 /**
  Folder types
@@ -116,7 +117,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 -(void)removeArticleFromCache:(NSString *)guid;
 -(void)restoreArticleToCache:(Article *)article;
 -(void)markArticlesInCacheRead;
--(NSArray *)arrayOfUnreadArticlesRefs;
+-(NSArray<ArticleReference *> *)arrayOfUnreadArticlesRefs;
 -(NSComparisonResult)folderNameCompare:(Folder *)otherObject;
 -(NSComparisonResult)folderIDCompare:(Folder *)otherObject;
 @property (readonly, nonatomic) NSString *feedSourceFilePath;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -655,7 +655,7 @@
 /* arrayOfUnreadArticlesRefs
  * Return an array of ArticleReference of all unread articles
  */
--(NSArray *)arrayOfUnreadArticlesRefs
+-(NSArray<ArticleReference *> *)arrayOfUnreadArticlesRefs
 {
 @synchronized(self) {
     if (self.isCached) {


### PR DESCRIPTION
The confusion isn't really an issue, as ArticleReference accessors are also present into Article (this is in fact used by some methods like -innerMarkReadByRefsArray:readFlag: as an advantage for flexibility), but the proposed change should improve memory management.

Also explicit some NSArray's types to limit risks of further confusions.