### PR TITLE
Handle command-click and option-click on links

### DIFF
--- a/Vienna/Sources/Main window/Browser.swift
+++ b/Vienna/Sources/Main window/Browser.swift
@@ -46,6 +46,7 @@ protocol Browser {
     ///   - load: whether the page to which the URL points is supposed to be loaded immediately
     ///           (otherwise it is opened when opening the tab)
     /// - Returns: the new tab
+    @discardableResult
     func createNewTab(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab
 
     /// Add a new tab to the open tabs of the browser, after the currently selected one
@@ -56,6 +57,7 @@ protocol Browser {
     ///   - load: whether the page to which the URL points is supposed to be loaded immediately
     ///           (otherwise it is opened when opening the tab)
     /// - Returns: the new tab
+    @discardableResult
     func createNewTabAfterSelected(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab
 
     /// Saves all tabs persistently.

--- a/Vienna/Sources/Main window/Browser.swift
+++ b/Vienna/Sources/Main window/Browser.swift
@@ -48,6 +48,16 @@ protocol Browser {
     /// - Returns: the new tab
     func createNewTab(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab
 
+    /// Add a new tab to the open tabs of the browser, after the currently selected one
+    ///
+    /// - Parameters:
+    ///   - url: optional URL for the new tab
+    ///   - inBackground: if the tab shall stay unselected
+    ///   - load: whether the page to which the URL points is supposed to be loaded immediately
+    ///           (otherwise it is opened when opening the tab)
+    /// - Returns: the new tab
+    func createNewTabAfterSelected(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab
+
     /// Saves all tabs persistently.
     /// Next time when instanciating the browser, these tabs will be re-instanciated as well.
     func saveOpenTabs()

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -339,6 +339,24 @@ extension BrowserTab: Tab {
 
 extension BrowserTab: WKNavigationDelegate {
 
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if navigationAction.navigationType == .linkActivated {
+            let commandKey = navigationAction.modifierFlags.contains(.command)
+            let optionKey = navigationAction.modifierFlags.contains(.option)
+            if commandKey {
+                decisionHandler(.cancel)
+                _ = NSApp.appController.browser.createNewTabAfterSelected(navigationAction.request.url, inBackground: true, load: true)
+            } else if optionKey {
+                decisionHandler(.cancel)
+                NSApp.appController.open(navigationAction.request.url, inPreferredBrowser: false)
+            } else {
+                decisionHandler(.allow)
+            }
+        } else {
+            decisionHandler(.allow)
+        }
+    }
+
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
         if navigationResponse.canShowMIMEType {
             decisionHandler(.allow)

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -345,7 +345,7 @@ extension BrowserTab: WKNavigationDelegate {
             let optionKey = navigationAction.modifierFlags.contains(.option)
             if commandKey {
                 decisionHandler(.cancel)
-                _ = NSApp.appController.browser.createNewTabAfterSelected(navigationAction.request.url, inBackground: true, load: true)
+                NSApp.appController.browser.createNewTabAfterSelected(navigationAction.request.url, inBackground: true, load: true)
             } else if optionKey {
                 decisionHandler(.cancel)
                 NSApp.appController.open(navigationAction.request.url, inPreferredBrowser: false)

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -162,11 +162,6 @@ extension TabbedBrowserViewController: Browser {
         createNewTab(url, inBackground: inBackground, load: load, insertAt: getIndexAfterSelected())
     }
 
-    func createNewTab(_ request: URLRequest, config: WKWebViewConfiguration, inBackground: Bool, insertAt index: Int? = nil) -> any Tab {
-        let newTab = BrowserTab(request, config: config)
-        return initNewTab(newTab, request.url, false, inBackground, insertAt: index)
-    }
-
     @discardableResult
     func createNewTab(_ url: URL? = nil, inBackground: Bool = false, load: Bool = false, insertAt index: Int? = nil) -> any Tab {
         let newTab = BrowserTab()

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -323,15 +323,6 @@ extension TabbedBrowserViewController: CustomWKUIDelegate {
 
     private static var contextMenuCustomizer: any BrowserContextMenuDelegate = WebKitContextMenuCustomizer()
 
-    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        let newTab = self.createNewTab(navigationAction.request, config: configuration, inBackground: false, insertAt: getIndexAfterSelected())
-        if let webView = webView as? CustomWKWebView {
-            // The listeners are removed from the old webview userContentController on creating the new one, restore them
-            webView.resetScriptListeners()
-        }
-        return (newTab as? BrowserTab)?.webView
-    }
-
     func contextMenuItemsFor(purpose: WKWebViewContextMenuContext, existingMenuItems: [NSMenuItem]) -> [NSMenuItem] {
         // specific customization of menuItems may be added here
         // using the following commented out construct

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -152,10 +152,12 @@ class TabbedBrowserViewController: NSViewController, RSSSource {
 }
 
 extension TabbedBrowserViewController: Browser {
+    @discardableResult
     func createNewTab(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab {
         createNewTab(url, inBackground: inBackground, load: load, insertAt: nil)
     }
 
+    @discardableResult
     func createNewTabAfterSelected(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab {
         createNewTab(url, inBackground: inBackground, load: load, insertAt: getIndexAfterSelected())
     }
@@ -165,6 +167,7 @@ extension TabbedBrowserViewController: Browser {
         return initNewTab(newTab, request.url, false, inBackground, insertAt: index)
     }
 
+    @discardableResult
     func createNewTab(_ url: URL? = nil, inBackground: Bool = false, load: Bool = false, insertAt index: Int? = nil) -> any Tab {
         let newTab = BrowserTab()
         return initNewTab(newTab, url, load, inBackground, insertAt: index)
@@ -301,7 +304,7 @@ extension TabbedBrowserViewController: MMTabBarViewDelegate {
     }
 
     func addNewTab(to aTabView: NSTabView) {
-        _ = self.createNewTab()
+        self.createNewTab()
     }
 
     func tabView(_ tabView: NSTabView, willSelect tabViewItem: NSTabViewItem?) {
@@ -343,9 +346,9 @@ extension TabbedBrowserViewController: CustomWKUIDelegate {
         }
         switch menuItem.identifier {
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInBackground:
-            _ = self.createNewTabAfterSelected(url, inBackground: true, load: true)
+            self.createNewTabAfterSelected(url, inBackground: true, load: true)
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInNewWindow, NSUserInterfaceItemIdentifier.WKMenuItemOpenImageInNewWindow, NSUserInterfaceItemIdentifier.WKMenuItemOpenMediaInNewWindow:
-            _ = self.createNewTabAfterSelected(url, inBackground: false, load: true)
+            self.createNewTabAfterSelected(url, inBackground: false, load: true)
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInSystemBrowser:
             NSApp.appController.openURL(inDefaultBrowser: url)
         case NSUserInterfaceItemIdentifier.WKMenuItemDownloadImage, NSUserInterfaceItemIdentifier.WKMenuItemDownloadMedia, NSUserInterfaceItemIdentifier.WKMenuItemDownloadLinkedFile:

--- a/Vienna/Sources/Main window/TabbedBrowserViewController.swift
+++ b/Vienna/Sources/Main window/TabbedBrowserViewController.swift
@@ -156,6 +156,10 @@ extension TabbedBrowserViewController: Browser {
         createNewTab(url, inBackground: inBackground, load: load, insertAt: nil)
     }
 
+    func createNewTabAfterSelected(_ url: URL?, inBackground: Bool, load: Bool) -> any Tab {
+        createNewTab(url, inBackground: inBackground, load: load, insertAt: getIndexAfterSelected())
+    }
+
     func createNewTab(_ request: URLRequest, config: WKWebViewConfiguration, inBackground: Bool, insertAt index: Int? = nil) -> any Tab {
         let newTab = BrowserTab(request, config: config)
         return initNewTab(newTab, request.url, false, inBackground, insertAt: index)
@@ -339,9 +343,9 @@ extension TabbedBrowserViewController: CustomWKUIDelegate {
         }
         switch menuItem.identifier {
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInBackground:
-            _ = self.createNewTab(url, inBackground: true, load: true, insertAt: getIndexAfterSelected())
+            _ = self.createNewTabAfterSelected(url, inBackground: true, load: true)
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInNewWindow, NSUserInterfaceItemIdentifier.WKMenuItemOpenImageInNewWindow, NSUserInterfaceItemIdentifier.WKMenuItemOpenMediaInNewWindow:
-            _ = self.createNewTab(url, inBackground: false, load: true, insertAt: getIndexAfterSelected())
+            _ = self.createNewTabAfterSelected(url, inBackground: false, load: true)
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInSystemBrowser:
             NSApp.appController.openURL(inDefaultBrowser: url)
         case NSUserInterfaceItemIdentifier.WKMenuItemDownloadImage, NSUserInterfaceItemIdentifier.WKMenuItemDownloadMedia, NSUserInterfaceItemIdentifier.WKMenuItemDownloadLinkedFile:

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -98,7 +98,7 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
 
     // MARK: Navigation delegate
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    override func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         // TODO: how do forms work in the article view?
         // i.e. navigationAction.navigationType == .formSubmitted or .formResubmitted
         // TODO: in the future, we might want to allow limited browsing in the primary tab

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -152,9 +152,9 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
         }
         switch menuItem.identifier {
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInBackground:
-            _ = NSApp.appController.browser.createNewTab(url, inBackground: true, load: true)
+            NSApp.appController.browser.createNewTab(url, inBackground: true, load: true)
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInNewWindow, NSUserInterfaceItemIdentifier.WKMenuItemOpenImageInNewWindow, NSUserInterfaceItemIdentifier.WKMenuItemOpenMediaInNewWindow:
-            _ = NSApp.appController.browser.createNewTab(url, inBackground: false, load: true)
+            NSApp.appController.browser.createNewTab(url, inBackground: false, load: true)
         case NSUserInterfaceItemIdentifier.WKMenuItemOpenLinkInSystemBrowser:
             NSApp.appController.openURL(inDefaultBrowser: url)
         case NSUserInterfaceItemIdentifier.WKMenuItemDownloadImage, NSUserInterfaceItemIdentifier.WKMenuItemDownloadMedia, NSUserInterfaceItemIdentifier.WKMenuItemDownloadLinkedFile:


### PR DESCRIPTION
Make command-click on a link in a browser tab to open a new tab, like in other major web browsers.

Also have option-click in a browser tab to behave the same way as an option-click in the primary tab : open the link in the browser which is not set as the default in General settings (either it is the system's default browser or Vienna's internal browser).

Solves request expressed in discussion #1740