### PR TITLE
Improve management of folder's caches of articles

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		F696D23E2561F9FC003DF0C0 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = F696D23D2561F9FC003DF0C0 /* Sparkle */; };
 		F69964F71F13029600FC8493 /* OverlayStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69964F61F13029500FC8493 /* OverlayStatusBar.swift */; };
 		F6A179D326B82BE3008DDA42 /* NSFileManagerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A179D226B82BE3008DDA42 /* NSFileManagerExtensionTests.swift */; };
+		F6A243E12C69E534000A006F /* Article+Tags.m in Sources */ = {isa = PBXBuildFile; fileRef = F6A243E02C69E534000A006F /* Article+Tags.m */; };
 		F6A464BC272F47BE0071E3F6 /* NSKeyedUnarchiver+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = F6A464BA272F47BE0071E3F6 /* NSKeyedUnarchiver+Compatibility.m */; };
 		F6A464BD272F47BE0071E3F6 /* NSKeyedArchiver+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = F6A464BB272F47BE0071E3F6 /* NSKeyedArchiver+Compatibility.m */; };
 		F6A4E8481F040D58001C9191 /* PlugInToolbarItemButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A4E8471F040D58001C9191 /* PlugInToolbarItemButton.swift */; };
@@ -564,6 +565,8 @@
 		F69964F61F13029500FC8493 /* OverlayStatusBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverlayStatusBar.swift; sourceTree = "<group>"; };
 		F69AE7E91F2224F500342640 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = da; path = da.lproj/RSSSources.plist; sourceTree = "<group>"; };
 		F6A179D226B82BE3008DDA42 /* NSFileManagerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSFileManagerExtensionTests.swift; sourceTree = "<group>"; };
+		F6A243DF2C69E534000A006F /* Article+Tags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Article+Tags.h"; sourceTree = "<group>"; };
+		F6A243E02C69E534000A006F /* Article+Tags.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Article+Tags.m"; sourceTree = "<group>"; };
 		F6A464B8272F47BE0071E3F6 /* NSKeyedUnarchiver+Compatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "NSKeyedUnarchiver+Compatibility.h"; sourceTree = "<group>"; };
 		F6A464B9272F47BE0071E3F6 /* NSKeyedArchiver+Compatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "NSKeyedArchiver+Compatibility.h"; sourceTree = "<group>"; };
 		F6A464BA272F47BE0071E3F6 /* NSKeyedUnarchiver+Compatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "NSKeyedUnarchiver+Compatibility.m"; sourceTree = "<group>"; };
@@ -729,6 +732,8 @@
 				2F88B2A42545BB450067EEA6 /* ArticleConverter.h */,
 				2F88B2A52545BB450067EEA6 /* ArticleConverter.m */,
 				2FC4A1BE25852C0E005FF227 /* ArticleConverter.swift */,
+				F6A243DF2C69E534000A006F /* Article+Tags.h */,
+				F6A243E02C69E534000A006F /* Article+Tags.m */,
 			);
 			name = Common;
 			sourceTree = "<group>";
@@ -1808,6 +1813,7 @@
 				435028AC165DE9E00018EDB7 /* NewSubscription.m in Sources */,
 				2F88FF432969FC530076B99E /* DateWithUnitPredicateEditorRowTemplate.swift in Sources */,
 				F6EB26031E58D37100570B22 /* DirectoryMonitor.swift in Sources */,
+				F6A243E12C69E534000A006F /* Article+Tags.m in Sources */,
 				435028AD165DE9E00018EDB7 /* PluginManager.m in Sources */,
 				B81B536425565CD700C65459 /* Constants.swift in Sources */,
 				435028AE165DE9E00018EDB7 /* ProgressTextCell.m in Sources */,

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -2462,19 +2462,11 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
              @(folderId),
              guid];
         }];
-        if (isDeleted && !article.deleted) {
-            [article markDeleted:YES];
-            if (folder.countOfCachedArticles > 0) {
-				// If we're in a smart folder, the cached article may be different.
-				Article * cachedArticle = [folder articleFromGuid:guid];
-				[cachedArticle markDeleted:YES];
-				[folder removeArticleFromCache:guid];
-			}
-        } else if (!isDeleted) {
-            // if we undelete, allow the RSS or OpenReader folder
-            // to get the restored article 
-            [folder restoreArticleToCache:article];
-            [article markDeleted:NO];
+        [article markDeleted:isDeleted];
+        if (folder.countOfCachedArticles > 0) {
+            // If we're in a smart folder, the cached article may be different.
+            Article * cachedArticle = [folder articleFromGuid:guid];
+            [cachedArticle markDeleted:isDeleted];
         }
 	}
 }

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -2239,7 +2239,8 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 			results = [db executeQuery:queryString, filterString, filterString];
 		}
 		while ([results next]) {
-			Article * article = [[Article alloc] initWithGuid:[results stringForColumnIndex:0]];
+			NSString * guid = [results stringForColumnIndex:0];
+			Article * article = [[Article alloc] initWithGuid:guid];
 			article.folderId = [results intForColumnIndex:1];
 			article.parentId = [results intForColumnIndex:2];
 			[article markRead:[results intForColumnIndex:3]];
@@ -2255,6 +2256,8 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 			[article markRevised:[results intForColumnIndex:12]];
 			article.hasEnclosure = [results intForColumnIndex:13];
 			article.enclosure = [results stringForColumnIndex:14];
+			Folder * articleFolder = [self folderFromID:article.folderId];
+			article.status = [articleFolder retrieveKnownStatusForGuid:guid];
 		
 			if (folder == nil || !article.deleted || folder.type == VNAFolderTypeTrash) {
 				[newArray addObject:article];

--- a/Vienna/Sources/Fetching/OpenReader.m
+++ b/Vienna/Sources/Fetching/OpenReader.m
@@ -639,6 +639,7 @@ typedef NS_ENUM (NSInteger, OpenReaderStatus) {
 
             // Here's where we add the articles to the database
             if (articleArray.count > 0) {
+                [refreshedFolder resetArticleStatuses];
                 NSArray *guidHistory = [dbManager guidHistoryForFolderId:refreshedFolder.itemId];
 
                 for (Article *article in articleArray) {

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -854,6 +854,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
         // Here's where we add the articles to the database
         if (articleArray.count > 0u) {
+            [folder resetArticleStatuses];
             NSArray *guidHistory = [dbManager guidHistoryForFolderId:folderId];
             for (Article * article in articleArray) {
                 if ([folder createArticle:article

--- a/Vienna/Sources/Main window/Article+Tags.h
+++ b/Vienna/Sources/Main window/Article+Tags.h
@@ -1,0 +1,45 @@
+//
+//  Article+Tags.h
+//  Vienna
+//
+//  Copyright 2024 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "Article.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Article (Tags)
+
+// The following methods are called dynamically by the ArticleConverter class,
+// specifically -expandTagsOfArticle:intoTemplate:withConditional:. It creates
+// selectors by appending a tag name to the string "tag", e.g. $ArticleAuthor$
+// becomes tagArticleAuthor. The method signatures must not be changed without
+// changing the corresponding tag names elsewhere.
+
+- (NSString *)tagArticleTitle;
+- (NSString *)tagArticleAuthor;
+- (NSString *)tagArticleBody;
+- (NSString *)tagArticleDate;
+- (NSString *)tagArticleLink;
+- (NSString *)tagArticleEnclosureLink;
+- (NSString *)tagArticleEnclosureFilename;
+- (NSString *)tagFeedTitle;
+- (NSString *)tagFeedDescription;
+- (NSString *)tagFeedLink;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/Article+Tags.m
+++ b/Vienna/Sources/Main window/Article+Tags.m
@@ -1,0 +1,92 @@
+//
+//  Article+Tags.m
+//  Vienna
+//
+//  Copyright 2024 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "Article+Tags.h"
+
+#import "Database.h"
+#import "DateFormatterExtension.h"
+#import "Folder.h"
+#import "HelperFunctions.h"
+#import "StringExtensions.h"
+
+@implementation Article (Tags)
+
+- (NSString *)tagArticleTitle
+{
+    NSMutableString *articleTitle = [NSMutableString stringWithString:SafeString(self.title)];
+    [articleTitle vna_replaceString:@"$Article" withString:@"$_%$%_Article"];
+    [articleTitle vna_replaceString:@"$Feed" withString:@"$_%$%_Feed"];
+    return [NSString vna_stringByConvertingHTMLEntities:articleTitle];
+}
+
+- (NSString *)tagArticleAuthor
+{
+    return SafeString(self.author);
+}
+
+- (NSString *)tagArticleBody
+{
+    NSMutableString *articleBody = [NSMutableString stringWithString:SafeString(self.body)];
+    [articleBody vna_replaceString:@"$Article" withString:@"$_%$%_Article"];
+    [articleBody vna_replaceString:@"$Feed" withString:@"$_%$%_Feed"];
+    [articleBody vna_fixupRelativeImgTags:self.link];
+    [articleBody vna_fixupRelativeIframeTags:self.link];
+    [articleBody vna_fixupRelativeAnchorTags:self.link];
+    return articleBody;
+}
+
+- (NSString *)tagArticleDate
+{
+    return [NSDateFormatter vna_relativeDateStringFromDate:self.lastUpdate];
+}
+
+- (NSString *)tagArticleLink
+{
+    return cleanedUpUrlFromString(self.link).absoluteString;
+}
+
+- (NSString *)tagArticleEnclosureLink
+{
+    return cleanedUpUrlFromString(self.enclosure).absoluteString;
+}
+
+- (NSString *)tagArticleEnclosureFilename
+{
+    return self.enclosure.lastPathComponent.stringByRemovingPercentEncoding;
+}
+
+- (NSString *)tagFeedTitle
+{
+    Folder *folder = [Database.sharedManager folderFromID:self.folderId];
+    return [NSString vna_stringByConvertingHTMLEntities:SafeString(folder.name)];
+}
+
+- (NSString *)tagFeedDescription
+{
+    Folder *folder = [Database.sharedManager folderFromID:self.folderId];
+    return folder.feedDescription;
+}
+
+- (NSString *)tagFeedLink
+{
+    Folder *folder = [Database.sharedManager folderFromID:self.folderId];
+    return cleanedUpUrlFromString(folder.homePage).absoluteString;
+}
+
+@end

--- a/Vienna/Sources/Main window/ArticleConverter.m
+++ b/Vienna/Sources/Main window/ArticleConverter.m
@@ -42,6 +42,8 @@
  */
 -(NSString *)expandTagsOfArticle:(Article *)theArticle intoTemplate:(NSString *)theString withConditional:(BOOL)cond
 {
+    NSAssert(theArticle.status != ArticleStatusDiscarded,
+             @"Attempting to access %@ with discarded elements", theArticle);
     NSMutableString * newString = [NSMutableString stringWithString:SafeString(theString)];
     NSUInteger tagStartIndex = 0;
 

--- a/Vienna/Sources/Models/Article.h
+++ b/Vienna/Sources/Models/Article.h
@@ -69,10 +69,11 @@ typedef NS_ENUM(NSInteger, VNAArticleFieldTag) {
 typedef NS_ENUM(NSInteger, ArticleStatus) {
     ArticleStatusEmpty = 0,
     ArticleStatusNew,
-    ArticleStatusUpdated
+    ArticleStatusUpdated,
+    ArticleStatusDiscarded
 };
 
-@interface Article : NSObject
+@interface Article : NSObject<NSDiscardableContent>
 
 // Accessor functions
 -(instancetype _Nonnull)initWithGuid:(NSString * _Nonnull)theGuid /*NS_DESIGNATED_INITIALIZER*/;

--- a/Vienna/Sources/Models/Article.m
+++ b/Vienna/Sources/Models/Article.m
@@ -308,4 +308,33 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
     return nil;
 }
 
+// MARK: - NSDiscardableContent
+
+-(BOOL)beginContentAccess
+{
+    return self.status != ArticleStatusDiscarded;
+}
+
+- (void)endContentAccess
+{
+    // do nothing special,
+    // as we are not attempting to retrieve discarded content by ourself
+    // and don't manage any access count
+}
+
+-(void)discardContentIfPossible
+{
+    self.status = ArticleStatusDiscarded;
+    [articleData removeObjectForKey:MA_Field_Text];
+    [articleData removeObjectForKey:MA_Field_Summary];
+    [articleData removeObjectForKey:MA_Field_Author];
+    [articleData removeObjectForKey:MA_Field_LastUpdate];
+    [articleData removeObjectForKey:MA_Field_PublicationDate];
+}
+
+- (BOOL)isContentDiscarded
+{
+    return self.status == ArticleStatusDiscarded;
+}
+
 @end

--- a/Vienna/Sources/Models/Article.m
+++ b/Vienna/Sources/Models/Article.m
@@ -18,13 +18,11 @@
 //  limitations under the License.
 //
 
-
 #import "Article.h"
+
 #import "Database.h"
-#import "DateFormatterExtension.h"
-#import "StringExtensions.h"
-#import "HelperFunctions.h"
 #import "Folder.h"
+#import "StringExtensions.h"
 
 // The names here are internal field names, not for localisation.
 NSString * const MA_Field_GUID = @"GUID";
@@ -308,98 +306,6 @@ NSString * const MA_Field_HasEnclosure = @"HasEnclosure";
                                                                                           index:index];
     }
     return nil;
-}
-
-/* tagArticleLink
- * Returns the article link as a safe string.
- */
--(NSString *)tagArticleLink
-{
-    return cleanedUpUrlFromString(self.link).absoluteString;
-}
-
-/* tagArticleTitle
- * Returns the article title.
- */
--(NSString *)tagArticleTitle
-{
-    NSMutableString * articleTitle = [NSMutableString stringWithString:SafeString([self title])];
-    [articleTitle vna_replaceString:@"$Article" withString:@"$_%$%_Article"];
-    [articleTitle vna_replaceString:@"$Feed" withString:@"$_%$%_Feed"];
-    return [NSString vna_stringByConvertingHTMLEntities:articleTitle];
-}
-
-/* tagArticleBody
- * Returns the article body.
- */
--(NSString *)tagArticleBody
-{
-    NSMutableString * articleBody = [NSMutableString stringWithString:SafeString(self.body)];
-    [articleBody vna_replaceString:@"$Article" withString:@"$_%$%_Article"];
-    [articleBody vna_replaceString:@"$Feed" withString:@"$_%$%_Feed"];
-    [articleBody vna_fixupRelativeImgTags:self.link];
-    [articleBody vna_fixupRelativeIframeTags:self.link];
-    [articleBody vna_fixupRelativeAnchorTags:self.link];
-    return articleBody;
-}
-
-/* tagArticleAuthor
- * Returns the article author as a safe string.
- */
--(NSString *)tagArticleAuthor
-{
-    return SafeString([self author]);
-}
-
-/* tagArticleDate
- * Returns the article date.
- */
--(NSString *)tagArticleDate
-{
-    return [NSDateFormatter vna_relativeDateStringFromDate:self.lastUpdate];
-}
-
-/* tagArticleEnclosureLink
- * Returns the article enclosure link.
- */
--(NSString *)tagArticleEnclosureLink
-{
-    return cleanedUpUrlFromString(self.enclosure).absoluteString;
-}
-
-/* tagArticleEnclosureFilename
- * Returns the article enclosure file name.
- */
--(NSString *)tagArticleEnclosureFilename
-{
-    return [self.enclosure.lastPathComponent stringByRemovingPercentEncoding];
-}
-
-/* tagFeedTitle
- * Returns the article's feed title.
- */
--(NSString *)tagFeedTitle
-{
-    Folder * folder = [[Database sharedManager] folderFromID:self.folderId];
-    return [NSString vna_stringByConvertingHTMLEntities:SafeString([folder name])];
-}
-
-/* tagFeedLink
- * Returns the article's feed URL.
- */
--(NSString *)tagFeedLink
-{
-    Folder * folder = [[Database sharedManager] folderFromID:self.folderId];
-    return cleanedUpUrlFromString(folder.homePage).absoluteString;
-}
-
-/* tagFeedDescription
- * Returns the article's feed description.
- */
--(NSString *)tagFeedDescription
-{
-    Folder * folder = [[Database sharedManager] folderFromID:self.folderId];
-    return folder.feedDescription;
 }
 
 @end

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -113,6 +113,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 -(void)clearNonPersistedFlag:(VNAFolderFlag)flagToClear;
 -(NSUInteger)indexOfArticle:(Article *)article;
 -(Article *)articleFromGuid:(NSString *)guid;
+-(NSInteger)retrieveKnownStatusForGuid:(NSString *)guid;
 -(BOOL)createArticle:(Article *)article guidHistory:(NSArray *)guidHistory;
 -(void)removeArticleFromCache:(NSString *)guid;
 -(void)markArticlesInCacheRead;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -115,7 +115,6 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 -(Article *)articleFromGuid:(NSString *)guid;
 -(BOOL)createArticle:(Article *)article guidHistory:(NSArray *)guidHistory;
 -(void)removeArticleFromCache:(NSString *)guid;
--(void)restoreArticleToCache:(Article *)article;
 -(void)markArticlesInCacheRead;
 -(NSArray<ArticleReference *> *)arrayOfUnreadArticlesRefs;
 -(NSComparisonResult)folderNameCompare:(Folder *)otherObject;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -117,6 +117,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 -(BOOL)createArticle:(Article *)article guidHistory:(NSArray *)guidHistory;
 -(void)removeArticleFromCache:(NSString *)guid;
 -(void)markArticlesInCacheRead;
+-(void)resetArticleStatuses;
 -(NSArray<ArticleReference *> *)arrayOfUnreadArticlesRefs;
 -(NSComparisonResult)folderNameCompare:(Folder *)otherObject;
 -(NSComparisonResult)folderIDCompare:(Folder *)otherObject;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -609,8 +609,11 @@
         NSArray * myArray = [[Database sharedManager] minimalCacheForFolder:self.itemId];
         for (Article * myArticle in myArray) {
             NSString * guid = myArticle.guid;
+            myArticle.status = [self retrieveKnownStatusForGuid:guid];
             [self.cachedArticles setObject:myArticle forKey:[NSString stringWithString:guid]];
-            [self.cachedGuids addObject:guid];
+            if (![self.cachedGuids containsObject:guid]) {
+                [self.cachedGuids addObject:guid];
+            }
         }
         self.isCached = YES;
         // Note that this only builds a minimal cache, so we cannot set the containsBodies flag
@@ -702,6 +705,7 @@
                     } else {
                         // some problem
                         NSLog(@"Bug retrieving from cache in folder %li : after %lu insertions of %lu, guid %@",(long)self.itemId, (unsigned long)articles.count,(unsigned long)self.cachedGuids.count,object);
+                        [self.cachedArticles removeAllObjects];
                         return [self getCompleteArticles];
                     }
                 }
@@ -728,11 +732,11 @@
     // Only feeds folders can be cached, as they are the only ones to guarantee
     // bijection : one article <-> one guid
     if (self.type == VNAFolderTypeRSS || self.type == VNAFolderTypeOpenReader) {
-        [self.cachedArticles removeAllObjects];
         [self.cachedGuids removeAllObjects];
-        for (id object in articles) {
-            NSString * guid = ((Article *)object).guid;
-            [self.cachedArticles setObject:object forKey:[NSString stringWithString:guid]];
+        for (Article * article in articles) {
+            NSString * guid = article.guid;
+            article.status = [self retrieveKnownStatusForGuid:guid];
+            [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
             [self.cachedGuids addObject:guid];
         }
         self.isCached = YES;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -506,14 +506,16 @@
             // add the article as new
             BOOL success = [[Database sharedManager] addArticle:article toFolder:self.itemId];
             if (success) {
+                [article beginContentAccess];
                 article.status = ArticleStatusNew;
                 // add to the cache
                 NSString * guid = article.guid;
-	            [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
+	            [self.cachedArticles setObject:article forKey:guid];
 	            [self.cachedGuids addObject:guid];
                 if(!article.read) {
                     adjustment = 1;
                 }
+                [article endContentAccess];
             } else {
                 return NO;
             }
@@ -609,12 +611,14 @@
     if (!self.isCached) {
         NSArray * myArray = [[Database sharedManager] minimalCacheForFolder:self.itemId];
         for (Article * myArticle in myArray) {
+            [myArticle beginContentAccess];
             NSString * guid = myArticle.guid;
             myArticle.status = [self retrieveKnownStatusForGuid:guid];
-            [self.cachedArticles setObject:myArticle forKey:[NSString stringWithString:guid]];
+            [self.cachedArticles setObject:myArticle forKey:guid];
             if (![self.cachedGuids containsObject:guid]) {
                 [self.cachedGuids addObject:guid];
             }
+            [myArticle endContentAccess];
         }
         self.isCached = YES;
         // Note that this only builds a minimal cache, so we cannot set the containsBodies flag
@@ -735,10 +739,12 @@
     if (self.type == VNAFolderTypeRSS || self.type == VNAFolderTypeOpenReader) {
         [self.cachedGuids removeAllObjects];
         for (Article * article in articles) {
+            [article beginContentAccess];
             NSString * guid = article.guid;
             article.status = [self retrieveKnownStatusForGuid:guid];
-            [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
+            [self.cachedArticles setObject:article forKey:guid];
             [self.cachedGuids addObject:guid];
+            [article endContentAccess];
         }
         self.isCached = YES;
         self.containsBodies = YES;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -575,22 +575,6 @@
     }
 }
 
-/* restoreArticleToCache
- * Re-add an article to the cache (useful for unmarking article as deleted).
- */
--(void)restoreArticleToCache:(Article *)article
-{
-    @synchronized(self) {
-        NSString * guid = article.guid;
-        [self.cachedArticles setObject:article forKey:[NSString stringWithString:guid]];
-        [self.cachedGuids addObject:guid];
-        // note if article has incomplete data
-        if (article.publicationDate == nil) {
-            self.containsBodies = NO;
-        }
-    }
-}
-
 /* countOfCachedArticles
  * Return the number of articles in our cache, or -1 if the cache is empty.
  * (Note: empty is not the same as a folder with zero articles. The semantics are
@@ -807,10 +791,8 @@
     @synchronized(self) {
         Article * theArticle = ((Article *)obj);
         NSString * guid = theArticle.guid;
-        if (self.isCached && !theArticle.isDeleted) {
-            self.isCached = NO;
-            self.containsBodies = NO;
-        }
+        self.isCached = NO;
+        self.containsBodies = NO;
         [self.cachedGuids removeObject:guid];
     }
 }

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -658,6 +658,21 @@
   } // synchronized
 }
 
+/* resetArticleStatuses
+ * iterate through the cache and empty the articles status
+ */
+-(void)resetArticleStatuses
+{
+    for (NSString * guid in self.cachedGuids) {
+        Article * article = [self.cachedArticles objectForKey:guid];
+        if (article) {
+            [article beginContentAccess];
+            article.status = ArticleStatusEmpty;
+            [article endContentAccess];
+        }
+    }
+}
+
 /* arrayOfUnreadArticlesRefs
  * Return an array of ArticleReference of all unread articles
  */

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -69,6 +69,7 @@
 		_containsBodies = NO;
 		_hasPassword = NO;
 		_cachedArticles = [NSCache new];
+		_cachedArticles.evictsObjectsWithDiscardedContent = NO;
 		_cachedArticles.delegate = self;
 		_cachedGuids = [NSMutableArray array];
 		_attributes = [NSMutableDictionary dictionary];

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -464,6 +464,19 @@
 	}
 }
 
+/* retrieveKnownStatusForGuid
+   Returns article status if already known
+ */
+-(NSInteger)retrieveKnownStatusForGuid:(NSString *)guid
+{
+    Article * article = (Article *)[self.cachedArticles objectForKey:guid];
+    if (article) {
+        return article.status;
+    } else {
+        return ArticleStatusEmpty;
+    }
+}
+
 /* createArticle
  * Adds or updates an article in the folder.
  * Returns YES if the article was added or updated

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -607,6 +607,7 @@
  */
  -(void)ensureCache
  {
+    NSAssert(self.type == VNAFolderTypeRSS || self.type == VNAFolderTypeOpenReader, @"Attempting to create cache for non RSS folder");
     if (!self.isCached) {
         NSArray * myArray = [[Database sharedManager] minimalCacheForFolder:self.itemId];
         for (Article * myArticle in myArray) {
@@ -683,7 +684,8 @@
  */
 -(NSArray<Article *> *)articlesWithFilter:(NSString *)filterString
 {
-	if ([filterString isEqualToString:@""]) {
+	if ([filterString isEqualToString:@""]
+        && [@[@(VNAFolderTypeGroup), @(VNAFolderTypeRSS), @(VNAFolderTypeOpenReader)] containsObject:@(self.type)]) {
 		if (self.type == VNAFolderTypeGroup) {
 			NSMutableArray * articles = [NSMutableArray array];
 			NSArray * subFolders = [[Database sharedManager] arrayOfFolders:self.itemId];


### PR DESCRIPTION
After PR #1770 was merged, I noticed that the "Last Refresh" filter did not always have the expected behavior.

Investigation led to various discoveries regarding the use of NSCache and parts of the code where article's `status` was lost.
This PR solves these issues and gives back a functional "Last Refresh" filter, with a difference though:  "Last Refresh" now refers to the last time each feed was refreshed and _got new articles_, while previously
it referred to the last time "Refresh All Subscriptions" was _triggered_.