### PR TITLE
Update folder data even when the feed has no articles

### DIFF
--- a/Vienna/Interfaces/Base.lproj/InfoWindow.xib
+++ b/Vienna/Interfaces/Base.lproj/InfoWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,7 +31,7 @@
             <windowCollectionBehavior key="collectionBehavior" moveToActiveSpace="YES" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="120" y="530" width="270" height="388"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="270" height="388"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -61,15 +61,15 @@
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="150" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                        <rect key="frame" x="46" y="346" width="87" height="14"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Last Refreshed:" id="105">
+                        <rect key="frame" x="46" y="346" width="78" height="14"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Last Updated:" id="105">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" verticalHuggingPriority="750" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="34">
-                        <rect key="frame" x="134" y="346" width="123" height="14"/>
+                        <rect key="frame" x="125" y="346" width="132" height="14"/>
                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" id="106">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/Vienna/Interfaces/mul.lproj/InfoWindow.xcstrings
+++ b/Vienna/Interfaces/mul.lproj/InfoWindow.xcstrings
@@ -2,132 +2,132 @@
   "sourceLanguage" : "en",
   "strings" : {
     "105.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Last Refreshed:\"; ObjectID = \"105\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Last Updated:\"; ObjectID = \"105\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Obnoveno:"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Sidst opdateret:"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Letzte Aktualisierung:"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Last Refreshed:"
+            "value" : "Last Updated:"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Última actualización:"
           }
         },
         "eu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Azken Eguneratuak:"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Dernière actualisation :"
           }
         },
         "gl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Última actualización:"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ultimo Aggiornamento:"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "最後の更新："
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "최종 갱신일:"
           }
         },
         "lt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Paskutinį kartą atnaujinta:"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Laatste keer vernieuwd:"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Última atualização:"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Última actualização:"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Последние обновленные:"
           }
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Senaste uppdaterad:"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "En son yenilendi:"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Останнє оновлення:"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "上次更新:"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "上次重新整理："
           }
         }

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -609,9 +609,6 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
 
         if (responseStatusCode == 304) {
             // No modification from last check
-
-            [dbManager setLastUpdate:[NSDate date] forFolder:folderId];
-
             [self setFolderErrorFlag:folder flag:NO];
             [connectorItem appendDetail:NSLocalizedString(@"Got HTTP status 304 - No news from last check", nil)];
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -766,8 +763,6 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         if (lastModifiedString != nil && lastModifiedString.length > 0) {
             [dbManager setLastUpdateString:lastModifiedString forFolder:folderId];
         }
-        // Set the last update date for this folder.
-        [dbManager setLastUpdate:[NSDate date] forFolder:folderId];
 
         if (newFeed.items.count == 0) {
             // Mark the feed as empty
@@ -889,6 +884,10 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
                     ++newArticlesFromFeed;
                 }
             }
+        }
+
+        if (newArticlesFromFeed > 0u) {
+            [dbManager setLastUpdate:[NSDate date] forFolder:folderId];
         }
 
         // Mark the feed as succeeded


### PR DESCRIPTION
Closes #1813 

Previously, if the feed had no articles at all, the `finalizeFolderRefresh:` method exited immediately, before applying any changes to the folder title, description, homepage or last-update string/date. Even if the feed has (currently) no articles, the feed-level data and last-refresh data ought to be updated.