### PR TITLE
Filter article from cache when it was marked deleted

### DIFF
--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -2472,7 +2472,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	NSString * guid = article.guid;
 	Folder * folder = [self folderFromID:folderId];
 	if (folder !=nil) {
-		if (isDeleted && !article.read) {
+        if (isDeleted && !article.read) {
 			[self markArticleRead:folderId guid:guid isRead:YES];
 		}
         FMDatabaseQueue *queue = self.databaseQueue;
@@ -2483,6 +2483,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
              guid];
         }];
         [article markDeleted:isDeleted];
+        //TODO this should all move to the folder implementation, to make this less of a god object.
+        // Or even better: when marking an article as deleted it triggers the deletion from its folder itself, and that in turn triggers the db update.
+        // The same also applies to deleteArticle and probably many other parts of this class.
         if (folder.countOfCachedArticles > 0) {
             // If we're in a smart folder, the cached article may be different.
             Article * cachedArticle = [folder articleFromGuid:guid];

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -739,7 +739,10 @@
                 for (id object in self.cachedGuids) {
                     Article * theArticle = [self.cachedArticles objectForKey:object];
                     if (theArticle != nil) {
-                        [articles addObject:theArticle];
+                        // deleted articles are not removed from cache any more
+                        if (!theArticle.isDeleted) {
+                            [articles addObject:theArticle];
+                        }
                     } else {
                         // some problem
                         NSLog(@"Bug retrieving from cache in folder %li : after %lu insertions of %lu, guid %@",(long)self.itemId, (unsigned long)articles.count,(unsigned long)self.cachedGuids.count,object);


### PR DESCRIPTION
fixes #1834, #1833
In cb9e3b5, a line from Database.m removing the article from cache explicitly was deleted. That led to articles reappearing until the folder cache was purged.