### PR TITLE
Browser fixes

### DIFF
--- a/Vienna/Sources/Main window/BrowserTab+Interface.swift
+++ b/Vienna/Sources/Main window/BrowserTab+Interface.swift
@@ -140,13 +140,13 @@ extension BrowserTab {
     }
 
     func updateTabTitle() {
-        if self.url != webView.url || self.url == nil {
+        if self.url != webView.url || webView.url == nil {
             // Currently loading (the first time), webview title not yet correct / available
             self.title = self.url?.host ?? NSLocalizedString("New Tab", comment: "")
         } else if let title = self.webView.title, !title.isEmpty {
             self.title = title
-        } else {
-            // Webview is about:blank or empty
+        } else if (self.title ?? "").isEmpty {
+            // we haven't yet set a title and Webview is about:blank or empty
             self.title = NSLocalizedString("New Tab", comment: "")
         }
     }

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -354,6 +354,9 @@ extension BrowserTab: WKNavigationDelegate {
             } else if optionKey {
                 decisionHandler(.cancel)
                 NSApp.appController.open(navigationAction.request.url, inPreferredBrowser: false)
+            } else if navigationAction.targetFrame == nil { // link with target="_blank"
+                decisionHandler(.cancel)
+                NSApp.appController.browser.createNewTabAfterSelected(navigationAction.request.url, inBackground: false, load: true)
             } else {
                 decisionHandler(.allow)
             }

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -230,17 +230,11 @@ extension BrowserTab: Tab {
 
     func back() -> Bool {
         let couldGoBack = self.webView.goBack() != nil
-        // title and url observation not triggered by goBack() -> manual setting
-        self.url = self.webView.url
-        updateTabTitle()
         return couldGoBack
     }
 
     func forward() -> Bool {
         let couldGoForward = self.webView.goForward() != nil
-        // title observation not triggered by goForware() -> manual setting
-        self.url = self.webView.url
-        updateTabTitle()
         return couldGoForward
     }
 


### PR DESCRIPTION
- Fix links specifying `target="_blank"` (issue #1847)
- Work around some tab with titles stuck to "New Tab" until they are selected
- Clean up some code
