### PR TITLE
Parse item elements in RSS feeds outside of the channel element too

### DIFF
--- a/Vienna Tests/Files/RSSFeedWithItemElementUnderRSSAndChannelElement.rss
+++ b/Vienna Tests/Files/RSSFeedWithItemElementUnderRSSAndChannelElement.rss
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>Feed title</title>
+        <link>http://localhost</link>
+        <description>Feed description</description>
+        <item>
+            <description>Item description</description>
+            <content:encoded>Item content</content:encoded>
+            <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+            <guid isPermaLink="false">channelItemGUID</guid>
+        </item>
+    </channel>
+    <item>
+        <description>Item description</description>
+        <content:encoded>Item content</content:encoded>
+        <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+        <guid isPermaLink="false">rssItemGUID</guid>
+    </item>
+</rss>

--- a/Vienna Tests/Files/RSSFeedWithItemElementUnderRSSElement.rss
+++ b/Vienna Tests/Files/RSSFeedWithItemElementUnderRSSElement.rss
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>Feed title</title>
+        <link>http://localhost</link>
+        <description>Feed description</description>
+    </channel>
+    <item>
+        <description>Item description</description>
+        <content:encoded>Item content</content:encoded>
+        <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+        <guid isPermaLink="false">itemGUID</guid>
+    </item>
+</rss>

--- a/Vienna Tests/RSSFeedTests.swift
+++ b/Vienna Tests/RSSFeedTests.swift
@@ -23,6 +23,32 @@ class RSSFeedTests: XCTestCase {
 
     // MARK: Test methods
 
+    func testParsingItemElementUnderRSSElement() throws {
+        let fileData = try data(
+            forResource: "RSSFeedWithItemElementUnderRSSElement",
+            withExtension: "rss"
+        )
+        let feedData = try VNAXMLFeedParser().feed(withXMLData: fileData)
+        let rssFeed = try XCTUnwrap(feedData as? RSSFeed)
+        let feedItems = rssFeed.items
+
+        XCTAssert(feedItems.count == 1)
+        XCTAssert(feedItems.first?.guid == "itemGUID")
+    }
+
+    func testParsingItemElementUnderRSSAndChannelElement() throws {
+        let fileData = try data(
+            forResource: "RSSFeedWithItemElementUnderRSSAndChannelElement",
+            withExtension: "rss"
+        )
+        let feedData = try VNAXMLFeedParser().feed(withXMLData: fileData)
+        let rssFeed = try XCTUnwrap(feedData as? RSSFeed)
+        let feedItems = rssFeed.items
+
+        XCTAssert(feedItems.count == 1)
+        XCTAssert(feedItems.first?.guid == "channelItemGUID")
+    }
+
     /// Validate the content:encoded elements.
     func testParsingContentElement() throws {
         let fileData = try data(forResource: "RSSFeedWithContentElements", withExtension: "rss")

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -214,6 +214,8 @@
 		F6B059E42961D0DD00F6E31B /* JSONFeedParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B059E32961D0DD00F6E31B /* JSONFeedParser.swift */; };
 		F6B3561525616313008CA1ED /* DownloadItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B3561425616313008CA1ED /* DownloadItem.m */; };
 		F6B7BC3624A2A9A40051D76F /* FMDB in Frameworks */ = {isa = PBXBuildFile; productRef = F6B7BC3524A2A9A40051D76F /* FMDB */; };
+		F6C136582D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss in Resources */ = {isa = PBXBuildFile; fileRef = F6C136572D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss */; };
+		F6C1365A2D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss in Resources */ = {isa = PBXBuildFile; fileRef = F6C136592D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss */; };
 		F6C9DA70271BB3BB00FC3027 /* RSSFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C9DA6F271BB3BB00FC3027 /* RSSFeed.m */; };
 		F6C9DA73271BB55000FC3027 /* AtomFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C9DA72271BB55000FC3027 /* AtomFeed.m */; };
 		F6CE47131E7E3DCB0045EAD7 /* ActivityItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F6CE47121E7E3DCB0045EAD7 /* ActivityItem.m */; };
@@ -633,6 +635,8 @@
 		F6BD1FDA2C9D7DD40075D04F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		F6BD1FDC2C9D7E230075D04F /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		F6BD1FDD2C9D7E2E0075D04F /* LICENCE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENCE.md; sourceTree = "<group>"; };
+		F6C136572D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = RSSFeedWithItemElementUnderRSSElement.rss; sourceTree = "<group>"; };
+		F6C136592D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = RSSFeedWithItemElementUnderRSSAndChannelElement.rss; sourceTree = "<group>"; };
 		F6C9DA6E271BB3BB00FC3027 /* RSSFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSSFeed.h; sourceTree = "<group>"; };
 		F6C9DA6F271BB3BB00FC3027 /* RSSFeed.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSSFeed.m; sourceTree = "<group>"; };
 		F6C9DA71271BB55000FC3027 /* AtomFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AtomFeed.h; sourceTree = "<group>"; };
@@ -1062,6 +1066,8 @@
 			children = (
 				F64499FB259773B9005A1EFA /* FeedDiscovery.html */,
 				F6E01A082C652FA50082E07B /* RSSFeedWithContentElements.rss */,
+				F6C136592D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss */,
+				F6C136572D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss */,
 			);
 			path = Files;
 			sourceTree = "<group>";
@@ -1540,6 +1546,8 @@
 			files = (
 				F6449A0325977521005A1EFA /* FeedDiscovery.html in Resources */,
 				F6E01A092C652FA50082E07B /* RSSFeedWithContentElements.rss in Resources */,
+				F6C1365A2D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss in Resources */,
+				F6C136582D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Vienna/Sources/Parsing/RSSFeed.m
+++ b/Vienna/Sources/Parsing/RSSFeed.m
@@ -62,6 +62,13 @@
             success = [self initRSSFeedItems:rssElement];
         } else {
             success = [self initRSSFeedItems:channelElement];
+
+            // Previous versions of RSS allowed <item> elements under the <rss>
+            // element instead of the <channel> element. If no items were found
+            // under the <channel> element then traverse the <rss> element too.
+            if (self.items.count == 0) {
+                success = [self initRSSFeedItems:rssElement];
+            }
         }
     }
     return success;

--- a/Vienna/Sources/Parsing/RSSFeed.m
+++ b/Vienna/Sources/Parsing/RSSFeed.m
@@ -59,15 +59,15 @@
     success = [self initRSSFeedHeaderWithElement:channelElement];
     if (success) {
         if (isRDF) {
-            success = [self initRSSFeedItems:rssElement];
+            [self initRSSFeedItems:rssElement];
         } else {
-            success = [self initRSSFeedItems:channelElement];
+            [self initRSSFeedItems:channelElement];
 
             // Previous versions of RSS allowed <item> elements under the <rss>
             // element instead of the <channel> element. If no items were found
             // under the <channel> element then traverse the <rss> element too.
             if (self.items.count == 0) {
-                success = [self initRSSFeedItems:rssElement];
+                [self initRSSFeedItems:rssElement];
             }
         }
     }
@@ -175,9 +175,8 @@
     }
 }
 
-- (BOOL)initRSSFeedItems:(NSXMLElement *)startElement
+- (void)initRSSFeedItems:(NSXMLElement *)startElement
 {
-    BOOL success = YES;
     NSMutableArray *items = [NSMutableArray array];
 
     for (NSXMLElement *element in startElement.children) {
@@ -355,7 +354,7 @@
 
     self.items = items;
 
-    return success;
+    return;
 }
 
 // MARK: Overrides


### PR DESCRIPTION
Resolves #1676

RSS feeds that have their `<item>` elements under the `<rss>` element instead of the `<channel>` element will work now too. This provides compatibility with other versions of RSS. However, as a precaution, if items _are_ present under the `<channel>` element then the `<rss>` element won't be traversed.