### PR TITLE
Fix smart-folder lookup/selection

### DIFF
--- a/Vienna/Sources/Application/AppController+Notifications.m
+++ b/Vienna/Sources/Application/AppController+Notifications.m
@@ -21,6 +21,7 @@
 
 #import "Database.h"
 #import "Folder.h"
+#import "Vienna-Swift.h"
 
 @implementation AppController (Notifications)
 
@@ -59,9 +60,14 @@ NSString *const UserNotificationContextFileDownloadFailed = @"User Notification 
     }
     [self showMainWindow:self];
 
-    Folder *unreadArticles = [db folderFromName:NSLocalizedString(@"Unread Articles", nil)];
-    if (unreadArticles) {
-        [self selectFolder:unreadArticles.itemId];
+    Criteria *unreadCriteria =
+        [[Criteria alloc] initWithField:MA_Field_Read
+                           operatorType:VNACriteriaOperatorEqualTo
+                                  value:@"No"];
+    NSString *predicateFormat = unreadCriteria.predicate.predicateFormat;
+    Folder *smartFolder = [db folderForPredicateFormat:predicateFormat];
+    if (smartFolder) {
+        [self selectFolder:smartFolder.itemId];
     }
 }
 

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -65,7 +65,21 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 -(NSArray *)arrayOfAllFolders;
 -(NSArray *)arrayOfFolders:(NSInteger)parentId;
 -(Folder *)folderFromID:(NSInteger)wantedId;
+/*!
+ *  folderFromFeedURL
+ *
+ *  @param wantedFeedURL The feed URL the folder is wanted for
+ *
+ *  @return An RSSFolder that is subscribed to the specified feed URL.
+ */
 -(Folder *)folderFromFeedURL:(NSString *)wantedFeedURL;
+/*!
+ *  folderFromRemoteId
+ *
+ *  @param wantedRemoteId The remote identifier the folder is wanted for
+ *
+ *  @return An OpenReaderFolder that corresponds
+ */
 -(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId;
 -(Folder *)folderFromName:(NSString *)wantedName;
 /// Returns a smart folder for the predicate format string.

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -82,9 +82,15 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
  */
 -(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId;
 -(Folder *)folderFromName:(NSString *)wantedName;
-/// Returns a smart folder for the predicate format string.
-/// - Parameter predicateFormat: An NSPredicate format string.
-/// - Returns: A Folder of type `VNAFolderTypeSmart` or `nil`.
+/*!
+ * folderForPredicateFormat
+ * Returns a smart folder for the predicate format string.
+ * This function is reliable only with simple one-term predicates
+ *
+ * @param predicateFormat: An NSPredicate format string
+ *
+ * @return A Folder of type `VNAFolderTypeSmart` or `nil`
+ */
 - (Folder *)folderForPredicateFormat:(NSString *)predicateFormat;
 -(NSString *)sqlScopeForFolder:(Folder *)folder flags:(VNAQueryScope)scopeFlags field:(NSString *)field;
 -(NSInteger)addFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId folderName:(NSString *)name type:(NSInteger)type canAppendIndex:(BOOL)canAppendIndex;

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -68,6 +68,10 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 -(Folder *)folderFromFeedURL:(NSString *)wantedFeedURL;
 -(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId;
 -(Folder *)folderFromName:(NSString *)wantedName;
+/// Returns a smart folder for the predicate format string.
+/// - Parameter predicateFormat: An NSPredicate format string.
+/// - Returns: A Folder of type `VNAFolderTypeSmart` or `nil`.
+- (Folder *)folderForPredicateFormat:(NSString *)predicateFormat;
 -(NSString *)sqlScopeForFolder:(Folder *)folder flags:(VNAQueryScope)scopeFlags field:(NSString *)field;
 -(NSInteger)addFolder:(NSInteger)parentId afterChild:(NSInteger)predecessorId folderName:(NSString *)name type:(NSInteger)type canAppendIndex:(BOOL)canAppendIndex;
 -(BOOL)deleteFolder:(NSInteger)folderId;

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -100,7 +100,6 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
         subscriptionURL:(NSString *)url remoteId:(NSString *)remoteId;
 
 // Smart folder functions
--(void)initSmartfoldersDict;
 -(NSInteger)addSmartFolder:(NSString *)folderName underParent:(NSInteger)parentId withQuery:(CriteriaTree *)criteriaTree;
 -(void)updateSearchFolder:(NSInteger)folderId withFolder:(NSString *)folderName withQuery:(CriteriaTree *)criteriaTree;
 -(CriteriaTree *)searchStringForSmartFolder:(NSInteger)folderId;

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -1428,14 +1428,6 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	return folder;
 }
 
-
-/*!
- *  folderFromFeedURL
- *
- *  @param wantedFeedURL The feed URL the folder is wanted for
- *
- *  @return An RSSFolder that is subscribed to the specified feed URL.
- */
 -(Folder *)folderFromFeedURL:(NSString *)wantedFeedURL
 {
 	Folder * folder;
@@ -1447,14 +1439,6 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 	}
 	return folder;
 }
-
-/*!
- *  folderFromRemoteId
- *
- *  @param wantedRemoteId The remote identifier the folder is wanted for
- *
- *  @return An OpenReaderFolder that corresponds
- */
 
 -(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId
 {


### PR DESCRIPTION
The current implementation uses the localised default name "Unread Articles" to look up the smart folder. However, this breaks if the user changes the name afterwards or switches to a different localisation (which is what I did). My proposed solution uses the underlying predicate format string to look for the smart folder.