### PR TITLE
Remove a few unused constants

### DIFF
--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -21,7 +21,6 @@
 @import Cocoa;
 
 extern NSString * const MA_DefaultUserAgentString;
-extern NSString * const MA_BrowserUserAgentString;
 
 extern NSNotificationName const MA_Notify_ArticleListContentChange;
 extern NSNotificationName const MA_Notify_ArticleListFontChange;
@@ -87,8 +86,6 @@ extern NSString * const MAPref_UseJavaScript;
 extern NSString * const MAPref_CachedArticleGUID;
 extern NSString * const MAPref_ArticleListSortOrders;
 extern NSString * const MAPref_FilterMode;
-extern NSString * const MAPref_TabList;
-extern NSString * const MAPref_TabTitleDictionary;
 extern NSString * const MAPref_Layout;
 extern NSString * const MAPref_NewArticlesNotification;
 extern NSString * const MAPref_EmptyTrashNotification;

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -21,7 +21,6 @@
 #import "Constants.h"
 
 NSString * const MA_DefaultUserAgentString = @"%@/%@ (Macintosh; Intel macOS %@)";
-NSString * const MA_BrowserUserAgentString = @"(Macintosh; Intel Mac OS X %@) AppleWebKit/%@ (KHTML, like Gecko) Version/%@ Safari/604.1.38 %@/%@";
 
 NSNotificationName const MA_Notify_ArticleListContentChange = @"MA_Notify_ArticleListContentChange";
 NSNotificationName const MA_Notify_ArticleListFontChange = @"MA_Notify_ArticleListFontChange";
@@ -87,8 +86,6 @@ NSString * const MAPref_UseJavaScript = @"UseJavaScript";
 NSString * const MAPref_CachedArticleGUID = @"CachedArticleGUID";
 NSString * const MAPref_ArticleListSortOrders = @"ArticleListSortOrders";
 NSString * const MAPref_FilterMode = @"FilterMode";
-NSString * const MAPref_TabList = @"TabList";
-NSString * const MAPref_TabTitleDictionary = @"TabTitleDict";
 NSString * const MAPref_Layout = @"Layout";
 NSString * const MAPref_NewArticlesNotification = @"NewArticlesNotification";
 NSString * const MAPref_EmptyTrashNotification = @"EmptyTrashNotification";


### PR DESCRIPTION
Spotted randomly when i was looking at the files for an unrelated reason.

There are more unused constants in the DataItem* section but I left them alone because there's a comment saying

    We are not using all of them yet, but they might become useful in the future.