### PR TITLE
Configure the user agent during the initial subscription

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -38,6 +38,7 @@
 #import "Vienna-Swift.h"
 #import "XMLFeed.h"
 #import "XMLFeedParser.h"
+#import "HelperFunctions.h"
 
 typedef NS_ENUM (NSInteger, Redirect301Status) {
     HTTP301Unknown = 0,
@@ -96,16 +97,9 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         networkQueue = [[NSOperationQueue alloc] init];
         networkQueue.name = @"VNAHTTPSession queue";
         networkQueue.maxConcurrentOperationCount = [[Preferences standardPreferences] integerForKey:MAPref_ConcurrentDownloads];
-        NSString * osVersion;
-        NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
-        osVersion = [NSString stringWithFormat:@"%ld_%ld_%ld", version.majorVersion, version.minorVersion, version.patchVersion];
-        Preferences * prefs = [Preferences standardPreferences];
-        NSString *name = prefs.userAgentName;
-
-        NSString * userAgent = [NSString stringWithFormat:MA_DefaultUserAgentString, name, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], osVersion];
         NSURLSessionConfiguration * config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.timeoutIntervalForResource = 300;
-        config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent};
+        config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent()};
         config.HTTPMaximumConnectionsPerHost = 6;
         config.HTTPShouldUsePipelining = YES;
         _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:[NSOperationQueue mainQueue]];

--- a/Vienna/Sources/Shared/HelperFunctions.h
+++ b/Vienna/Sources/Shared/HelperFunctions.h
@@ -51,5 +51,6 @@ NSString * _Nullable getDefaultBrowser(void);
 NSURL * _Nullable cleanedUpUrlFromString(NSString * _Nullable urlString);
 NSURL * _Nullable urlFromUserString(NSString *urlString);
 BOOL hasOSScriptsMenu(void);
+NSString * userAgent(void);
 
 NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -18,6 +18,8 @@
 // 
 
 #import "HelperFunctions.h"
+#import "Constants.h"
+#import "Preferences.h"
 @import WebKit;
 
 // Determines whether the system-wide script menu is present. This is usually
@@ -240,4 +242,15 @@ void runOKAlertSheet(NSString * titleString, NSString * bodyText, ...)
     }];
     
 	va_end(arguments);
+}
+
+/* Returns a fully-formed HTTP user agent of the reader.
+ */
+NSString * userAgent(void) {
+    NSString *osVersion;
+    NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
+    osVersion = [NSString stringWithFormat:@"%ld_%ld_%ld", version.majorVersion, version.minorVersion, version.patchVersion];
+    Preferences *prefs = [Preferences standardPreferences];
+    NSString *name = prefs.userAgentName;
+    return [NSString stringWithFormat:MA_DefaultUserAgentString, name, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"], osVersion];
 }

--- a/Vienna/Sources/Shared/SubscriptionModel.m
+++ b/Vienna/Sources/Shared/SubscriptionModel.m
@@ -46,7 +46,10 @@
     __block NSURL * myURL;
     // semaphore with count equal to zero for synchronizing completion of work
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:rssFeedURL
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent()};
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+    NSURLSessionDataTask *task = [session dataTaskWithURL:rssFeedURL
       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error || (((NSHTTPURLResponse *)response).statusCode != 200)) {
             myURL = rssFeedURL;


### PR DESCRIPTION
I saw in the HTTP logs that when creating a new subscription the reader presented itself as

    Vienna/8414 CFNetwork/3826.400.120 Darwin/24.3.0

while later, during refreshing the feed/subscription it sent the user agent set to

    Vienna/8414 (Macintosh; Intel macOS 15_3_0)

and I figured I'd make that consistent.