### PR TITLE
Fixes and small improvements to AppleScript support

### DIFF
--- a/Vienna/Resources/Vienna.sdef
+++ b/Vienna/Resources/Vienna.sdef
@@ -356,8 +356,11 @@
 			<property type="folder" name="containing folder" code="arFL" access="r" description="The folder to which this article belongs">
 				<cocoa key="containingFolder"/>
 			</property>
-			<property type="date" name="date" code="arDA" access="r" description="The date when the article was posted">
-				<cocoa key="date"/>
+			<property type="date" name="date" code="arDA" access="r" description="The date when the article was posted/updated">
+				<cocoa key="lastUpdate"/>
+			</property>
+			<property type="date" name="publication date" code="arDP" access="r" description="The date when the article was initially published">
+				<cocoa key="publicationDate"/>
 			</property>
 			<property type="boolean" name="deleted" code="arDL" access="r" description="Whether the article has been deleted">
 				<cocoa key="isDeleted"/>

--- a/Vienna/Resources/Vienna.sdef
+++ b/Vienna/Resources/Vienna.sdef
@@ -326,6 +326,12 @@
 			<property type="boolean" name="rss folder" code="flIR" access="r" description="Returns a true value if the folder is an RSS subscription">
 				<cocoa key="isRSSFolder"/>
 			</property>
+			<property type="boolean" name="open reader folder" code="flIO" access="r" description="Returns a true value if the folder is an OpenReader Cloud subscription">
+				<cocoa key="isOpenReaderFolder"/>
+			</property>
+			<property type="boolean" name="subscription folder" code="flIF" access="r" description="Returns a true value if the folder is a feed subscription">
+				<cocoa key="isSubscriptionFolder"/>
+			</property>
 			<property type="boolean" name="smart folder" code="flIS" access="r" description="Returns a strue value if the folder is a smart folder">
 				<cocoa key="isSmartFolder"/>
 			</property>

--- a/Vienna/Resources/Vienna.sdef
+++ b/Vienna/Resources/Vienna.sdef
@@ -359,6 +359,9 @@
 			<property type="text" name="body" code="arTX" access="r" description="The contents of the article">
 				<cocoa key="body"/>
 			</property>
+			<property type="text" name="summary" code="arSU" access="r" description="The contents of the article, cleaned up">
+				<cocoa key="summary"/>
+			</property>
 			<property type="folder" name="containing folder" code="arFL" access="r" description="The folder to which this article belongs">
 				<cocoa key="containingFolder"/>
 			</property>

--- a/Vienna/Resources/Vienna.sdef
+++ b/Vienna/Resources/Vienna.sdef
@@ -213,7 +213,7 @@
 			<property type="folder" name="current folder" code="cuFL" description="The current folder in the article list pane">
 				<cocoa key="currentFolder"/>
 			</property>
-			<property type="text" name="current selection" code="cuSE" access="r" description="Returns the text selected in the current article or web page">
+			<property type="text" name="current selection" code="cuSE" access="r" description="Returns the text selected in the current web page">
 				<cocoa key="currentTextSelection"/>
 			</property>
 			<property type="text" name="display style" code="dpSY" description="The current display style for articles">

--- a/Vienna/Sources/Application/ViennaApp.m
+++ b/Vienna/Sources/Application/ViennaApp.m
@@ -310,7 +310,7 @@
  */
 -(void)setCurrentFolder:(Folder *)newCurrentFolder
 {
-	AppController * controller = APPCONTROLLER;
+	AppController * controller = (AppController*)self.delegate;
 	NSInteger folderId = newCurrentFolder.itemId;
 	[controller selectFolder:folderId];
 }
@@ -323,7 +323,7 @@
 -(BOOL)readingPaneOnRight			{ return [Preferences standardPreferences].layout == VNALayoutCondensed; }
 -(NSInteger)filterMode					{ return [Preferences standardPreferences].filterMode; }
 -(BOOL)refreshOnStartup				{ return [Preferences standardPreferences].refreshOnStartup; }
--(BOOL)checkForNewOnStartup			{ return APPCONTROLLER.sparkleController.updater.automaticallyChecksForUpdates; }
+-(BOOL)checkForNewOnStartup			{ return ((AppController*)self.delegate).sparkleController.updater.automaticallyChecksForUpdates; }
 -(BOOL)openLinksInVienna			{ return [Preferences standardPreferences].openLinksInVienna; }
 -(BOOL)openLinksInBackground		{ return [Preferences standardPreferences].openLinksInBackground; }
 -(NSInteger)minimumFontSize				{ return [Preferences standardPreferences].minimumFontSize; }
@@ -342,7 +342,7 @@
 -(void)setMarkReadInterval:(float)newInterval		{ [Preferences standardPreferences].markReadInterval = newInterval; }
 -(void)setRefreshOnStartup:(BOOL)flag				{ [Preferences standardPreferences].refreshOnStartup = flag; }
 -(void)setFilterMode:(NSInteger)newMode					{ [Preferences standardPreferences].filterMode = newMode; }
--(void)setCheckForNewOnStartup:(BOOL)flag			{ APPCONTROLLER.sparkleController.updater.automaticallyChecksForUpdates = flag; }
+-(void)setCheckForNewOnStartup:(BOOL)flag			{ ((AppController*)self.delegate).sparkleController.updater.automaticallyChecksForUpdates = flag; }
 -(void)setOpenLinksInVienna:(BOOL)flag				{ [Preferences standardPreferences].openLinksInVienna = flag; }
 -(void)setOpenLinksInBackground:(BOOL)flag			{ [Preferences standardPreferences].openLinksInBackground = flag; }
 -(void)setMinimumFontSize:(NSInteger)newSize				{ [Preferences standardPreferences].minimumFontSize = newSize; }

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -857,26 +857,21 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
  */
 -(void)markAllFoldersReadByArray:(NSArray *)folderArray
 {
-	NSArray * refArray = [self wrappedMarkAllFoldersReadInArray:folderArray];
-	if (refArray != nil && refArray.count > 0) {
-		NSUndoManager * undoManager = NSApp.mainWindow.undoManager;
-		[undoManager registerUndoWithTarget:self selector:@selector(markAllReadUndo:) object:refArray];
-		[undoManager setActionName:NSLocalizedString(@"Mark All Read", nil)];
-	}
-	
-	// Smart and Search folders are not included in folderArray when you mark all subscriptions read,
-	// so we need to mark articles read if they're the current folder or might be inside it.
-	Folder * currentFolder = [[Database sharedManager] folderFromID:currentFolderId];
-	if (currentFolder != nil &&
-		(currentFolder.type == VNAFolderTypeSmart || currentFolder.type == VNAFolderTypeGroup ||
-		 ![folderArray containsObject:currentFolder]))
-	{
-		for (Article *theArticle in folderArrayOfArticles) {
-			theArticle.read = YES;
-		}
-	}
-	
-	[mainArticleView refreshFolder:VNARefreshRedrawList];
+    NSArray * refArray = [self wrappedMarkAllFoldersReadInArray:folderArray];
+    if (refArray != nil && refArray.count > 0) {
+        NSUndoManager * undoManager = NSApp.mainWindow.undoManager;
+        [undoManager registerUndoWithTarget:self selector:@selector(markAllReadUndo:) object:refArray];
+        [undoManager setActionName:NSLocalizedString(@"Mark All Read", nil)];
+    }
+
+    // We need to refresh view if current folder is Group, Smart or Search folder
+    Folder * currentFolder = [[Database sharedManager] folderFromID:currentFolderId];
+    if (currentFolder != nil && !currentFolder.isRSSFolder && !currentFolder.isOpenReaderFolder) {
+        articleToPreserve = self.selectedArticle;
+        [self reloadArrayOfArticles];
+    } else {
+        [mainArticleView refreshFolder:VNARefreshRedrawList];
+    }
 }
 
 /* wrappedMarkAllFoldersReadInArray

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -102,6 +102,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 @property (nonatomic, getter=isSmartFolder, readonly) BOOL smartFolder;
 @property (nonatomic, getter=isRSSFolder, readonly) BOOL RSSFolder;
 @property (nonatomic, getter=isOpenReaderFolder, readonly) BOOL OpenReaderFolder;
+@property (nonatomic, getter=isSubscriptionFolder, readonly) BOOL subscriptionFolder;
 @property (nonatomic, readonly) BOOL loadsFullHTML;
 @property (nonatomic, getter=isUnsubscribed, readonly) BOOL unsubscribed;
 @property (nonatomic, getter=isUpdating, readonly) BOOL updating;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -383,6 +383,13 @@
     return self.type == VNAFolderTypeOpenReader;
 }
 
+/* isSubscriptionFolder
+ * Returns YES if this folder is a subscription folder.
+ */
+-(BOOL)isSubscriptionFolder {
+    return self.type == VNAFolderTypeRSS || self.type == VNAFolderTypeOpenReader;
+}
+
 // MARK: - VNAFolderFlag methods
 
 /* loadsFullHTML


### PR DESCRIPTION
A small demo script :

````AppleScript
tell application "Vienna"
	
	-- display the current article if any
	set myArticle to current article
	if myArticle is not missing value then
		display dialog title of myArticle & linefeed & summary of myArticle & linefeed & "(" & (name of myArticle's containing folder) & ")" as string
	end if
	
	
	-- pronounce the titles of last 3 unread articles from BBC News
	set myList to (articles of folder "BBC News" whose read is false)
	set myCount to count of myList
	repeat with i from myCount - 2 to myCount
		say (title of item i of myList as string) using "Daniel" -- British voice
		delay 1
	end repeat
	
	
	-- pronounce title of last article from lemonde.fr
	say (title of last article of folder "Le Monde.fr") as string using "Thomas" -- french voice
	
	
	-- add a subscription, backup the subscription list
	create new subscription for "https://blog.barijaona.com/shortened.xml" under folder "Blogs perso"
	export subscriptions from folder "Blogs perso" to "~/Desktop/test.opml"
	
end tell
````