### PR TITLE
Relax main view constraints on 'leading' attributes

### DIFF
--- a/Vienna/Interfaces/Base.lproj/MainWindowController.xib
+++ b/Vienna/Interfaces/Base.lproj/MainWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -207,8 +207,8 @@
                     </customView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="659-iz-w4S" firstAttribute="leading" secondItem="2" secondAttribute="leading" id="Odf-ud-2hZ"/>
-                    <constraint firstItem="993" firstAttribute="leading" secondItem="2" secondAttribute="leading" id="PHO-d8-qak"/>
+                    <constraint firstItem="659-iz-w4S" firstAttribute="leading" secondItem="2" secondAttribute="leading" priority="995" id="Odf-ud-2hZ"/>
+                    <constraint firstItem="993" firstAttribute="leading" secondItem="2" secondAttribute="leading" priority="995" id="PHO-d8-qak"/>
                     <constraint firstItem="659-iz-w4S" firstAttribute="top" secondItem="993" secondAttribute="bottom" id="RG4-2b-ToH"/>
                     <constraint firstAttribute="trailing" secondItem="659-iz-w4S" secondAttribute="trailing" id="RZ6-nX-HHh"/>
                     <constraint firstItem="993" firstAttribute="top" secondItem="2" secondAttribute="top" id="dyB-H2-9DB"/>
@@ -224,7 +224,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                             <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="only" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="pdk-MS-QME" id="xAh-aB-Ek3">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="menu"/>
+                                <font key="font" metaFont="message"/>
                                 <menu key="menu" id="tQg-b5-Yiu">
                                     <items>
                                         <menuItem state="on" image="NewFeedTemplate" hidden="YES" id="pdk-MS-QME">
@@ -361,7 +361,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                             <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="only" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" id="NJC-fy-OS8">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="menu"/>
+                                <font key="font" metaFont="message"/>
                                 <menu key="menu" id="Mx2-fn-A84">
                                     <items>
                                         <menuItem image="FunnelFilterTemplate" hidden="YES" id="yGM-WH-fbb">
@@ -433,7 +433,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                             <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="only" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" id="anL-VR-Fny">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="menu"/>
+                                <font key="font" metaFont="message"/>
                                 <menu key="menu" id="0bc-TU-NSg">
                                     <items>
                                         <menuItem state="on" image="NSActionTemplate" hidden="YES" id="A67-46-hiu">
@@ -504,7 +504,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                             <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="StyleTemplate" imagePosition="only" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="lu2-BZ-Gxd" id="5CR-Qn-4pP">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="menu"/>
+                                <font key="font" metaFont="message"/>
                                 <menu key="menu" identifier="StylesMenu" id="mit-Vi-iR1">
                                     <items>
                                         <menuItem state="on" image="StyleTemplate" hidden="YES" id="lu2-BZ-Gxd">

--- a/Vienna/Interfaces/BrowserTab.xib
+++ b/Vienna/Interfaces/BrowserTab.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -92,7 +92,7 @@
                                     <rect key="frame" x="806" y="0.0" width="30" height="20"/>
                                     <subviews>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oDE-XG-Zic">
-                                            <rect key="frame" x="0.0" y="0.0" width="30" height="21.5"/>
+                                            <rect key="frame" x="0.0" y="0.5" width="30" height="21.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="recessed" bezelStyle="recessed" image="NSStopProgressTemplate" imagePosition="only" alignment="center" state="on" imageScaling="proportionallyDown" inset="2" id="Qgx-sg-FMt">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
@@ -172,11 +172,6 @@
             <point key="canvasLocation" x="106.5" y="154"/>
         </customView>
     </objects>
-    <designables>
-        <designable name="t9A-Dp-YtC">
-            <size key="intrinsicContentSize" width="-1" height="4"/>
-        </designable>
-    </designables>
     <resources>
         <image name="NSGoBackTemplate" width="12" height="17"/>
         <image name="NSGoForwardTemplate" width="12" height="17"/>


### PR DESCRIPTION
When entering full screen, the folder panel would be the only one to widen.

Fix issue #1863