### PR TITLE
Improve handling and storage of font selection

### DIFF
--- a/Vienna/Resources/Vienna.sdef
+++ b/Vienna/Resources/Vienna.sdef
@@ -196,7 +196,7 @@
 				<cocoa key="version"/>
 			</property>
 			<property type="text" name="article list font" code="mlFt" description="The font used in the article list pane">
-				<cocoa key="articleListFont"/>
+				<cocoa key="articleListFontName"/>
 			</property>
 			<property type="integer" name="article list font size" code="mlFS" description="The size of the font used in the article list pane">
 				<cocoa key="articleListFontSize"/>

--- a/Vienna/Sources/Application/ViennaApp.h
+++ b/Vienna/Sources/Application/ViennaApp.h
@@ -79,7 +79,7 @@
 @property (nonatomic) BOOL enableMinimumFontSize;
 @property (nonatomic) NSInteger refreshFrequency;
 @property (nonatomic, copy) NSString *displayStyle;
-@property (nonatomic, copy) NSString *articleListFont;
+@property (nonatomic, copy) NSString *articleListFontName;
 @property (nonatomic) NSInteger articleListFontSize;
 @property (nonatomic) BOOL statusBarVisible;
 @property (nonatomic) BOOL filterBarVisible;

--- a/Vienna/Sources/Application/ViennaApp.m
+++ b/Vienna/Sources/Application/ViennaApp.m
@@ -378,16 +378,16 @@
     [defaults setInteger:feedListSizeMode forKey:MAPref_FeedListSizeMode];
 }
 
-- (NSString *)articleListFont
+- (NSString *)articleListFontName
 {
     return Preferences.standardPreferences.articleListFont.fontName;
 }
 
-- (void)setArticleListFont:(NSString *)articleListFont
+- (void)setArticleListFontName:(NSString *)articleListFontName
 {
     NSFont *font = Preferences.standardPreferences.articleListFont;
     font = [NSFontManager.sharedFontManager convertFont:font
-                                                 toFace:articleListFont];
+                                                 toFace:articleListFontName];
     Preferences.standardPreferences.articleListFont = font;
 }
 

--- a/Vienna/Sources/Application/ViennaApp.m
+++ b/Vienna/Sources/Application/ViennaApp.m
@@ -330,8 +330,6 @@
 -(BOOL)enableMinimumFontSize		{ return [Preferences standardPreferences].enableMinimumFontSize; }
 -(NSInteger)refreshFrequency				{ return [Preferences standardPreferences].refreshFrequency; }
 -(NSString *)displayStyle			{ return [Preferences standardPreferences].displayStyle; }
--(NSString *)articleListFont		{ return [Preferences standardPreferences].articleListFont; }
--(NSInteger)articleListFontSize			{ return [Preferences standardPreferences].articleListFontSize; }
 -(BOOL)statusBarVisible				{ return [Preferences standardPreferences].showStatusBar; }
 -(BOOL)filterBarVisible				{ return [Preferences standardPreferences].showFilterBar; }
 
@@ -349,11 +347,8 @@
 -(void)setEnableMinimumFontSize:(BOOL)flag			{ [Preferences standardPreferences].enableMinimumFontSize = flag; }
 -(void)setRefreshFrequency:(NSInteger)newFrequency		{ [Preferences standardPreferences].refreshFrequency = newFrequency; }
 -(void)setDisplayStyle:(NSString *)newStyle			{ [Preferences standardPreferences].displayStyle = [newStyle copy]; }
--(void)setArticleListFont:(NSString *)newFontName	{ [Preferences standardPreferences].articleListFont = [newFontName copy]; }
--(void)setArticleListFontSize:(NSInteger)newFontSize		{ [Preferences standardPreferences].articleListFontSize = newFontSize; }
 -(void)setStatusBarVisible:(BOOL)flag				{ [Preferences standardPreferences].showStatusBar = flag; }
 -(void)setFilterBarVisible:(BOOL)flag				{ [Preferences standardPreferences].showFilterBar = flag; }
-
 
 - (VNAFeedListSizeMode)feedListSizeMode
 {
@@ -381,6 +376,32 @@
     }
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
     [defaults setInteger:feedListSizeMode forKey:MAPref_FeedListSizeMode];
+}
+
+- (NSString *)articleListFont
+{
+    return Preferences.standardPreferences.articleListFont.fontName;
+}
+
+- (void)setArticleListFont:(NSString *)articleListFont
+{
+    NSFont *font = Preferences.standardPreferences.articleListFont;
+    font = [NSFontManager.sharedFontManager convertFont:font
+                                                 toFace:articleListFont];
+    Preferences.standardPreferences.articleListFont = font;
+}
+
+- (NSInteger)articleListFontSize
+{
+    return Preferences.standardPreferences.articleListFont.pointSize;
+}
+
+- (void)setArticleListFontSize:(NSInteger)articleListFontSize
+{
+    NSFont *font = Preferences.standardPreferences.articleListFont;
+    font = [NSFontManager.sharedFontManager convertFont:font
+                                                 toSize:articleListFontSize];
+    Preferences.standardPreferences.articleListFont = font;
 }
 
 // MARK: Obsolete accessors

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -540,7 +540,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 
 	Preferences * prefs = [Preferences standardPreferences];
-	articleListFont = [NSFont fontWithName:prefs.articleListFont size:prefs.articleListFontSize];
+	articleListFont = prefs.articleListFont;
 	articleListUnreadFont = [prefs boolForKey:MAPref_ShowUnreadArticlesInBold] ? [[NSFontManager sharedFontManager] convertWeight:YES ofFont:articleListFont] : articleListFont;
 
 	reportCellDict[NSFontAttributeName] = articleListFont;

--- a/Vienna/Sources/Preferences window/AppearancePreferencesViewController.h
+++ b/Vienna/Sources/Preferences window/AppearancePreferencesViewController.h
@@ -20,7 +20,7 @@
 
 @import Cocoa;
 
-@interface AppearancePreferencesViewController : NSViewController
+@interface AppearancePreferencesViewController : NSViewController <NSFontChanging>
 
 // Action functions
 -(IBAction)selectArticleFont:(id)sender;

--- a/Vienna/Sources/Preferences window/AppearancePreferencesViewController.m
+++ b/Vienna/Sources/Preferences window/AppearancePreferencesViewController.m
@@ -31,7 +31,6 @@ static NSInteger const availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24
 
 @interface AppearancePreferencesViewController ()
 -(void)initializePreferences;
--(void)selectUserDefaultFont:(NSString *)name size:(NSInteger)size control:(NSTextField *)control;
 
 @end
 
@@ -72,7 +71,7 @@ static NSInteger const availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24
     Preferences * prefs = [Preferences standardPreferences];
     
     // Populate the drop downs with the font names and sizes
-    [self selectUserDefaultFont:prefs.articleListFont size:prefs.articleListFontSize control:articleFontSample];
+    [self displaySelectedFont:prefs.articleListFont inTextField:articleFontSample];
 
     // Show folder images option
     showFolderImagesButton.state = prefs.showFolderImages ? NSControlStateValueOn : NSControlStateValueOff;
@@ -117,13 +116,13 @@ static NSInteger const availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24
     [Preferences standardPreferences].minimumFontSize = newMinimumFontSize;
 }
 
-/* selectUserDefaultFont
- * Display sample text in the specified font and size.
- */
--(void)selectUserDefaultFont:(NSString *)name size:(NSInteger)size control:(NSTextField *)control
+// Display sample text in the specified font and size.
+- (void)displaySelectedFont:(NSFont *)font inTextField:(NSTextField *)textField
 {
-    control.font = [NSFont fontWithName:name size:size];
-    control.stringValue = [NSString stringWithFormat:@"%@ %li", name, (long)size];
+    textField.font = font;
+    textField.stringValue = [NSString stringWithFormat:@"%@ %.0f",
+                                                       font.displayName,
+                                                       font.pointSize];
 }
 
 /* selectArticleFont
@@ -137,7 +136,7 @@ static NSInteger const availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24
     fontManager.action = @selector(changeArticleFont:);
 
     NSFontPanel *fontPanel = [fontManager fontPanel:YES];
-    [fontPanel setPanelFont:[NSFont fontWithName:prefs.articleListFont size:prefs.articleListFontSize] isMultiple:NO];
+    [fontPanel setPanelFont:prefs.articleListFont isMultiple:NO];
     [fontPanel orderFront:self];
     fontPanel.enabled = YES;
 }
@@ -148,11 +147,10 @@ static NSInteger const availableMinimumFontSizes[] = { 9, 10, 11, 12, 14, 18, 24
 -(IBAction)changeArticleFont:(id)sender
 {
     Preferences * prefs = [Preferences standardPreferences];
-    NSFont * font = [NSFont fontWithName:prefs.articleListFont size:prefs.articleListFontSize];
+    NSFont *font = prefs.articleListFont;
     font = [sender convertFont:font];
-    prefs.articleListFont = font.fontName;
-    prefs.articleListFontSize = font.pointSize;
-    [self selectUserDefaultFont:prefs.articleListFont size:prefs.articleListFontSize control:articleFontSample];
+    prefs.articleListFont = font;
+    [self displaySelectedFont:font inTextField:articleFontSample];
 }
 
 /* dealloc

--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -94,8 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat textSizeMultiplier;
 
 // Article list font
-@property (nonatomic, copy) NSString *articleListFont;
-@property (nonatomic) NSInteger articleListFontSize;
+@property (nonatomic) NSFont *articleListFont;
 
 // Article list sort descriptors
 @property (null_resettable, nonatomic, copy) NSArray *articleSortDescriptors;


### PR DESCRIPTION
This is in response to #1882.

I added a safeguard to make sure that Vienna won't return an invalid font that stored in user defaults. I also changed the way the font is stored by storing/retrieving the NSFont directly rather than a recreation of the font based on font name and size.