### PR TITLE
Fix "open with" menu in download window

### DIFF
--- a/Vienna/Sources/Download window/NSWorkspace+OpenWithMenu.m
+++ b/Vienna/Sources/Download window/NSWorkspace+OpenWithMenu.m
@@ -168,8 +168,8 @@
     }
     
     if (@available(macOS 10.15, *)) {
-        NSURL *appURL = [NSURL URLWithString:appPath];
-        NSURL *fileURL = [NSURL URLWithString:filePath];
+        NSURL *appURL = [NSURL fileURLWithPath:appPath];
+        NSURL *fileURL = [NSURL fileURLWithPath:filePath];
         if (!appURL || !fileURL) {
             return;
         }


### PR DESCRIPTION
I noticed that the "open with" menu does not work. I am pretty sure that this worked when I committed ae81eed33bb19f44e267fdafcca1fea627b06cf8.