### PR TITLE
Remove localisable keys for URLs/hostnames from many plug-ins

### DIFF
--- a/Vienna/SharedSupport/Plugins/BazQuxSyncServer.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/BazQuxSyncServer.viennaplugin/en.lproj/InfoPlist.strings
@@ -1,6 +1,3 @@
-/* The host name (domain) of the sync server. You can change the domain to use a version of the website that matches the language. */
-"Address" = "www.bazqux.com";
-
 /* The name of sync server. */
 "FriendlyName" = "BazQux";
 

--- a/Vienna/SharedSupport/Plugins/BloggerFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/BloggerFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter Blogspot user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "http://%@.blogspot.com/atom.xml";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "http://www.blogspot.com";

--- a/Vienna/SharedSupport/Plugins/FeedHQSyncServer.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/FeedHQSyncServer.viennaplugin/en.lproj/InfoPlist.strings
@@ -1,6 +1,3 @@
-/* The host name (domain) of the sync server. You can change the domain to use a version of the website that matches the language. */
-"Address" = "feedhq.org";
-
 /* The name of sync server. */
 "FriendlyName" = "FeedHQ";
 

--- a/Vienna/SharedSupport/Plugins/HatenaBlogFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/HatenaBlogFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter Hatena Blog user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://%@.hatenablog.com/feed";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "https://hatenablog.com";

--- a/Vienna/SharedSupport/Plugins/InoReaderSyncServer.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/InoReaderSyncServer.viennaplugin/en.lproj/InfoPlist.strings
@@ -1,6 +1,3 @@
-/* The host name (domain) of the sync server. You can change the domain to use a version of the website that matches the language. */
-"Address" = "www.inoreader.com";
-
 /* The name of sync server. */
 "FriendlyName" = "InoReader";
 

--- a/Vienna/SharedSupport/Plugins/LiveJournalFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/LiveJournalFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter LiveJournal user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://www.livejournal.com/users/%@/data/rss";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "https://www.livejournal.com";

--- a/Vienna/SharedSupport/Plugins/LogdownFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/LogdownFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter Logdown user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://%@.logdown.com/posts.atom";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "https://logdown.com";

--- a/Vienna/SharedSupport/Plugins/PChomeFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/PChomeFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter PChome user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://mypaper.pchome.com.tw/%@/rss";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "https://mypaper.pchome.com.tw";

--- a/Vienna/SharedSupport/Plugins/PixnetFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/PixnetFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter Pixnet user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://feed.pixnet.net/blog/posts/atom/%@";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "https://www.pixnet.net/blog";

--- a/Vienna/SharedSupport/Plugins/ShareWithBuffer.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithBuffer.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Add the current article to Buffer";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "http://bufferapp.com/add?url=$ArticleLink$&text=$ArticleTitle$&source=vienna";

--- a/Vienna/SharedSupport/Plugins/ShareWithEvernote.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithEvernote.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Share the current article on Evernote";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "http://www.evernote.com/clip.action?url=$ArticleLink$&title=$ArticleTitle$";

--- a/Vienna/SharedSupport/Plugins/ShareWithGoogleCurrents.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithGoogleCurrents.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Share the current article on Google Currents";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://currents.google.com/share?url=$ArticleLink$";

--- a/Vienna/SharedSupport/Plugins/ShareWithHootsuite.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithHootsuite.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Share the current article on Hootsuite";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://hootsuite.com/hootlet/load?address=$ArticleLink$&title=$ArticleTitle$";

--- a/Vienna/SharedSupport/Plugins/ShareWithInstapaper.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithInstapaper.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Add the current article to Instapaper";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://www.instapaper.com/hello2?url=$ArticleLink$&title=$ArticleTitle$";

--- a/Vienna/SharedSupport/Plugins/ShareWithPinboard.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithPinboard.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Share the current article on Pinboard";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://pinboard.in/add?showtags=yes&url=$ArticleLink$&description=&title=$ArticleTitle$";

--- a/Vienna/SharedSupport/Plugins/ShareWithPocket.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithPocket.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Add the current article to Pocket";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://getpocket.com/edit?url=$ArticleLink$&amp;title=$ArticleTitle$";

--- a/Vienna/SharedSupport/Plugins/ShareWithTwitter.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithTwitter.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Share the current article on twitter";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://twitter.com/intent/tweet?url=$ArticleLink$";

--- a/Vienna/SharedSupport/Plugins/ShareWithWallabag.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ShareWithWallabag.viennaplugin/en.lproj/InfoPlist.strings
@@ -6,6 +6,3 @@
 
 /* The tool tip for the plug-in in toolbar items. */
 "Tooltip" = "Add the current article to wallabag.it";
-
-/* The URL that will be opened when the plug-in is invoked. You can change the domain or parts of the URL query to use a version of the website that matches the language. The tokens "$ArticleLink$" and "$ArticleTitle$" must be kept and must not be translated. */
-"URL" = "https://app.wallabag.it/bookmarklet?url=$ArticleLink$";

--- a/Vienna/SharedSupport/Plugins/TheOldReaderSyncServer.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/TheOldReaderSyncServer.viennaplugin/en.lproj/InfoPlist.strings
@@ -1,6 +1,3 @@
-/* The host name (domain) of the sync server. You can change the domain to use a version of the website that matches the language. */
-"Address" = "theoldreader.com";
-
 /* The name of sync server. */
 "FriendlyName" = "The Old Reader";
 

--- a/Vienna/SharedSupport/Plugins/WordpressFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/WordpressFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -4,8 +4,5 @@
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter Wordpress user name";
 
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://%@.wordpress.com/feed/";
-
 /* The home page of the feed source. */
 "SiteHomePage" = "https://wordpress.com";

--- a/Vienna/SharedSupport/Plugins/ZiMediaFeedSource.viennaplugin/en.lproj/InfoPlist.strings
+++ b/Vienna/SharedSupport/Plugins/ZiMediaFeedSource.viennaplugin/en.lproj/InfoPlist.strings
@@ -3,9 +3,3 @@
 
 /* An instruction for the user. This will be shown above a text field. */
 "LinkName" = "Enter ZiMedia user name";
-
-/* The feed or web-page URL that will be used to add or discover a feed. You can change the domain or parts of the URL query to use a version of the website that matches the language. */
-"LinkTemplate" = "https://zi.media/rss/authors/%@";
-
-/* The home page of the feed source. */
-"SiteHomePage" = "https://zi.media/";


### PR DESCRIPTION
These services do not seem to have localised versions. This reduces the number of localisable keys.