### PR TITLE
Improve MA_Notify_ArticleListContentChange handling

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -899,9 +899,8 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         dispatch_async(dispatch_get_main_queue(), ^{
             connectorItem.status = logText;
         });
-        [[NSNotificationCenter defaultCenter] vna_postNotificationOnMainThreadWithName:MA_Notify_ArticleListContentChange object:@(folder.
-                                                                                                                                  itemId)];
     }
+    [[NSNotificationCenter defaultCenter] vna_postNotificationOnMainThreadWithName:MA_Notify_ArticleListContentChange object:@(folder.itemId)];
 
     // Done with this connection
 


### PR DESCRIPTION
When "Mark updated articles as new" setting is enabled, articles may have their statuses change from "unread" to "unread and revised". So an update might be necessary, even if count of new articles itself does not reveal any change.

Follow-up to commit 86a349a