### PR TITLE
Implement UNUserNotifications framework for macOS 10.14+

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -192,6 +192,10 @@
 		F69140E41E71B94200D51BFF /* AppController+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = F69140E31E71B94200D51BFF /* AppController+Notifications.m */; };
 		F692559A2572A32900D387D8 /* MMTabBarView in Frameworks */ = {isa = PBXBuildFile; productRef = F69255992572A32900D387D8 /* MMTabBarView */; };
 		F696D23E2561F9FC003DF0C0 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = F696D23D2561F9FC003DF0C0 /* Sparkle */; };
+		F69743E92ADAC497006C5BBC /* UserNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69743E82ADAC497006C5BBC /* UserNotificationCenter.swift */; };
+		F69743EB2ADAC49D006C5BBC /* UserNotificationCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69743EA2ADAC49D006C5BBC /* UserNotificationCenterDelegate.swift */; };
+		F69743ED2ADAC4A2006C5BBC /* UserNotificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69743EC2ADAC4A2006C5BBC /* UserNotificationRequest.swift */; };
+		F69743EF2ADAC4A7006C5BBC /* UserNotificationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69743EE2ADAC4A7006C5BBC /* UserNotificationResponse.swift */; };
 		F69964F71F13029600FC8493 /* OverlayStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69964F61F13029500FC8493 /* OverlayStatusBar.swift */; };
 		F69EA3962DAC3B7800A97F71 /* DownloadListCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = F69EA3952DAC3B7800A97F71 /* DownloadListCellView.m */; };
 		F6A179D326B82BE3008DDA42 /* NSFileManagerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A179D226B82BE3008DDA42 /* NSFileManagerExtensionTests.swift */; };
@@ -538,6 +542,10 @@
 		F69140E31E71B94200D51BFF /* AppController+Notifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AppController+Notifications.m"; sourceTree = "<group>"; };
 		F695E9E1283CF02D00320578 /* FeedListConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FeedListConstants.h; sourceTree = "<group>"; };
 		F695E9E2283D0C8100320578 /* FolderViewDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FolderViewDelegate.h; sourceTree = "<group>"; };
+		F69743E82ADAC497006C5BBC /* UserNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCenter.swift; sourceTree = "<group>"; };
+		F69743EA2ADAC49D006C5BBC /* UserNotificationCenterDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCenterDelegate.swift; sourceTree = "<group>"; };
+		F69743EC2ADAC4A2006C5BBC /* UserNotificationRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationRequest.swift; sourceTree = "<group>"; };
+		F69743EE2ADAC4A7006C5BBC /* UserNotificationResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationResponse.swift; sourceTree = "<group>"; };
 		F698E6FF29E9D1CA00D49475 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Predicates.strings; sourceTree = "<group>"; };
 		F69964F61F13029500FC8493 /* OverlayStatusBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverlayStatusBar.swift; sourceTree = "<group>"; };
 		F69EA3942DAC3B7800A97F71 /* DownloadListCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DownloadListCellView.h; sourceTree = "<group>"; };
@@ -973,6 +981,17 @@
 			name = "Smart folder";
 			sourceTree = "<group>";
 		};
+		F69743D72ADAC473006C5BBC /* UserNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				F69743E82ADAC497006C5BBC /* UserNotificationCenter.swift */,
+				F69743EA2ADAC49D006C5BBC /* UserNotificationCenterDelegate.swift */,
+				F69743EC2ADAC4A2006C5BBC /* UserNotificationRequest.swift */,
+				F69743EE2ADAC4A7006C5BBC /* UserNotificationResponse.swift */,
+			);
+			path = UserNotifications;
+			sourceTree = "<group>";
+		};
 		F6A7DDCB1E470E980017BE5E /* Vienna Help */ = {
 			isa = PBXGroup;
 			children = (
@@ -1138,6 +1157,7 @@
 				F6D7FEDB1F1CDF41004F095A /* Info panel */,
 				F6D7FEDC1F1CDF49004F095A /* Activity panel */,
 				F6D7FEDD1F1CDFCD004F095A /* Download window */,
+				F69743D72ADAC473006C5BBC /* UserNotifications */,
 				F6D7FEDE1F1CE135004F095A /* Alerts */,
 				F6D7FEDF1F1CE13F004F095A /* Fetching */,
 				F6D7FEE01F1CE147004F095A /* Parsing */,
@@ -1821,6 +1841,7 @@
 				2F88FF412969B2A40076B99E /* DatePredicateWithUnit.swift in Sources */,
 				43502896165DE9E00018EDB7 /* ActivityPanelController.m in Sources */,
 				0378753125E34743009AB1C9 /* FeedListCellView.m in Sources */,
+				F69743EF2ADAC4A7006C5BBC /* UserNotificationResponse.swift in Sources */,
 				2FE44CAD25B7995400554E82 /* NSApplication+AppController.swift in Sources */,
 				F6CE47131E7E3DCB0045EAD7 /* ActivityItem.m in Sources */,
 				43502897165DE9E00018EDB7 /* AppController.m in Sources */,
@@ -1831,9 +1852,11 @@
 				F67E7828285DDAB200D1CECE /* Toolbar.swift in Sources */,
 				2FE44CB525B79EDE00554E82 /* WebKitContextMenuCustomizer.swift in Sources */,
 				F61CEA661F039E57009C878E /* ButtonToolbarItem.swift in Sources */,
+				F69743EB2ADAC49D006C5BBC /* UserNotificationCenterDelegate.swift in Sources */,
 				F6B059E42961D0DD00F6E31B /* JSONFeedParser.swift in Sources */,
 				F68792872700A678009B7BB5 /* SecurityScopedBookmark.swift in Sources */,
 				F6094E331F10107800677D3B /* ExportAccessoryViewController.swift in Sources */,
+				F69743ED2ADAC4A2006C5BBC /* UserNotificationRequest.swift in Sources */,
 				2FCD69302260B3E7005BAA75 /* CustomWKWebView.swift in Sources */,
 				F6A464BC272F47BE0071E3F6 /* NSKeyedUnarchiver+Compatibility.m in Sources */,
 				2FDF6FC0218A266A002F77E9 /* BrowserTab.swift in Sources */,
@@ -1902,6 +1925,7 @@
 				F69140E41E71B94200D51BFF /* AppController+Notifications.m in Sources */,
 				3A4DBEC71733C207006DD2AB /* ArticleCellView.m in Sources */,
 				F6A464BD272F47BE0071E3F6 /* NSKeyedArchiver+Compatibility.m in Sources */,
+				F69743E92ADAC497006C5BBC /* UserNotificationCenter.swift in Sources */,
 				37C650801816EBAD3C0D9DBF /* NSURL+CaminoExtensions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Vienna/Sources/Application/AppController+Notifications.m
+++ b/Vienna/Sources/Application/AppController+Notifications.m
@@ -21,7 +21,6 @@
 
 #import "Database.h"
 #import "Folder.h"
-#import "Vienna-Swift.h"
 
 @implementation AppController (Notifications)
 
@@ -36,9 +35,10 @@ NSString *const UserNotificationContextFileDownloadFailed = @"User Notification 
 
 // MARK: Delegate methods
 
-- (void)userNotificationCenter:(NSUserNotificationCenter *)center
-       didActivateNotification:(NSUserNotification *)notification {
-    NSDictionary<NSString *, NSString *> *userInfo = notification.userInfo;
+- (void)userNotificationCenter:(VNAUserNotificationCenter *)center
+            didReceiveResponse:(VNAUserNotificationResponse *)response
+{
+    NSDictionary<NSString *, NSString *> *userInfo = response.userInfo;
     if ([userInfo[UserNotificationContextKey] isEqual:UserNotificationContextFetchCompleted]) {
         [self openWindowAndShowUnreadArticles];
     } else if ([userInfo[UserNotificationContextKey] isEqual:UserNotificationContextFileDownloadCompleted]) {
@@ -76,7 +76,7 @@ NSString *const UserNotificationContextFileDownloadFailed = @"User Notification 
  */
 - (void)showFileInFinderAtPath:(NSString *)filePath {
     [[NSWorkspace sharedWorkspace] selectFile:filePath
-                     inFileViewerRootedAtPath:@""];
+                     inFileViewerRootedAtPath:[filePath stringByDeletingLastPathComponent]];
 }
 
 @end

--- a/Vienna/Sources/Download window/DownloadManager.m
+++ b/Vienna/Sources/Download window/DownloadManager.m
@@ -29,6 +29,8 @@
 #import "Preferences.h"
 #import "Vienna-Swift.h"
 
+static NSString * const VNAUserNotificationFileDownloadThreadIdentifier = @"FileDownloadThreadIdentifier";
+
 @interface DownloadManager ()
 
 // Private properties
@@ -311,6 +313,9 @@
             VNAUserNotificationRequest *request =
                 [[VNAUserNotificationRequest alloc] initWithIdentifier:item.fileURL.absoluteString
                                                                  title:title];
+            // Use a thread identifier to group all file download notifications
+            // (this can be disabled by the user in System Settings).
+            request.threadIdentifier = VNAUserNotificationFileDownloadThreadIdentifier;
             request.body = body;
             request.playSound = settings.isSoundEnabled;
             request.userInfo = userInfo;

--- a/Vienna/Sources/Download window/DownloadManager.m
+++ b/Vienna/Sources/Download window/DownloadManager.m
@@ -275,26 +275,60 @@
     [self notifyDownloadItemChange:item];
     [self archiveDownloadsList];
 
-    NSString *fileName = item.filename.lastPathComponent;
-
-    NSUserNotification *notification = [NSUserNotification new];
-    notification.soundName = NSUserNotificationDefaultSoundName;
+    NSString *filename = item.filename.lastPathComponent;
 
     if (item.state == DownloadStateCompleted) {
-        notification.title = NSLocalizedString(@"Download completed", @"Notification title");
-        notification.informativeText = [NSString stringWithFormat:NSLocalizedString(@"File %@ downloaded", @"Notification body"), fileName];
-        notification.userInfo = @{UserNotificationContextKey: UserNotificationContextFileDownloadCompleted,
-                                  UserNotificationFilePathKey: fileName};
-
-        [NSNotificationCenter.defaultCenter postNotificationName:MA_Notify_DownloadCompleted object:fileName];
-    } else if (item.state == DownloadStateFailed) {
-        notification.title = NSLocalizedString(@"Download failed", @"Notification title");
-        notification.informativeText = [NSString stringWithFormat:NSLocalizedString(@"File %@ failed to download", @"Notification body"), fileName];
-        notification.userInfo = @{UserNotificationContextKey: UserNotificationContextFileDownloadFailed,
-                                  UserNotificationFilePathKey: fileName};
+        [NSNotificationCenter.defaultCenter postNotificationName:MA_Notify_DownloadCompleted
+                                                          object:filename];
     }
 
-    [NSUserNotificationCenter.defaultUserNotificationCenter deliverNotification:notification];
+    VNAUserNotificationCenter *center = VNAUserNotificationCenter.current;
+    [center getNotificationSettingsWithCompletionHandler:^(VNAUserNotificationSettings *settings) {
+        VNAUserNotificationAuthorizationStatus status = settings.authorizationStatus;
+        if (status == VNAUserNotificationAuthorizationStatusDenied) {
+            return;
+        }
+
+        void (^deliverNotification)(void) = ^{
+            NSString *title;
+            NSString *body;
+            NSDictionary<NSString *, id> *userInfo;
+            if (item.state == DownloadStateCompleted) {
+                title = NSLocalizedString(@"Download completed", @"Notification title");
+                body = [NSString stringWithFormat:NSLocalizedString(@"File %@ downloaded", @"Notification body"), filename];
+                userInfo = @{
+                    UserNotificationContextKey: UserNotificationContextFileDownloadCompleted,
+                    UserNotificationFilePathKey: item.fileURL.path
+                };
+            } else if (item.state == DownloadStateFailed) {
+                title = NSLocalizedString(@"Download failed", @"Notification title");
+                body = [NSString stringWithFormat:NSLocalizedString(@"File %@ failed to download", @"Notification body"), filename];
+                userInfo = @{
+                    UserNotificationContextKey: UserNotificationContextFileDownloadFailed,
+                    UserNotificationFilePathKey: item.fileURL.path
+                };
+            }
+            VNAUserNotificationRequest *request =
+                [[VNAUserNotificationRequest alloc] initWithIdentifier:item.fileURL.absoluteString
+                                                                 title:title];
+            request.body = body;
+            request.playSound = settings.isSoundEnabled;
+            request.userInfo = userInfo;
+            [center addNotificationRequest:request
+                     withCompletionHandler:nil];
+        };
+
+        if (status == VNAUserNotificationAuthorizationStatusProvisional ||
+            status == VNAUserNotificationAuthorizationStatusAuthorized) {
+            deliverNotification();
+        } else if (status == VNAUserNotificationAuthorizationStatusNotDetermined) {
+            [center requestAuthorizationWithCompletionHandler:^(BOOL granted) {
+                if (granted) {
+                    deliverNotification();
+                }
+            }];
+        }
+    }];
 }
 
 // MARK: - NSURLSessionDownloadDelegate

--- a/Vienna/Sources/Download window/DownloadWindow.m
+++ b/Vienna/Sources/Download window/DownloadWindow.m
@@ -27,6 +27,7 @@
 #import "DownloadManager.h"
 #import "HelperFunctions.h"
 #import "NSWorkspace+OpenWithMenu.h"
+#import "Vienna-Swift.h"
 
 @implementation DownloadWindow {
     IBOutlet NSWindow *downloadWindow;
@@ -116,15 +117,18 @@
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
 	// Clear relevant notifications when the user views this window.
-	NSUserNotificationCenter *center = NSUserNotificationCenter.defaultUserNotificationCenter;
-	[center.deliveredNotifications enumerateObjectsUsingBlock:^(NSUserNotification *notification, NSUInteger idx, BOOL *stop) {
-		BOOL completed = [notification.userInfo[UserNotificationContextKey] isEqualToString:UserNotificationContextFileDownloadCompleted];
-		BOOL failed = [notification.userInfo[UserNotificationContextKey] isEqualToString:UserNotificationContextFileDownloadFailed];
-
-		if (completed || failed) {
-			[center removeDeliveredNotification: notification];
-		}
-	}];
+    VNAUserNotificationCenter *center = VNAUserNotificationCenter.current;
+    [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<VNAUserNotificationResponse *> *responses) {
+        NSMutableArray *identifiers = [NSMutableArray array];
+        for (VNAUserNotificationResponse *response in responses) {
+            NSString *context = response.userInfo[UserNotificationContextKey];
+            if ([context isEqualToString:UserNotificationContextFileDownloadCompleted] ||
+                [context isEqualToString:UserNotificationContextFileDownloadFailed]) {
+                [identifiers addObject:response.identifier];
+            }
+        }
+        [center removeDeliveredNotificationsWithIdentifiers:identifiers];
+    }];
 }
 
 /* clearList

--- a/Vienna/Sources/UserNotifications/UserNotificationCenter.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationCenter.swift
@@ -1,0 +1,334 @@
+//
+//  UserNotificationCenter.swift
+//  Vienna
+//
+//  Copyright 2023-2025 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import UserNotifications
+import os.log
+
+@objc(VNAUserNotificationCenter)
+class UserNotificationCenter: NSObject {
+
+    @objc static let current = UserNotificationCenter()
+
+    // MARK: Registering notifications
+
+    @objc(VNAUserNotificationAuthorizationStatus)
+    enum AuthorizationStatus: Int {
+        case notDetermined
+        case provisional
+        case authorized
+        case denied
+    }
+
+    @objc(VNAUserNotificationSettings)
+    class UserNotificationSettings: NSObject {
+        @objc let authorizationStatus: AuthorizationStatus
+
+        @objc(isSoundEnabled)
+        let soundEnabled: Bool
+
+        init(authorizationStatus: AuthorizationStatus, soundEnabled: Bool) {
+            self.authorizationStatus = authorizationStatus
+            self.soundEnabled = soundEnabled
+        }
+    }
+
+    /// Retrieves the authorization status.
+    ///
+    /// - Parameter completionHandler: The block to execute asynchronously with
+    ///     the results. It may be executed on a background thread.
+    @objc(getNotificationSettingsWithCompletionHandler:)
+    func getNotificationSettings(
+        completionHandler: @escaping (_ settings: UserNotificationSettings) -> Void
+    ) {
+        guard #available(macOS 10.14, *) else {
+            // NSNotificationCenter has no mechanism to query authorization.
+            let notificationSettings = UserNotificationSettings(
+                authorizationStatus: .authorized,
+                soundEnabled: true
+            )
+            completionHandler(notificationSettings)
+            return
+        }
+
+        UNUserNotificationCenter.current().getNotificationSettings { authorizationSettings in
+            let authorizationStatus: AuthorizationStatus
+            switch authorizationSettings.authorizationStatus {
+            case .notDetermined:
+                authorizationStatus = .notDetermined
+            case .provisional:
+                authorizationStatus = .provisional
+            case .authorized:
+                authorizationStatus = .authorized
+            case .denied:
+                authorizationStatus = .denied
+            @unknown default:
+                authorizationStatus = .denied
+                os_log(
+                    "User notification center did ignore unknown authorization status: %@",
+                    log: .userNotificationCenter,
+                    type: .debug,
+                    String(reflecting: authorizationSettings.authorizationStatus)
+                )
+            }
+            let notificationSettings = UserNotificationSettings(
+                authorizationStatus: authorizationStatus,
+                soundEnabled: authorizationSettings.soundSetting == .enabled
+            )
+            completionHandler(notificationSettings)
+        }
+    }
+
+    /// Requests the user's authorization to allow notifications.
+    ///
+    /// - Parameter completionHandler: The block to execute asynchronously with
+    ///     the authorization status. It may be executed on a background thread.
+    /// - Note: Currently only authorization for sounds and alerts as well as
+    ///     provisional notifications and badges are requested.
+    @objc(requestAuthorizationWithCompletionHandler:)
+    func requestAuthorization(completionHandler: @escaping (_ granted: Bool) -> Void) {
+        guard #available(macOS 10.14, *) else {
+            // NSNotificationCenter has no mechanism to request authorization.
+            completionHandler(true)
+            return
+        }
+
+        let center = UNUserNotificationCenter.current()
+        // Provisional notifications and badges should always be requested.
+        // Although Vienna uses NSDockTile to set the badge count instead of
+        // the UNNotificationContent.badge property, the authorization is still
+        // needed to show the badge setting in System Settings.
+        let authorizationOptions: UNAuthorizationOptions = [.badge, .sound, .alert, .provisional]
+        center.requestAuthorization(options: authorizationOptions) { granted, error in
+            if let error {
+                os_log(
+                    "User notification center authorization request failed with error: %{public}@",
+                    log: .userNotificationCenter,
+                    type: .debug,
+                    error.localizedDescription
+                )
+            }
+            // `granted` is true when any options were granted; false when all
+            // options were denied.
+            completionHandler(granted)
+        }
+    }
+
+    // MARK: Handling notifications
+
+    @objc(addNotificationRequest:withCompletionHandler:)
+    func add(
+        _ request: UserNotificationRequest,
+        withCompletionHandler completionHandler: ((_ error: (any Error)?) -> Void)? = nil
+    ) {
+        guard #available(macOS 10.14, *) else {
+            let center = NSUserNotificationCenter.default
+            center.add(request, withCompletionHandler: completionHandler)
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = request.title
+        if let subtitle = request.subtitle {
+            content.subtitle = subtitle
+        }
+        if let body = request.body {
+            content.body = body
+        }
+        if let userInfo = request.userInfo {
+            content.userInfo = userInfo
+        }
+        content.sound = request.playSound ? .default : nil
+        let notificationRequest = UNNotificationRequest(
+            identifier: request.identifier,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(notificationRequest) { completionHandler?($0) }
+    }
+
+    @objc
+    func getDeliveredNotifications(
+        completionHandler: @escaping (_ notifications: [UserNotificationResponse]) -> Void
+    ) {
+        guard #available(macOS 10.14, *) else {
+            let center = NSUserNotificationCenter.default
+            center.getDeliveredNotifications(completionHandler: completionHandler)
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { notifications in
+            let notifications = notifications.map { notification in
+                let request = notification.request
+                return UserNotificationResponse(
+                    identifier: request.identifier,
+                    userInfo: request.content.userInfo
+                )
+            }
+            completionHandler(notifications)
+        }
+    }
+
+    @objc
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+        guard #available(macOS 10.14, *) else {
+            let center = NSUserNotificationCenter.default
+            center.removeDeliveredNotifications(withIdentifiers: identifiers)
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        center.removeDeliveredNotifications(withIdentifiers: identifiers)
+    }
+
+    // MARK: Delegate
+
+    @objc weak var delegate: (any UserNotificationCenterDelegate)? {
+        didSet {
+            if #available(macOS 10.14, *) {
+                UNUserNotificationCenter.current().delegate = self
+            } else {
+                NSUserNotificationCenter.default.delegate = self
+            }
+        }
+    }
+
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+@available(macOS 10.14, *)
+extension UserNotificationCenter: UNUserNotificationCenterDelegate {
+
+    // Sent when the user responded to a notification.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        defer {
+            completionHandler()
+        }
+        guard let delegate else {
+            return
+        }
+        let request = response.notification.request
+        let identifier = request.identifier
+        let userInfo = request.content.userInfo as? [String: AnyHashable]
+        let response = UserNotificationResponse(
+            identifier: identifier,
+            userInfo: userInfo
+        )
+        delegate.userNotificationCenter(self, didReceive: response)
+    }
+
+}
+
+// MARK: - NSUserNotificationCenterDelegate (deprecated)
+
+@available(macOS, deprecated: 10.14)
+extension UserNotificationCenter: NSUserNotificationCenterDelegate {
+
+    // Sent when the user responded to a notification.
+    func userNotificationCenter(
+        _ center: NSUserNotificationCenter,
+        didActivate notification: NSUserNotification
+    ) {
+        guard let delegate else {
+            return
+        }
+        guard let identifier = notification.identifier else {
+            os_log(
+                "User notification center did activate unhandled notification: %@",
+                log: .userNotificationCenter,
+                type: .debug,
+                notification
+            )
+            return
+        }
+        let response = UserNotificationResponse(
+            identifier: identifier,
+            userInfo: notification.userInfo
+        )
+        delegate.userNotificationCenter(self, didReceive: response)
+    }
+
+}
+
+// MARK: - NSUserNotificationCenter (deprecated)
+
+@available(macOS, deprecated: 10.14)
+extension NSUserNotificationCenter {
+
+    fileprivate func add(
+        _ request: UserNotificationRequest,
+        withCompletionHandler completionHandler: ((_ error: (any Error)?) -> Void)? = nil
+    ) {
+        defer {
+            completionHandler?(nil)
+        }
+        // Remove any previous notification with the same identifier to trigger
+        // the presentation on delivery.
+        if let notification = deliveredNotifications.first(where: { $0.identifier == request.identifier }) {
+            removeDeliveredNotification(notification)
+        }
+        let notification = NSUserNotification()
+        notification.identifier = request.identifier
+        notification.userInfo = request.userInfo as? [String: Any]
+        notification.title = request.title
+        notification.subtitle = request.subtitle
+        notification.informativeText = request.body
+        notification.soundName = request.playSound ? NSUserNotificationDefaultSoundName : nil
+        deliver(notification)
+    }
+
+    fileprivate func getDeliveredNotifications(
+        completionHandler: @escaping (_ notifications: [UserNotificationResponse]) -> Void
+    ) {
+        let notifications = deliveredNotifications.compactMap { notification in
+            guard let identifier = notification.identifier else {
+                return nil as UserNotificationResponse?
+            }
+            return UserNotificationResponse(
+                identifier: identifier,
+                userInfo: notification.userInfo
+            )
+        }
+        completionHandler(notifications)
+    }
+
+    fileprivate func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+        for notification in deliveredNotifications {
+            if let identifier = notification.identifier, identifiers.contains(identifier) {
+                removeDeliveredNotification(notification)
+            }
+        }
+    }
+
+}
+
+// MARK: -
+
+extension OSLog {
+
+    fileprivate static let userNotificationCenter = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "--",
+        category: "UserNotificationCenter"
+    )
+
+}

--- a/Vienna/Sources/UserNotifications/UserNotificationCenter.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationCenter.swift
@@ -154,6 +154,9 @@ class UserNotificationCenter: NSObject {
         if let userInfo = request.userInfo {
             content.userInfo = userInfo
         }
+        if let threadIdentifier = request.threadIdentifier {
+            content.threadIdentifier = threadIdentifier
+        }
         content.sound = request.playSound ? .default : nil
         let notificationRequest = UNNotificationRequest(
             identifier: request.identifier,
@@ -178,6 +181,7 @@ class UserNotificationCenter: NSObject {
                 let request = notification.request
                 return UserNotificationResponse(
                     identifier: request.identifier,
+                    threadIdentifier: request.content.threadIdentifier,
                     userInfo: request.content.userInfo
                 )
             }
@@ -229,9 +233,11 @@ extension UserNotificationCenter: UNUserNotificationCenterDelegate {
         }
         let request = response.notification.request
         let identifier = request.identifier
+        let threadIdentifier = request.content.threadIdentifier
         let userInfo = request.content.userInfo as? [String: AnyHashable]
         let response = UserNotificationResponse(
             identifier: identifier,
+            threadIdentifier: threadIdentifier,
             userInfo: userInfo
         )
         delegate.userNotificationCenter(self, didReceive: response)

--- a/Vienna/Sources/UserNotifications/UserNotificationCenterDelegate.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationCenterDelegate.swift
@@ -1,8 +1,8 @@
 //
-//  AppController+Notifications.h
+//  UserNotificationCenterDelegate.swift
 //  Vienna
 //
-//  Copyright 2017
+//  Copyright 2023-2025 Eitot
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -17,19 +17,13 @@
 //  limitations under the License.
 //
 
-#import "AppController.h"
+@objc(VNAUserNotificationCenterDelegate)
+protocol UserNotificationCenterDelegate: AnyObject {
 
-#import "Vienna-Swift.h"
+    @objc(userNotificationCenter:didReceiveResponse:)
+    func userNotificationCenter(
+        _ center: UserNotificationCenter,
+        didReceive response: UserNotificationResponse
+    )
 
-@interface AppController (Notifications) <VNAUserNotificationCenterDelegate>
-
-// Notification keys
-extern NSString *const UserNotificationContextKey;
-extern NSString *const UserNotificationFilePathKey;
-
-// Notification context descriptors
-extern NSString *const UserNotificationContextFetchCompleted;
-extern NSString *const UserNotificationContextFileDownloadCompleted;
-extern NSString *const UserNotificationContextFileDownloadFailed;
-
-@end
+}

--- a/Vienna/Sources/UserNotifications/UserNotificationRequest.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationRequest.swift
@@ -1,0 +1,49 @@
+//
+//  UserNotificationRequest.swift
+//  Vienna
+//
+//  Copyright 2023-2025 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+@objc(VNAUserNotificationRequest)
+class UserNotificationRequest: NSObject {
+
+    /// The identifier of the notification.
+    @objc let identifier: String
+
+    /// Additional user info that is attached to the notification.
+    @objc var userInfo: [AnyHashable: Any]?
+
+    /// The title of the notification.
+    @objc var title: String
+
+    /// The subtitle of the notification.
+    @objc var subtitle: String?
+
+    /// The body text of the notification.
+    @objc var body: String?
+
+    /// Whether the notification plays a sound.
+    @objc var playSound = false
+
+    @objc
+    init(identifier: String, title: String) {
+        self.identifier = identifier
+        self.title = title
+    }
+
+}

--- a/Vienna/Sources/UserNotifications/UserNotificationRequest.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationRequest.swift
@@ -25,6 +25,9 @@ class UserNotificationRequest: NSObject {
     /// The identifier of the notification.
     @objc let identifier: String
 
+    /// The identifier of the thread to which the notification belongs.
+    @objc var threadIdentifier: String?
+
     /// Additional user info that is attached to the notification.
     @objc var userInfo: [AnyHashable: Any]?
 

--- a/Vienna/Sources/UserNotifications/UserNotificationResponse.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationResponse.swift
@@ -25,14 +25,19 @@ class UserNotificationResponse: NSObject {
     /// The identifier of the notification.
     @objc let identifier: String
 
+    /// The identifier of the thread to which the notification belongs.
+    @objc let threadIdentifier: String?
+
     /// Additional user info that is attached to the notification.
     @objc let userInfo: [AnyHashable: Any]?
 
     init(
         identifier: String,
+        threadIdentifier: String? = nil,
         userInfo: [AnyHashable: Any]? = nil
     ) {
         self.identifier = identifier
+        self.threadIdentifier = threadIdentifier
         self.userInfo = userInfo
     }
 

--- a/Vienna/Sources/UserNotifications/UserNotificationResponse.swift
+++ b/Vienna/Sources/UserNotifications/UserNotificationResponse.swift
@@ -1,8 +1,8 @@
 //
-//  AppController+Notifications.h
+//  UserNotificationResponse.swift
 //  Vienna
 //
-//  Copyright 2017
+//  Copyright 2023-2025 Eitot
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -17,19 +17,23 @@
 //  limitations under the License.
 //
 
-#import "AppController.h"
+import Foundation
 
-#import "Vienna-Swift.h"
+@objc(VNAUserNotificationResponse)
+class UserNotificationResponse: NSObject {
 
-@interface AppController (Notifications) <VNAUserNotificationCenterDelegate>
+    /// The identifier of the notification.
+    @objc let identifier: String
 
-// Notification keys
-extern NSString *const UserNotificationContextKey;
-extern NSString *const UserNotificationFilePathKey;
+    /// Additional user info that is attached to the notification.
+    @objc let userInfo: [AnyHashable: Any]?
 
-// Notification context descriptors
-extern NSString *const UserNotificationContextFetchCompleted;
-extern NSString *const UserNotificationContextFileDownloadCompleted;
-extern NSString *const UserNotificationContextFileDownloadFailed;
+    init(
+        identifier: String,
+        userInfo: [AnyHashable: Any]? = nil
+    ) {
+        self.identifier = identifier
+        self.userInfo = userInfo
+    }
 
-@end
+}


### PR DESCRIPTION
This mostly replicates the previous functionality, with the exception of grouping file download notifications in Notification Centre (if not disabled by the user in System Settings).