### PR TITLE
Make folder selection in smart folders more robust

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		03A131B31AA54EAC0037471F /* Database+Migration.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A131B21AA54EAC0037471F /* Database+Migration.m */; };
 		03F33D961DF2A2F900B04FAF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03F33D951DF2A2F900B04FAF /* Assets.xcassets */; };
 		2F06504C2506B5B500468A0E /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F06504B2506B5B500468A0E /* LoadingIndicator.swift */; };
+		2F1248372DE3447E00C96C40 /* Database+CriteriaMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1248362DE3447E00C96C40 /* Database+CriteriaMigration.swift */; };
 		2F125EDE24D0638600868E11 /* BrowserTabWithLegacyAddressBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2F125EDD24D0638600868E11 /* BrowserTabWithLegacyAddressBar.xib */; };
 		2F125EE024D066ED00868E11 /* AsyncHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F125EDF24D066ED00868E11 /* AsyncHelper.swift */; };
 		2F20FF8F25618627000F68C2 /* WebKitArticleTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F20FF8E25618627000F68C2 /* WebKitArticleTab.swift */; };
@@ -312,6 +313,7 @@
 		03F33D951DF2A2F900B04FAF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2A37F4B0FDCFA73011CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = main.m; sourceTree = "<group>"; };
 		2F06504B2506B5B500468A0E /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
+		2F1248362DE3447E00C96C40 /* Database+CriteriaMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database+CriteriaMigration.swift"; sourceTree = "<group>"; };
 		2F125EDD24D0638600868E11 /* BrowserTabWithLegacyAddressBar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BrowserTabWithLegacyAddressBar.xib; sourceTree = "<group>"; };
 		2F125EDF24D066ED00868E11 /* AsyncHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncHelper.swift; sourceTree = "<group>"; };
 		2F20FF8E25618627000F68C2 /* WebKitArticleTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebKitArticleTab.swift; sourceTree = "<group>"; };
@@ -1319,6 +1321,7 @@
 				AA26F4D50604927300FE7994 /* Database.m */,
 				03A131B11AA54EAC0037471F /* Database+Migration.h */,
 				03A131B21AA54EAC0037471F /* Database+Migration.m */,
+				2F1248362DE3447E00C96C40 /* Database+CriteriaMigration.swift */,
 				AA36CD7906100692001E33A4 /* Field.h */,
 				AA36CD7A06100692001E33A4 /* Field.m */,
 				43502865165DE9DF0018EDB7 /* Export.h */,
@@ -1880,6 +1883,7 @@
 				435028A8165DE9E00018EDB7 /* Import.m in Sources */,
 				435028A9165DE9E00018EDB7 /* InfoPanelController.m in Sources */,
 				435028AA165DE9E00018EDB7 /* MessageListView.m in Sources */,
+				2F1248372DE3447E00C96C40 /* Database+CriteriaMigration.swift in Sources */,
 				435028AB165DE9E00018EDB7 /* NewGroupFolder.m in Sources */,
 				F6A4E8481F040D58001C9191 /* PlugInToolbarItemButton.swift in Sources */,
 				2F33DB3229244ADB00A9716A /* DoesNotContainPredicateEditorRowTemplate.swift in Sources */,

--- a/Vienna/Sources/Alerts/SmartFolder.m
+++ b/Vienna/Sources/Alerts/SmartFolder.m
@@ -321,7 +321,7 @@ static NSNibName const VNASmartFolderNibName = @"SearchFolder";
         [controller selectFolder:self.smartFolderId];
     } else {
         [Database.sharedManager updateSearchFolder:self.smartFolderId
-                                        withFolder:folderName
+                                        withNewFolderName:folderName
                                          withQuery:criteriaTree];
     }
 

--- a/Vienna/Sources/Criteria/Criteria+SQL.swift
+++ b/Vienna/Sources/Criteria/Criteria+SQL.swift
@@ -149,7 +149,11 @@ extension Criteria: SQLConversion {
     }
 
     func folderSqlString(sqlFieldName: String, database: Database) -> String {
-        let folder = database.folder(fromName: value)
+        guard let value = Int(value) else {
+            fatalError("Value should have been migrated to folder id")
+        }
+        let folder = database.folder(fromID: Int(value))
+
         let scope: QueryScope
         switch operatorType {
         case .under:

--- a/Vienna/Sources/Criteria/Criteria.swift
+++ b/Vienna/Sources/Criteria/Criteria.swift
@@ -90,7 +90,10 @@ protocol CriteriaElement: PredicateConvertible {
 
 // Workaround while this variable is needed for objc, due to generics in traverse function
 protocol Traversable: CriteriaElement {
+    /// traversal for conversion
     func traverse<ResultType>(treeConversion: (_ element: CriteriaTree, _ subresult: [ResultType]) -> ResultType, criteriaConversion: (_ element: Criteria) -> ResultType) -> ResultType
+    /// traversal for modification
+    func traverse(treeModifier: ((_ element: CriteriaTree) -> Void)?, criteriaModifier: ((_ element: Criteria) -> Void)?)
 }
 
 @objc
@@ -130,6 +133,17 @@ class CriteriaTree: NSObject, Traversable {
         }
         return treeConversion(self, subresult)
     }
+
+    func traverse(treeModifier: ((CriteriaTree) -> Void)?, criteriaModifier: ((Criteria) -> Void)?) {
+        //traversion to modify is the same as traversion for conversion with implicit modification while discarding conversion result
+        _ = traverse { criteriaTree, _ in
+            treeModifier?(criteriaTree)
+            return ""
+        } criteriaConversion: { criteria in
+            criteriaModifier?(criteria)
+            return ""
+        }
+    }
 }
 
 @objc
@@ -148,5 +162,9 @@ class Criteria: NSObject, Traversable {
 
     func traverse<ResultType>(treeConversion: (_ element: CriteriaTree, _ subresult: [ResultType]) -> ResultType, criteriaConversion: (_ element: Criteria) -> ResultType) -> ResultType {
         return criteriaConversion(self)
+    }
+
+    func traverse(treeModifier: ((CriteriaTree) -> Void)?, criteriaModifier: ((Criteria) -> Void)?) {
+        criteriaModifier?(self)
     }
 }

--- a/Vienna/Sources/Database/Database+CriteriaMigration.swift
+++ b/Vienna/Sources/Database/Database+CriteriaMigration.swift
@@ -1,0 +1,50 @@
+//
+//  Database+CriteriaMigration.swift
+//  Vienna
+//
+//  Copyright 2025 Tassilo Karge
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension Database {
+    @objc
+    func migrateCriteria(from version: Int) {
+        switch version + 1 {
+        case 0..<27: //xml migration did not exist yet, but we could hit this case if someone jumps a major version
+            NSLog("Migration of xml for version < 27")
+            fallthrough
+        case 27: //migrate from folder names to folder ids
+            guard let smartfoldersDict = self.smartfoldersDict as? [Int: CriteriaTree] else {
+                NSLog("Criteria conversion to version 27 failed")
+                return
+            }
+            for (folderId, criteriaTree) in smartfoldersDict {
+
+                criteriaTree.traverse(treeModifier: { _ in }, criteriaModifier: { criteria in
+                    if criteria.field == MA_Field_Folder {
+                        criteria.value = Criteria.convertIndentedFolderNameToFolderId(criteria.value, on: self)
+                    }
+                })
+                self.updateSearchFolder(folderId, withNewFolderName: nil, withQuery: criteriaTree)
+            }
+
+            NSLog("Updated smart folder xmls to version 27")
+            fallthrough
+        default:
+            break
+        }
+    }
+}

--- a/Vienna/Sources/Database/Database+Migration.m
+++ b/Vienna/Sources/Database/Database+Migration.m
@@ -259,6 +259,9 @@
             database.userVersion = (uint32_t)26;
             NSLog(@"Updated database schema to version 26.");
         }
+        case 27: //change smart folder search strings from name to id, happens in Database+CriteriaMigration
+            database.userVersion = (uint32_t)27;
+            NSLog(@"Updated database schema to version 27.");
     }
 }
 

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -81,7 +81,7 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
  *  @return An OpenReaderFolder that corresponds
  */
 -(Folder *)folderFromRemoteId:(NSString *)wantedRemoteId;
--(Folder *)folderFromName:(NSString *)wantedName;
+-(Folder * _Nullable)folderFromName:(NSString *)wantedName;
 /*!
  * folderForPredicateFormat
  * Returns a smart folder for the predicate format string.
@@ -124,8 +124,9 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
         subscriptionURL:(NSString *)url remoteId:(NSString *)remoteId;
 
 // Smart folder functions
+@property (nonatomic) NSMutableDictionary<NSNumber *, CriteriaTree *> *smartfoldersDict;
 -(NSInteger)addSmartFolder:(NSString *)folderName underParent:(NSInteger)parentId withQuery:(CriteriaTree *)criteriaTree;
--(void)updateSearchFolder:(NSInteger)folderId withFolder:(NSString *)folderName withQuery:(CriteriaTree *)criteriaTree;
+-(void)updateSearchFolder:(NSInteger)folderId withNewFolderName:(NSString *)folderName withQuery:(CriteriaTree *)criteriaTree;
 -(CriteriaTree *)searchStringForSmartFolder:(NSInteger)folderId;
 
 // Article functions

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -41,7 +41,6 @@
 @property (nonatomic) NSMutableArray *fieldsOrdered;
 @property (nonatomic) NSMutableDictionary *fieldsByName;
 @property (nonatomic) NSMutableDictionary *foldersDict;
-@property (nonatomic) NSMutableDictionary<NSNumber *, CriteriaTree *> *smartfoldersDict;
 @property (readwrite, nonatomic) BOOL readOnly;
 @property (readwrite, nonatomic) NSInteger countOfUnread;
 
@@ -57,7 +56,7 @@
 
 // The current database version number
 static NSInteger const VNAMinimumSupportedDatabaseVersion = 12;
-static NSInteger const VNACurrentDatabaseVersion = 26;
+static NSInteger const VNACurrentDatabaseVersion = 27;
 
 @implementation Database
 
@@ -178,7 +177,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
             // TODO: move this into transaction so we can rollback on failure
             [Database migrateDatabase:db fromVersion:databaseVersion];
         }];
-        
+
+        [self migrateCriteriaFrom:databaseVersion];
+
         // Confirm the database is now at the correct version
         if (self.databaseVersion == VNACurrentDatabaseVersion) {
             return YES;
@@ -1431,8 +1432,9 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 /* folderFromName
  * Retrieve a Folder given its name.
  */
--(Folder *)folderFromName:(NSString *)wantedName
+-(Folder * _Nullable)folderFromName:(NSString *)wantedName
 {
+    [self initFolderArray];
 	Folder * folder;
 	for (folder in [self.foldersDict objectEnumerator]) {
 		if ([folder.name isEqualToString:wantedName]) {
@@ -1856,10 +1858,10 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 /* updateSearchFolder
  * Updates the search string for the specified folder.
  */
--(void)updateSearchFolder:(NSInteger)folderId withFolder:(NSString *)folderName withQuery:(CriteriaTree *)criteriaTree
+-(void)updateSearchFolder:(NSInteger)folderId withNewFolderName:(nullable NSString *)folderName withQuery:(CriteriaTree *)criteriaTree
 {
 	Folder * folder = [self folderFromID:folderId];
-    if (![folder.name isEqualToString:folderName]) {
+    if (folderName && ![folder.name isEqualToString:folderName]) {
         [self setName:folderName forFolder:folderId];
     }
 


### PR DESCRIPTION
The only ugly thing I had to do here is to access the db while converting Criteria (which now use IDs instead of (indented) names to reference folders) to NSPredicates. That could be solved in the future by creating a custom representation for folder criteria within the predicate editor.