### PR TITLE
Fix xcodebuild "fatal error" log

### DIFF
--- a/Vienna/Sources/Database/Database+Migration.h
+++ b/Vienna/Sources/Database/Database+Migration.h
@@ -19,6 +19,8 @@
 
 #import "Database.h"
 
+@import FMDB;
+
 @interface Database (Migration)
 
 /// Migrates the Vienna database schema.

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -19,7 +19,6 @@
 //
 
 @import Foundation;
-@import FMDB;
 
 @class Folder;
 @class Field;
@@ -39,7 +38,6 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 
 @property(nonatomic) Folder * trashFolder;
 @property(nonatomic) Folder * searchFolder;
-@property(nonatomic) FMDatabaseQueue * databaseQueue;
 @property (copy, nonatomic) NSString *searchString;
 
 @property (class, readonly, nonatomic) Database *sharedManager NS_SWIFT_NAME(shared);

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -20,6 +20,7 @@
 
 #import "Database.h"
 
+@import FMDB;
 @import os.log;
 
 #import "Database+Migration.h"
@@ -41,6 +42,7 @@
 @property (nonatomic) NSMutableArray *fieldsOrdered;
 @property (nonatomic) NSMutableDictionary *fieldsByName;
 @property (nonatomic) NSMutableDictionary *foldersDict;
+@property (nonatomic) FMDatabaseQueue *databaseQueue;
 @property (nonatomic) NSMutableDictionary<NSNumber *, CriteriaTree *> *smartfoldersDict;
 @property (readwrite, nonatomic) BOOL readOnly;
 @property (readwrite, nonatomic) NSInteger countOfUnread;


### PR DESCRIPTION
Resolves #1637

The fatal error is still logged when compiling with xcodebuild. This is the full log (without xcpretty):
```
SwiftGeneratePch normal arm64 Compiling\ bridging\ header (in target 'Vienna' from project 'Vienna')
fatal error: module 'FMDB' in AST file '/Users/<user>/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/3U1OW30DAD1K3/FMDB-1711M3MDYPI8X.pcm' (imported by AST file '/Users/<user>/Library/Developer/Xcode/DerivedData/Vienna-fklqbwkuobvwkgbajiaxtkmjqvse/Build/Intermediates.noindex/PrecompiledHeaders/Vienna-Bridging-Header-swift_1V7XQ7Z2G2HPR-clang_3U1OW30DAD1K3.pch') is not defined in any loaded module map file; maybe you need to load '/Users/<user>/Library/Developer/Xcode/DerivedData/Vienna-fklqbwkuobvwkgbajiaxtkmjqvse/Build/Intermediates.noindex/GeneratedModuleMaps/FMDB.modulemap'?
note: consider adding '/Users/<user>/Library/Developer/Xcode/DerivedData/Vienna-fklqbwkuobvwkgbajiaxtkmjqvse/Build/Intermediates.noindex/GeneratedModuleMaps' to the header search path
note: imported by '/Users/<user>/Library/Developer/Xcode/DerivedData/Vienna-fklqbwkuobvwkgbajiaxtkmjqvse/Build/Intermediates.noindex/PrecompiledHeaders/Vienna-Bridging-Header-swift_1V7XQ7Z2G2HPR-clang_3U1OW30DAD1K3.pch'
note: this is generally caused by modules with the same name found in multiple paths
```

Given the references to "SwiftGeneratePch", Vienna-Bridging-Header.h and FMDB I managed to narrow it down to Database.h which imported FMDB. Moving the import declaration to the implementation file seems to have resolved it.