### PR TITLE
Remove superfluous web view

### DIFF
--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -80,9 +80,8 @@ class BrowserTab: NSViewController {
 
     // MARK: object lifecycle
 
-    init(_ request: URLRequest? = nil, config: WKWebViewConfiguration = WKWebViewConfiguration()) {
-
-        self.webView = CustomWKWebView(configuration: config)
+    init(_ webView: CustomWKWebView) {
+        self.webView = webView
 
         if #available(macOS 10.14, *) {
             super.init(nibName: "BrowserTab", bundle: nil)
@@ -127,6 +126,10 @@ class BrowserTab: NSViewController {
                 self?.statusBar = nil
              }
         }
+    }
+
+    convenience init(_ request: URLRequest? = nil, config: WKWebViewConfiguration = WKWebViewConfiguration()) {
+        self.init(CustomWKWebView(configuration: config))
 
         if let request = request {
             webView.load(request)

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -60,7 +60,7 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
     @objc
     init() {
         self.articleWebView = WebKitArticleView(frame: CGRect.zero)
-        super.init()
+        super.init(articleWebView)
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
While investigating issue #1912 which made me suspect that there might be some zombie browser tab(s), I noticed that when Vienna runs with just the main tab open, Safari's Developer menu would list not one, but two items under Vienna, with the second one titled 'about:blank'

This removes the extraneous CustomWKWebView initiated by BrowserTab