### PR TITLE
Disable RSS detection in article view

### DIFF
--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -66,6 +66,8 @@ class BrowserTab: NSViewController {
     /// backing storage only, access via rssUrl property
     var rssFeedUrls: [URL] = []
 
+
+    var rssSourceEnabled = true
     var showRssButton = false
 
     var viewVisible = false
@@ -172,7 +174,9 @@ class BrowserTab: NSViewController {
             self.url = url
         }
 
-        self.viewDidLoadRss()
+        if rssSourceEnabled {
+            self.viewDidLoadRss()
+        }
 
         self.viewDidLoadHoverLinkUI()
 

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -80,9 +80,8 @@ class BrowserTab: NSViewController {
 
     // MARK: object lifecycle
 
-    init(_ request: URLRequest? = nil, config: WKWebViewConfiguration = WKWebViewConfiguration()) {
-
-        self.webView = CustomWKWebView(configuration: config)
+    init(_ webView: CustomWKWebView) {
+        self.webView = webView
 
         if #available(macOS 10.14, *) {
             super.init(nibName: "BrowserTab", bundle: nil)
@@ -127,6 +126,10 @@ class BrowserTab: NSViewController {
                 self?.statusBar = nil
              }
         }
+    }
+
+    convenience init(_ request: URLRequest? = nil, config: WKWebViewConfiguration = WKWebViewConfiguration()) {
+        self.init(CustomWKWebView(configuration: config))
 
         if let request = request {
             webView.load(request)

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -60,7 +60,7 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
     @objc
     init() {
         self.articleWebView = WebKitArticleView(frame: CGRect.zero)
-        super.init()
+        super.init(articleWebView)
     }
 
     override func viewDidLoad() {

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -61,6 +61,8 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
     init() {
         self.articleWebView = WebKitArticleView(frame: CGRect.zero)
         super.init(articleWebView)
+        //article view should not have react to embedded rss feeds
+        super.rssSourceEnabled = false
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
I assume it´s not necessary in the article view, and it makes sense to disable it in the article view which has no subscribe rss button.