### PR TITLE
Disable RSS detection for article tab

### DIFF
--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -56,6 +56,7 @@ extension BrowserTab: RSSSource {
         }
     }
 
+    @objc
     func viewDidLoadRss() {
         refreshRSSState()
         registerNavigationEndHandler { [weak self] success in self?.handleNavigationEndRss(success: success) }

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -69,6 +69,10 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
         hideAddressBar(true)
     }
 
+    override func viewDidLoadRss() {
+        // No need to search RSS feed in article tab
+    }
+
     // MARK: gui
 
     override func activateAddressBar() {


### PR DESCRIPTION
Avoid unnecessary effort when skimming through articles, and should fix issue #1912 (Vienna not responding).
