### PR TITLE
Update link underline color to match system link color

### DIFF
--- a/Vienna/Interfaces/Base.lproj/MainWindowController.xib
+++ b/Vienna/Interfaces/Base.lproj/MainWindowController.xib
@@ -1001,8 +1001,8 @@
                                     <rect key="frame" x="-2" y="0.0" width="304" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="1375">
                                         <font key="font" metaFont="smallSystem"/>
-                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
                             </subviews>

--- a/Vienna/Sources/Main window/EnclosureView.m
+++ b/Vienna/Sources/Main window/EnclosureView.m
@@ -118,10 +118,9 @@
         fileImage.image = [NSWorkspace.sharedWorkspace iconForFileType:extension];
     }
 	NSDictionary *linkAttributes = @{
-									 NSLinkAttributeName: enclosureURLString,
-									 NSForegroundColorAttributeName: [NSColor colorWithCalibratedHue:240.0f/360.0f saturation:1.0f brightness:0.75f alpha:1.0f],
-									 NSUnderlineStyleAttributeName: @YES,
-									 };
+		NSLinkAttributeName: enclosureURLString,
+        NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle),
+	};
 	NSAttributedString * link = [[NSAttributedString alloc] initWithString:basename attributes:linkAttributes];
 	filenameField.attributedStringValue = link;
 }


### PR DESCRIPTION
The link colour in Interface Builder (or `NSForegroundColorAttributeName`) does not actually affect the colour of the link itself when the NSLinkAttributeName is applied (https://stackoverflow.com/q/39926951/6423906). It does still affect the underline colour.