### PR TITLE
Make a NSLayoutConstraint apply to vertical layout only

### DIFF
--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -158,6 +158,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
         multiplier:0.f constant:self.contentStackView.frame.size.width];
     self.articleTextView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentStackView addConstraint:self.textViewWidthConstraint];
+    self.textViewWidthConstraint.active = splitView2.vertical;
 
 	Preferences * prefs = [Preferences standardPreferences];
 
@@ -829,13 +830,14 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		splitView2.dividerStyle = NSSplitViewDividerStyleThin;
 		splitView2.autosaveName = @"Vienna3SplitView2CondensedLayout";
 		self.textViewWidthConstraint.constant = self.contentStackView.frame.size.width;
+		self.textViewWidthConstraint.active = YES;
 	} else {
 		splitView2.dividerStyle = NSSplitViewDividerStylePaneSplitter;
 		splitView2.autosaveName = @"Vienna3SplitView2ReportLayout";
 		self.textViewWidthConstraint.constant = splitView2.frame.size.width;
+		self.textViewWidthConstraint.active = NO;
 	}
 	self.textViewWidthConstraint.priority = NSLayoutPriorityRequired;
-	self.textViewWidthConstraint.active = YES;
 	[splitView2 display];
 	isChangingOrientation = NO;
 }
@@ -1641,6 +1643,8 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
             }
         }
         self.articleTextView.translatesAutoresizingMaskIntoConstraints = YES;
+    } else {
+        self.textViewWidthConstraint.active = NO;
     }
 }
 
@@ -1661,6 +1665,9 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
             }
         }
         self.articleTextView.translatesAutoresizingMaskIntoConstraints = YES;
+        self.textViewWidthConstraint.active = splitView2.vertical;
+    } else {
+        self.textViewWidthConstraint.active = splitView2.vertical;
     }
 }
 


### PR DESCRIPTION
Reintroduce some logic from commit 999e9cc (introduced by PR #1625) and transpose it to resizes not induced by user dragging a divider (cf. https://developer.apple.com/documentation/appkit/nssplitview/didresizesubviewsnotification)

Verify changes do not affect behavior with feeds which caused earlier difficulties when vertical layout and "Use Web Page for Articles" were activated:
- https://waronguns.com/feed/
- https://www.confidential-renault.fr/?rss=RSS

Solves issue #1863 (insane resizing of left hand sidebar when user uses horizontal layout and switches to full screen)