### PR TITLE
Fix case of Info.plist filename in warning messages

### DIFF
--- a/Vienna/Sources/Plug-ins/PluginManager.m
+++ b/Vienna/Sources/Plug-ins/PluginManager.m
@@ -120,7 +120,7 @@ static NSString * const VNAPluginsDirectoryName = @"Plugins";
         [allPlugins addObject:plugin];
         [self didChangeValueForKey:NSStringFromSelector(@selector(numberOfPlugins))];
     } else {
-        NSLog(@"Missing or corrupt info.plist in %@", pluginPath);
+        NSLog(@"Missing or corrupt Info.plist in %@", pluginPath);
     }
 }
 
@@ -173,7 +173,7 @@ static NSString * const VNAPluginsDirectoryName = @"Plugins";
                     keyMod |= NSEventModifierFlagControl;
                 } else {
                     if (!keyChar.vna_isBlank) {
-                        NSLog(@"Warning: malformed MenuKey found in info.plist for plugin %@", plugin.identifier);
+                        NSLog(@"Warning: malformed MenuKey found in Info.plist for plugin %@", plugin.identifier);
                     }
                     keyChar = oneKey;
                 }


### PR DESCRIPTION
Clarification needed in regard to issue #1923 (Plug-in bundles with lowercase info.plist won't load on case-sensitive file systems)