### PR TITLE
Add XML parsing failure details in activity window

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -762,6 +762,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         }
         // Mark the feed as failed
         [self setFolderErrorFlag:folder flag:YES];
+        [connectorItem appendDetail:error.localizedDescription];
         dispatch_async(dispatch_get_main_queue(), ^{
             [connectorItem setStatus:NSLocalizedString(@"Error parsing data in feed", nil)];
         });

--- a/Vienna/Sources/Parsing/XMLFeedParser.m
+++ b/Vienna/Sources/Parsing/XMLFeedParser.m
@@ -56,12 +56,17 @@
                                                         error:&xmlDocumentError];
         }
     } @catch (NSException * __unused) {
-        if (xmlDocumentError && error) {
-            *error = xmlDocumentError;
+        if (error) {
+            if (xmlDocumentError) {
+                *error = xmlDocumentError;
+            } else {
+                *error = [NSError errorWithDomain:NSXMLParserErrorDomain
+                                             code:NSXMLParserInternalError
+                                         userInfo:nil];
+            }
         }
         xmlDocument = nil;
-
-        // FIXME: Should this method not return nil here?
+        return nil;
     }
 
     VNAXMLFeed *feed = nil;


### PR DESCRIPTION
Allow user to get explanations on the location of the problem that made NSXMLDocument's `-initWithData:options:error:` fail