### PR TITLE
Declare Objective-C designated initialisers

### DIFF
--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -31,19 +31,21 @@ typedef NS_OPTIONS(NSInteger, VNAQueryScope) {
     VNAQueryScopeSubFolders = 2
 } NS_SWIFT_NAME(QueryScope);
 
-@interface Database : NSObject
-
 extern NSNotificationName const VNADatabaseWillDeleteFolderNotification;
 extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
+
+@interface Database : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@property (class, readonly, nonatomic) Database *sharedManager NS_SWIFT_NAME(shared);
 
 @property(nonatomic) Folder * trashFolder;
 @property(nonatomic) Folder * searchFolder;
 @property (copy, nonatomic) NSString *searchString;
 
-@property (class, readonly, nonatomic) Database *sharedManager NS_SWIFT_NAME(shared);
-
 // General database functions
-- (instancetype)initWithDatabaseAtPath:(NSString *)dbPath /*NS_DESIGNATED_INITIALIZER*/;
 -(void)compactDatabase;
 -(void)reindexDatabase;
 -(void)optimizeDatabase;

--- a/Vienna/Sources/Main window/BackTrackArray.h
+++ b/Vienna/Sources/Main window/BackTrackArray.h
@@ -22,8 +22,12 @@
 
 @interface BackTrackArray : NSObject
 
+- (instancetype)initWithMaximum:(NSUInteger)maximum NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 // Accessor functions
--(instancetype)initWithMaximum:(NSUInteger)theMax /*NS_DESIGNATED_INITIALIZER*/;
 @property (nonatomic, getter=isAtStartOfQueue, readonly) BOOL atStartOfQueue;
 @property (nonatomic, getter=isAtEndOfQueue, readonly) BOOL atEndOfQueue;
 -(void)addToQueue:(NSInteger)folderId guid:(NSString *)guid;

--- a/Vienna/Sources/Main window/FoldersFilterable.h
+++ b/Vienna/Sources/Main window/FoldersFilterable.h
@@ -16,7 +16,11 @@
 #pragma clang diagnostic pop
 }
 
-- (instancetype)initWithDataSource:(id<NSOutlineViewDataSource>)dataSource /*NS_DESIGNATED_INITIALIZER*/;
+- (instancetype)initWithDataSource:(id<NSOutlineViewDataSource>)dataSource
+    NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/Vienna/Sources/Main window/TreeNode.h
+++ b/Vienna/Sources/Main window/TreeNode.h
@@ -26,8 +26,15 @@
 
 @interface TreeNode : NSObject
 
+- (instancetype)init:(TreeNode *)parentNode
+             atIndex:(NSInteger)insertIndex
+              folder:(Folder *)folder
+     canHaveChildren:(BOOL)childflag NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 // Accessor functions
--(instancetype)init:(TreeNode *)parentNode atIndex:(NSInteger)insertIndex folder:(Folder *)folder canHaveChildren:(BOOL)childflag /*NS_DESIGNATED_INITIALIZER*/;
 @property (nonatomic) TreeNode *parentNode;
 @property (nonatomic, readonly) TreeNode *nextSibling;
 @property (nonatomic, readonly) TreeNode *firstChild;

--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -71,8 +71,14 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
 
 @interface Folder : NSObject <NSCacheDelegate>
 
-// Initialisation functions
--(instancetype)initWithId:(NSInteger)itemId parentId:(NSInteger)parentId name:(NSString *)name type:(VNAFolderType)type /*NS_DESIGNATED_INITIALIZER*/;
+- (instancetype)initWithId:(NSInteger)itemId
+                  parentId:(NSInteger)parentId
+                      name:(NSString *)name
+                      type:(VNAFolderType)type NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, copy) NSString *feedDescription;
 @property (nonatomic, copy) NSString *homePage;


### PR DESCRIPTION
These were commented out, but there is no reason not to declare them. Following Swift conventions, the inherited initialisers are marked as unavailable.