### PR TITLE
Update document type declarations in Info.plist

### DIFF
--- a/Vienna/Info.plist
+++ b/Vienna/Info.plist
@@ -7,10 +7,6 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>viennaplugin</string>
-			</array>
 			<key>CFBundleTypeIconFile</key>
 			<string>PluginIcon</string>
 			<key>CFBundleTypeIconSystemGenerated</key>
@@ -25,14 +21,8 @@
 			<array>
 				<string>com.vienna-rss.plugin</string>
 			</array>
-			<key>LSTypeIsPackage</key>
-			<string>YES</string>
 		</dict>
 		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>viennastyle</string>
-			</array>
 			<key>CFBundleTypeIconFile</key>
 			<string>StyleIcon</string>
 			<key>CFBundleTypeIconSystemGenerated</key>
@@ -47,24 +37,18 @@
 			<array>
 				<string>com.vienna-rss.style</string>
 			</array>
-			<key>LSTypeIsPackage</key>
-			<string>YES</string>
 		</dict>
 		<dict>
-			<key>CFBundleTypeExtension</key>
-			<array>
-				<string>scpt</string>
-			</array>
 			<key>CFBundleTypeName</key>
-			<string>Script File</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>****</string>
-			</array>
+			<string>Open Scripting Architecture script</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.apple.applescript.script</string>
+			</array>
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>

--- a/Vienna/Info.plist
+++ b/Vienna/Info.plist
@@ -66,6 +66,18 @@
 			<key>LSHandlerRank</key>
 			<string>Default</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>OPML document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.opml.opml</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
@@ -211,6 +223,11 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>opml</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/xml</string>
+					<string>text/xml</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
- Adds OPML as a supported document type and declare its MIME types
Vienna can handle opening OPML files (see -[AppController application:openFile:]), so Vienna should be listed by LaunchServices, e.g. in "Open With" menus.
- Update document type declarations in Info.plist
The `CFBundleTypeExtensions`, `LSTypeIsPackage` and` CFBundleTypeOSTypes` keys have been deprecated many years ago in favour of the `LSItemContentTypes` key using Uniform Type Identifiers (UTI). Vienna's plug-in and style bundles are exported UTIs whereas the AppleScript/OSA script UTI is declared by Apple.
See also:
  - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-101685-TPXREF107
  - https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html
  - https://developer.apple.com/documentation/uniformtypeidentifiers/uttypeosascript