### PR TITLE
Several changes to Autorevision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Package.resolved
 # Vienna
 Vienna/Localizations/
 Scripts/Resources/CS-ID.xcconfig
-Vienna/Sources/autorevision.h
 
 # Jetbrains
 .idea

--- a/Scripts/ArchivalChecks.sh
+++ b/Scripts/ArchivalChecks.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "${OBJROOT}/autorevision.cache"
+. "${PROJECT_DERIVED_FILE_DIR}/autorevision.cache"
 
 # Fail if not deployment
 if [ ! "${CONFIGURATION}" = "Deployment" ]; then

--- a/Scripts/PostArchive.sh
+++ b/Scripts/PostArchive.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. "${OBJROOT}/autorevision.cache"
+. "${PROJECT_DERIVED_FILE_DIR}/autorevision.cache"
 # Magic number; do not touch!
 BUILD_NUMBER="2821"
 N_VCS_NUM="$((BUILD_NUMBER + VCS_NUM))"

--- a/Scripts/Sparkle-setup.sh
+++ b/Scripts/Sparkle-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Config
-. "${OBJROOT}/autorevision.cache"
+. "${PROJECT_DERIVED_FILE_DIR}/autorevision.cache"
 N_VCS_TAG="$(echo "${VCS_TAG}" | sed -e 's:^v/::')" # for urls/files
 V_VCS_TAG="$(echo "${N_VCS_TAG}" | sed -e 's:_beta: Beta :' -e 's:_rc: RC :')" # for display
 

--- a/Scripts/autorevision.sh
+++ b/Scripts/autorevision.sh
@@ -3,8 +3,6 @@
 # Config
 export PATH=/sw/bin:/opt/local/bin:/usr/local/bin:/usr/local/git/bin:${PATH}
 BUILD_NUMBER="2821"
-intermediateHeaderOutput="${DERIVED_FILE_DIR}/autorevision.h"
-finalHeaderOutput="${SRCROOT}/Vienna/Sources/autorevision.h"
 plistHeaderOutput="${OBJROOT}/autorevision.plist.h"
 cacheOutput="${OBJROOT}/autorevision.cache"
 tempCacheOutput="${DERIVED_FILE_DIR}/autorevision.tmp"
@@ -21,16 +19,6 @@ fi
 if ! ./External/autorevision/autorevision -o "${cacheOutput}" -t sh; then
 	exit ${?}
 fi
-
-
-# Output for Vienna/Sources/autorevision.h.
-# This header might be useful for including in code, (currently Vienna does not use it)
-# Be warned however that the VCS_NUM set will not reflect the reality, because of historical issues in Vienna
-./External/autorevision/autorevision -f -o "${cacheOutput}" -t h > "${intermediateHeaderOutput}"
-if [ ! -f "${finalHeaderOutput}" ] || ! cmp -s "${intermediateHeaderOutput}" "${finalHeaderOutput}"; then
-	mv "${intermediateHeaderOutput}" "${finalHeaderOutput}"
-fi
-
 
 # Source the initial autorevision output for filtering.
 . "${cacheOutput}"

--- a/Scripts/autorevision.sh
+++ b/Scripts/autorevision.sh
@@ -3,8 +3,8 @@
 # Config
 export PATH=/sw/bin:/opt/local/bin:/usr/local/bin:/usr/local/git/bin:${PATH}
 BUILD_NUMBER="2821"
-plistHeaderOutput="${OBJROOT}/autorevision.plist.h"
-cacheOutput="${OBJROOT}/autorevision.cache"
+plistHeaderOutput="${PROJECT_DERIVED_FILE_DIR}/autorevision.plist.h"
+cacheOutput="${PROJECT_DERIVED_FILE_DIR}/autorevision.cache"
 tempCacheOutput="${DERIVED_FILE_DIR}/autorevision.tmp"
 
 # Check our paths

--- a/Scripts/autorevision.sh
+++ b/Scripts/autorevision.sh
@@ -3,11 +3,11 @@
 # Config
 export PATH=/sw/bin:/opt/local/bin:/usr/local/bin:/usr/local/git/bin:${PATH}
 BUILD_NUMBER="2821"
-intermediateHeaderOutput="/tmp/autorevision.h"
+intermediateHeaderOutput="${DERIVED_FILE_DIR}/autorevision.h"
 finalHeaderOutput="${SRCROOT}/Vienna/Sources/autorevision.h"
 plistHeaderOutput="${OBJROOT}/autorevision.plist.h"
 cacheOutput="${OBJROOT}/autorevision.cache"
-tempCacheOutput="/tmp/autorevision.tmp"
+tempCacheOutput="${DERIVED_FILE_DIR}/autorevision.tmp"
 
 # Check our paths
 if [ ! -d "${BUILT_PRODUCTS_DIR}" ]; then

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1675,8 +1675,8 @@
 			name = "Run Autorevision";
 			outputPaths = (
 				"${DERIVED_FILE_DIR}/autorevision.tmp",
-				"${OBJROOT}/autorevision.cache",
-				"${OBJROOT}/autorevision.plist.h",
+				"${PROJECT_DERIVED_FILE_DIR}/autorevision.cache",
+				"${PROJECT_DERIVED_FILE_DIR}/autorevision.plist.h",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2302,7 +2302,7 @@
 				);
 				INFOPLIST_FILE = Vienna/Info.plist;
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
-				INFOPLIST_PREFIX_HEADER = "$(OBJROOT)/autorevision.plist.h";
+				INFOPLIST_PREFIX_HEADER = "$(PROJECT_DERIVED_FILE_DIR)/autorevision.plist.h";
 				INFOPLIST_PREPROCESS = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2345,7 +2345,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				INFOPLIST_FILE = Vienna/Info.plist;
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
-				INFOPLIST_PREFIX_HEADER = "$(OBJROOT)/autorevision.plist.h";
+				INFOPLIST_PREFIX_HEADER = "$(PROJECT_DERIVED_FILE_DIR)/autorevision.plist.h";
 				INFOPLIST_PREPROCESS = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -374,7 +374,6 @@
 		3A932D8923BB999A009B8061 /* ViennaDeployment.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = ViennaDeployment.entitlements; sourceTree = "<group>"; };
 		3AC411A426BBFDFD004A8700 /* WebKitArticleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebKitArticleView.swift; sourceTree = "<group>"; };
 		3ADBA70C23DDAFCA00156722 /* Notarize.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Notarize.sh; sourceTree = "<group>"; };
-		430C4ADB1661753F0079C9FC /* autorevision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autorevision.h; sourceTree = "<group>"; };
 		430C4AE0166175C20079C9FC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		435026E5165DD8BE0018EDB7 /* ArticleRef.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArticleRef.m; sourceTree = "<group>"; };
 		4350283D165DE7F60018EDB7 /* NSNotificationAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSNotificationAdditions.m; sourceTree = "<group>"; };
@@ -1167,7 +1166,6 @@
 				F6D7FEE31F1CE162004F095A /* Plug-ins */,
 				F6D7FEE41F1CE16A004F095A /* Shared */,
 				F6DAD20A1E75892C00FE2645 /* Vienna-Bridging-Header.h */,
-				430C4ADB1661753F0079C9FC /* autorevision.h */,
 				2A37F4B0FDCFA73011CA2CEA /* main.m */,
 			);
 			path = Sources;
@@ -1676,8 +1674,6 @@
 			);
 			name = "Run Autorevision";
 			outputPaths = (
-				"${SRCROOT}/Vienna/Sources/autorevision.h",
-				"${DERIVED_FILE_DIR}/autorevision.h",
 				"${DERIVED_FILE_DIR}/autorevision.tmp",
 				"${OBJROOT}/autorevision.cache",
 				"${OBJROOT}/autorevision.plist.h",

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -1677,6 +1677,8 @@
 			name = "Run Autorevision";
 			outputPaths = (
 				"${SRCROOT}/Vienna/Sources/autorevision.h",
+				"${DERIVED_FILE_DIR}/autorevision.h",
+				"${DERIVED_FILE_DIR}/autorevision.tmp",
 				"${OBJROOT}/autorevision.cache",
 				"${OBJROOT}/autorevision.plist.h",
 			);


### PR DESCRIPTION
- No longer generates temp files in the system /tmp directory, but uses the `$DERIVED_FILE_DIR` instead
- Removes the unused autorevision.h file from the project and the code that generated it from autorevision.sh
- Uses `$PROJECT_DERIVED_FILE_DIR` instead of `$OBJROOT` for shared derived files