### PR TITLE
Reduce dependence on AppController in ArticleListView/UnifiedDisplayView

### DIFF
--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -30,7 +30,6 @@
 @class PluginManager;
 @class SearchMethod;
 @class Database;
-@class ArticleController;
 @class Article;
 @class UnifiedDisplayView;
 @class ArticleListView;
@@ -44,7 +43,6 @@
 @property (nonatomic) IBOutlet SPUStandardUpdaterController *sparkleController;
 @property (nonatomic) PluginManager *pluginManager;
 @property (nonatomic, weak) id<Browser> browser;
-@property (nonatomic) ArticleController *articleController;
 @property (nonatomic, weak) UnifiedDisplayView *unifiedListView;
 @property (nonatomic, weak) ArticleListView *articleListView;
 @property (nonatomic) NewSubscription *rssFeed;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -24,6 +24,7 @@
 @import UniformTypeIdentifiers;
 
 #import "AppController+Notifications.h"
+#import "ArticleController.h"
 #import "Import.h"
 #import "Export.h"
 #import "RefreshManager.h"
@@ -97,6 +98,7 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 @property (nonatomic) VNADispatchTimer *refreshTimer;
 
 @property (nonatomic) MainWindowController *mainWindowController;
+@property (nonatomic) ArticleController *articleController;
 @property (nonatomic) ActivityPanelController *activityPanelController;
 @property (nonatomic) VNADirectoryMonitor *directoryMonitor;
 @property (nonatomic) NSWindowController *preferencesWindowController;
@@ -254,9 +256,11 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 
 	self.browser = self.mainWindowController.browser;
 	self.articleListView = self.mainWindowController.articleListView;
-	self.articleListView.controller = self;
+	self.articleListView.appController = self;
+	self.articleListView.articleController = self.articleController;
 	self.unifiedListView = self.mainWindowController.unifiedDisplayView;
-	self.unifiedListView.controller = self;
+	self.unifiedListView.appController = self;
+	self.unifiedListView.articleController = self.articleController;
 
 	self.outlineView = self.mainWindowController.outlineView;
     self.foldersTree.controller = self;

--- a/Vienna/Sources/Main window/ArticleCellView.h
+++ b/Vienna/Sources/Main window/ArticleCellView.h
@@ -8,6 +8,7 @@
 @import Cocoa;
 @import WebKit;
 
+@class ArticleController;
 @class ArticleConverter;
 @protocol ArticleContentView;
 
@@ -19,6 +20,7 @@
 @property BOOL inProgress;
 @property NSInteger folderId;
 @property NSUInteger articleRow;
+@property (weak, nonatomic) ArticleController *articleController;
 @property (nonatomic, weak) NSTableView *listView;
 @property CGFloat fittingHeight;
 

--- a/Vienna/Sources/Main window/ArticleCellView.m
+++ b/Vienna/Sources/Main window/ArticleCellView.m
@@ -16,7 +16,6 @@
 #define PROGRESS_INDICATOR_DIMENSION_REGULAR 24
 
 @implementation ArticleCellView {
-    AppController *controller;
     BOOL inProgress;
     NSInteger folderId;
     NSUInteger articleRow;
@@ -34,7 +33,6 @@
 -(instancetype)initWithFrame:(NSRect)frameRect
 {
 	if ((self = [super initWithFrame:frameRect])) {
-		controller = APPCONTROLLER;
         [self initializeWebKitArticleView:frameRect];
 
 		[self setInProgress:NO];
@@ -136,7 +134,7 @@
     if ([webView isEqualTo:((WebKitArticleView *)self.articleView)]) {
         [self setInProgress:NO];
         NSUInteger row = self.articleRow;
-        NSArray *allArticles = self->controller.articleController.allArticles;
+        NSArray *allArticles = self.articleController.allArticles;
         if (row < (NSInteger)allArticles.count) {
             [self.listView reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
         }
@@ -160,7 +158,7 @@
     if ([webView isEqualTo:((WebKitArticleView *)self.articleView)]) {
         [self setInProgress:NO];
         NSUInteger row = self.articleRow;
-        NSArray *allArticles = self->controller.articleController.allArticles;
+        NSArray *allArticles = self.articleController.allArticles;
         if (row < (NSInteger)allArticles.count) {
             [self.listView reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
         }
@@ -176,8 +174,8 @@
 {
     if ([webView isEqualTo:((WebKitArticleView *)self.articleView)]) {
         NSUInteger row = [self.listView rowForView:self];
-        if (row == self.articleRow && row < self->controller.articleController.allArticles.count
-            && self.folderId == [self->controller.articleController.allArticles[row] folderId])
+        if (row == self.articleRow && row < self.articleController.allArticles.count
+            && self.folderId == [self.articleController.allArticles[row] folderId])
         {    //relevant cell
             [webView evaluateJavaScript:@"document.documentElement.offsetHeight"
                       completionHandler:^(id _Nullable result, NSError *_Nullable error) {
@@ -196,7 +194,7 @@
                       }];
         } else { //non relevant cell
             [self setInProgress:NO];
-            if (row < self->controller.articleController.allArticles.count) {
+            if (row < self.articleController.allArticles.count) {
                 [self.listView reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
             }
             WebKitArticleView *articleView = (WebKitArticleView *)(self.articleView);

--- a/Vienna/Sources/Main window/ArticleListView.h
+++ b/Vienna/Sources/Main window/ArticleListView.h
@@ -25,7 +25,13 @@
 #import "ArticleViewDelegate.h"
 #import "MessageListView.h"
 
+@class AppController;
+@class ArticleController;
+
 @interface ArticleListView : NSView <BaseView, ArticleBaseView, ArticleViewDelegate, MessageListViewDelegate, NSTableViewDataSource, ExtendedTableViewDelegate, NSSplitViewDelegate>
+
+@property (weak, nonatomic) AppController *appController;
+@property (weak, nonatomic) ArticleController *articleController;
 
 // Public functions
 -(void)updateVisibleColumns;

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -313,7 +313,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 	NSInteger row = articleList.clickedRow;
 	NSInteger column = articleList.clickedColumn;
-	NSArray * allArticles = self.controller.articleController.allArticles;
+	NSArray * allArticles = self.articleController.allArticles;
 	
 	if (row >= 0 && row < (NSInteger)allArticles.count) {
 		NSArray * columns = articleList.tableColumns;
@@ -321,11 +321,11 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 			Article * theArticle = allArticles[row];
 			NSString * columnName = ((NSTableColumn *)columns[column]).identifier;
 			if ([columnName isEqualToString:MA_Field_Read]) {
-				[self.controller.articleController markReadByArray:@[theArticle] readFlag:!theArticle.isRead];
+				[self.articleController markReadByArray:@[theArticle] readFlag:!theArticle.isRead];
 				return;
 			}
 			if ([columnName isEqualToString:MA_Field_Flagged]) {
-				[self.controller.articleController markFlaggedByArray:@[theArticle] flagged:!theArticle.isFlagged];
+				[self.articleController markFlaggedByArray:@[theArticle] flagged:!theArticle.isFlagged];
 				return;
 			}
 			if ([columnName isEqualToString:MA_Field_HasEnclosure]) {
@@ -344,8 +344,8 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 	NSInteger clickedRow = articleList.clickedRow;
 	if (clickedRow != -1) {
-		Article * theArticle = self.controller.articleController.allArticles[clickedRow];
-		[self.controller openURLFromString:theArticle.link inPreferredBrowser:YES];
+		Article * theArticle = self.articleController.allArticles[clickedRow];
+		[self.appController openURLFromString:theArticle.link inPreferredBrowser:YES];
 	}
 }
 
@@ -512,7 +512,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	
 	// Remember the current folder and article
     NSString * guid = self.selectedArticle.guid;
-	[prefs setInteger:self.controller.articleController.currentFolderId forKey:MAPref_CachedFolderID];
+	[prefs setInteger:self.articleController.currentFolderId forKey:MAPref_CachedFolderID];
 	[prefs setString:(guid != nil ? guid : @"") forKey:MAPref_CachedArticleGUID];
 
 	// An array we need for the settings
@@ -596,7 +596,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)showSortDirection
 {
-	NSString * sortColumnIdentifier = self.controller.articleController.sortColumnIdentifier;
+	NSString * sortColumnIdentifier = self.articleController.sortColumnIdentifier;
 
     if (!sortColumnIdentifier) {
         sortColumnIdentifier = [Preferences.standardPreferences stringForKey:MAPref_SortColumn];
@@ -623,7 +623,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 	if (guid != nil) {
 		NSInteger rowIndex = 0;
-		for (Article * thisArticle in self.controller.articleController.allArticles) {
+		for (Article * thisArticle in self.articleController.allArticles) {
 			if ([thisArticle.guid isEqualToString:guid]) {
 				[self makeRowSelectedAndVisible:rowIndex];
 				return;
@@ -659,7 +659,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(BOOL)canGoForward
 {
-	return self.controller.articleController.canGoForward;
+	return self.articleController.canGoForward;
 }
 
 /* canGoBack
@@ -667,7 +667,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(BOOL)canGoBack
 {
-	return self.controller.articleController.canGoBack;
+	return self.articleController.canGoBack;
 }
 
 /* handleGoForward
@@ -675,7 +675,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(IBAction)handleGoForward:(id)sender
 {
-	[self.controller.articleController goForward];
+	[self.articleController goForward];
 }
 
 /* handleGoBack
@@ -683,7 +683,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(IBAction)handleGoBack:(id)sender
 {
-	[self.controller.articleController goBack];
+	[self.articleController goBack];
 }
 
 /* makeTextStandardSize
@@ -752,7 +752,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags
 {
-	return [self.controller handleKeyDown:keyChar withFlags:flags];
+	return [self.appController handleKeyDown:keyChar withFlags:flags];
 }
 
 /* selectedArticle
@@ -761,7 +761,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 -(Article *)selectedArticle
 {
 	NSInteger currentSelectedRow = articleList.selectedRow;
-	return (currentSelectedRow >= 0 && currentSelectedRow < self.controller.articleController.allArticles.count) ? self.controller.articleController.allArticles[currentSelectedRow] : nil;
+	return (currentSelectedRow >= 0 && currentSelectedRow < self.articleController.allArticles.count) ? self.articleController.allArticles[currentSelectedRow] : nil;
 }
 
 /* printDocument
@@ -778,7 +778,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 -(void)handleArticleListFontChange:(NSNotification *)note
 {
 	[self setTableViewFont];
-	if (self == self.controller.articleController.mainArticleView) {
+	if (self == self.articleController.mainArticleView) {
 		[articleList reloadData];
 	}
 }
@@ -788,7 +788,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)handleLoadFullHTMLChange:(NSNotification *)note
 {
-	if (self == self.controller.articleController.mainArticleView) {
+	if (self == self.articleController.mainArticleView) {
 		[self refreshArticlePane];
 	}
 }
@@ -798,7 +798,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)handleReadingPaneChange:(NSNotification *)notification
 {
-	if (self == self.controller.articleController.mainArticleView) {
+	if (self == self.articleController.mainArticleView) {
 		[self setOrientation:[Preferences standardPreferences].layout];
 		[self updateVisibleColumns];
 		[articleList reloadData];
@@ -810,7 +810,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)handleStyleChange:(NSNotification *)notification
 {
-    if (self == self.controller.articleController.mainArticleView) {
+    if (self == self.articleController.mainArticleView) {
         [self performSelector:@selector(refreshArticleAtCurrentRow) withObject:nil afterDelay:0.0];
     }
 }
@@ -846,7 +846,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)makeRowSelectedAndVisible:(NSInteger)rowIndex
 {
-	if (self.controller.articleController.allArticles.count == 0u) {
+	if (self.articleController.allArticles.count == 0u) {
 		[articleList deselectAll:self];
 	} else if (rowIndex != articleList.selectedRow) {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
@@ -884,7 +884,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		currentRow = 0;
 	}
 	
-	NSArray * allArticles = self.controller.articleController.allArticles;
+	NSArray * allArticles = self.articleController.allArticles;
 	NSInteger totalRows = allArticles.count;
 	Article * theArticle;
 	while (currentRow < totalRows) {
@@ -928,7 +928,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 	BOOL result = [self viewNextUnreadInCurrentFolder:-1];
 	if (!result) {
-		NSInteger count = self.controller.articleController.allArticles.count;
+		NSInteger count = self.articleController.allArticles.count;
 		if (count > 0) {
 			[self makeRowSelectedAndVisible:0];
 		}
@@ -941,7 +941,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
     if (articleText.canScrollDown) {
         [(NSView *)articleText scrollPageDown:nil];
     } else {
-        ArticleController * articleController = self.controller.articleController;
+        ArticleController * articleController = self.articleController;
         [articleController markReadByArray:self.markedArticleRange readFlag:YES];
         [articleController displayNextUnread];
     }
@@ -952,7 +952,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
     if (articleText.canScrollUp) {
         [(NSView *)articleText scrollPageUp:nil];
     } else {
-        [self.controller.articleController goBack];
+        [self.articleController goBack];
     }
 }
 
@@ -961,13 +961,13 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)performFindPanelAction:(NSInteger)actionTag
 {
-	[self.controller.articleController reloadArrayOfArticles];
+	[self.articleController reloadArrayOfArticles];
 	
 	// This action is send continuously by the filter field, so make sure not the mark read while searching
-    if (articleList.selectedRow < 0 && self.controller.articleController.allArticles.count > 0 ) {
+    if (articleList.selectedRow < 0 && self.articleController.allArticles.count > 0 ) {
 		BOOL shouldSelectArticle = YES;
 		if ([Preferences standardPreferences].markReadInterval > 0.0f) {
-			Article * article = self.controller.articleController.allArticles[0u];
+			Article * article = self.articleController.allArticles[0u];
             if (!article.isRead) {
 				shouldSelectArticle = NO;
             }
@@ -993,11 +993,11 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
         case VNARefreshRedrawList:
             break;
         case VNARefreshReapplyFilter:
-            [self.controller.articleController refilterArrayOfArticles];
-            [self.controller.articleController sortArticles];
+            [self.articleController refilterArrayOfArticles];
+            [self.articleController sortArticles];
             break;
         case VNARefreshSortAndRedraw:
-            [self.controller.articleController sortArticles];
+            [self.articleController sortArticles];
             [self showSortDirection];
             break;
     }
@@ -1042,7 +1042,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 		
 		// Add this to the backtrack list
         NSString * guid = article.guid;
-		[self.controller.articleController addBacktrack:guid];
+		[self.articleController addBacktrack:guid];
 	}
 }
 
@@ -1051,7 +1051,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)handleRefreshArticle:(NSNotification *)nc
 {
-	if (self == self.controller.articleController.mainArticleView && !isAppInitialising) {
+	if (self == self.articleController.mainArticleView && !isAppInitialising) {
 		[self refreshArticlePane];
 	}
 }
@@ -1158,7 +1158,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 {
 	Article * theArticle = self.selectedArticle;
 	if (theArticle != nil && !theArticle.isRead && ![Database sharedManager].readOnly) {
-		[self.controller.articleController markReadByArray:@[theArticle] readFlag:YES];
+		[self.articleController markReadByArray:@[theArticle] readFlag:YES];
 	}
 }
 
@@ -1168,7 +1168,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView
 {
-	return self.controller.articleController.allArticles.count;
+	return self.articleController.allArticles.count;
 }
 
 /* objectValueForTableColumn [datasource]
@@ -1178,7 +1178,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 -(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex
 {
 	Database * db = [Database sharedManager];
-	NSArray * allArticles = self.controller.articleController.allArticles;
+	NSArray * allArticles = self.articleController.allArticles;
 	Article * theArticle;
 	
 	if(rowIndex < 0 || rowIndex >= allArticles.count) {
@@ -1392,7 +1392,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 -(void)tableView:(NSTableView *)tableView didClickTableColumn:(NSTableColumn *)tableColumn
 {
 	NSString * columnName = tableColumn.identifier;
-	[self.controller.articleController sortByIdentifier:columnName];
+	[self.articleController sortByIdentifier:columnName];
 	[self showSortDirection];
 }
 
@@ -1484,7 +1484,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound) {
-		Article * thisArticle = self.controller.articleController.allArticles[msgIndex];
+		Article * thisArticle = self.articleController.allArticles[msgIndex];
 		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
 		NSString * msgTitle = thisArticle.title;
@@ -1544,7 +1544,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 
 		articleArray = [NSMutableArray arrayWithCapacity:rowIndexes.count];
 		while (rowIndex != NSNotFound) {
-			[articleArray addObject:self.controller.articleController.allArticles[rowIndex]];
+			[articleArray addObject:self.articleController.allArticles[rowIndex]];
 			rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
 		}
 	}
@@ -1595,7 +1595,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 
     if ([keyPath isEqualToString:MAPref_ShowUnreadArticlesInBold]) {
         [self setTableViewFont];
-        if (self == self.controller.articleController.mainArticleView) {
+        if (self == self.articleController.mainArticleView) {
             [articleList reloadData];
         }
     }
@@ -1606,7 +1606,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 // MARK: ArticleView delegate
 
 @synthesize error;
-@synthesize controller;
 
 - (void)startMainFrameLoad
 {
@@ -1626,7 +1625,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 // MARK: splitView2 & main window's splitView delegate
 
 - (void)splitViewWillResizeSubviews:(NSNotification *)notification {
-    if (self != APPCONTROLLER.articleController.mainArticleView) {
+    if (self != self.articleController.mainArticleView) {
         return;
     }
     NSDictionary * info = notification.userInfo;
@@ -1645,7 +1644,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 }
 
 - (void)splitViewDidResizeSubviews:(NSNotification *)notification {
-    if (self != APPCONTROLLER.articleController.mainArticleView) {
+    if (self != self.articleController.mainArticleView) {
         return;
     }
     // update constraint

--- a/Vienna/Sources/Main window/ArticleViewDelegate.h
+++ b/Vienna/Sources/Main window/ArticleViewDelegate.h
@@ -19,14 +19,11 @@
 
 @import Foundation;
 
-@class AppController;
-
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ArticleViewDelegate <NSObject>
 
 @property (nullable) NSError *error;
-@property AppController *controller;
 @property (getter=isCurrentPageFullHTML, readonly) BOOL currentPageFullHTML;
 
 - (void)startMainFrameLoad;

--- a/Vienna/Sources/Main window/UnifiedDisplayView.h
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.h
@@ -23,10 +23,12 @@
 #import "MessageListView.h"
 
 @class AppController;
+@class ArticleController;
 
 @interface UnifiedDisplayView : NSView <BaseView, ArticleBaseView, NSMenuItemValidation, MessageListViewDelegate, NSTableViewDataSource, ExtendedTableViewDelegate>
 
-@property (weak, nonatomic) AppController *controller;
+@property (weak, nonatomic) AppController *appController;
+@property (weak, nonatomic) ArticleController *articleController;
 
 // Public functions
 -(void)saveTableSettings;

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -210,7 +210,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 {
 	if (guid != nil) {
 		NSInteger rowIndex = 0;
-		for (Article * thisArticle in self.controller.articleController.allArticles) {
+		for (Article * thisArticle in self.articleController.allArticles) {
 			if ([thisArticle.guid isEqualToString:guid]) {
 				[self makeRowSelectedAndVisible:rowIndex];
 				return;
@@ -240,13 +240,13 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(void)performFindPanelAction:(NSInteger)actionTag
 {
-	[self.controller.articleController reloadArrayOfArticles];
+	[self.articleController reloadArrayOfArticles];
 
 	// make sure to not change the mark read while searching
-    if (articleList.selectedRow < 0 && self.controller.articleController.allArticles.count > 0 ) {
+    if (articleList.selectedRow < 0 && self.articleController.allArticles.count > 0 ) {
 		BOOL shouldSelectArticle = YES;
 		if ([Preferences standardPreferences].markReadInterval > 0.0f) {
-			Article * article = self.controller.articleController.allArticles[0u];
+			Article * article = self.articleController.allArticles[0u];
 			if (!article.isRead) {
 				shouldSelectArticle = NO;
 			}
@@ -297,7 +297,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 
 	// Remember the current folder and article
     NSString * guid = self.selectedArticle.guid;
-	[prefs setInteger:self.controller.articleController.currentFolderId forKey:MAPref_CachedFolderID];
+	[prefs setInteger:self.articleController.currentFolderId forKey:MAPref_CachedFolderID];
 	[prefs setString:(guid != nil ? guid : @"") forKey:MAPref_CachedArticleGUID];
 }
 
@@ -307,7 +307,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags
 {
-	return [self.controller handleKeyDown:keyChar withFlags:flags];
+	return [self.appController handleKeyDown:keyChar withFlags:flags];
 }
 
 /* canDeleteMessageAtRow
@@ -324,7 +324,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 -(Article *)selectedArticle
 {
 	NSInteger currentSelectedRow = articleList.selectedRow;
-	return (currentSelectedRow >= 0 && currentSelectedRow < self.controller.articleController.allArticles.count) ? self.controller.articleController.allArticles[currentSelectedRow] : nil;
+	return (currentSelectedRow >= 0 && currentSelectedRow < self.articleController.allArticles.count) ? self.articleController.allArticles[currentSelectedRow] : nil;
 }
 
 /* printDocument
@@ -340,7 +340,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(void)handleReadingPaneChange:(NSNotification *)notification
 {
-	if (self == self.controller.articleController.mainArticleView) {
+	if (self == self.articleController.mainArticleView) {
 		[articleList reloadData];
 	}
 }
@@ -350,7 +350,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(void)handleStyleChange:(NSNotification *)notification
 {
-    if (self == self.controller.articleController.mainArticleView) {
+    if (self == self.articleController.mainArticleView) {
         [articleList performSelector:@selector(reloadData) withObject:nil afterDelay:0.0];
     }
 }
@@ -361,7 +361,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(void)makeRowSelectedAndVisible:(NSInteger)rowIndex
 {
-	if (self.controller.articleController.allArticles.count == 0u) {
+	if (self.articleController.allArticles.count == 0u) {
 		[articleList deselectAll:self];
 	} else {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:rowIndex] byExtendingSelection:NO];
@@ -388,7 +388,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 		currentRow = 0;
 	}
 
-	NSArray * allArticles = self.controller.articleController.allArticles;
+	NSArray * allArticles = self.articleController.allArticles;
 	NSInteger totalRows = allArticles.count;
 	Article * theArticle;
 	while (currentRow < totalRows) {
@@ -410,7 +410,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 {
 	BOOL result = [self viewNextUnreadInCurrentFolder:-1];
 	if (!result) {
-		NSInteger count = self.controller.articleController.allArticles.count;
+		NSInteger count = self.articleController.allArticles.count;
 		if (count > 0) {
 			[self makeRowSelectedAndVisible:0];
 		}
@@ -431,7 +431,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
         [scrollView reflectScrolledClipView:[scrollView contentView]];
         [NSAnimationContext endGrouping];
     } else {
-        [self.controller skipFolder:nil];
+        [self.appController skipFolder:nil];
     }
 }
 
@@ -448,7 +448,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
         [scrollView reflectScrolledClipView:[scrollView contentView]];
         [NSAnimationContext endGrouping];
     } else {
-        [self.controller.articleController goBack];
+        [self.articleController goBack];
     }
 }
 
@@ -465,11 +465,11 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
         case VNARefreshRedrawList:
             break;
         case VNARefreshReapplyFilter:
-            [self.controller.articleController refilterArrayOfArticles];
-            [self.controller.articleController sortArticles];
+            [self.articleController refilterArrayOfArticles];
+            [self.articleController sortArticles];
             break;
         case VNARefreshSortAndRedraw:
-            [self.controller.articleController sortArticles];
+            [self.articleController sortArticles];
             break;
     }
 
@@ -484,7 +484,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 {
 	Article * theArticle = self.selectedArticle;
 	if (theArticle != nil && !theArticle.isRead && ![Database sharedManager].readOnly) {
-		[self.controller.articleController markReadByArray:@[theArticle] readFlag:YES];
+		[self.articleController markReadByArray:@[theArticle] readFlag:YES];
 	}
 }
 
@@ -497,7 +497,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(NSInteger)numberOfRowsInTableView:(NSTableView*)aTableView
 {
-	return self.controller.articleController.allArticles.count;
+	return self.articleController.allArticles.count;
 }
 
 - (CGFloat)tableView:(NSTableView *)aListView heightOfRow:(NSInteger)row
@@ -540,7 +540,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
         self.statusBar.label = nil;
 	}
 
-	NSArray * allArticles = self.controller.articleController.allArticles;
+	NSArray * allArticles = self.articleController.allArticles;
 	if (row < 0 || row >= allArticles.count) {
 	    return nil;
 	}
@@ -548,6 +548,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 	Article * theArticle = allArticles[row];
 	NSInteger articleFolderId = theArticle.folderId;
 
+	cellView.articleController = self.articleController;
 	cellView.folderId = articleFolderId;
 	cellView.articleRow = row;
 	cellView.listView = articleList;
@@ -626,7 +627,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound) {
-		Article * thisArticle = self.controller.articleController.allArticles[msgIndex];
+		Article * thisArticle = self.articleController.allArticles[msgIndex];
 		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
 		NSString * msgTitle = thisArticle.title;
@@ -697,7 +698,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(IBAction)delete:(id)sender
 {
-	[APPCONTROLLER deleteMessage:self];
+	[self.appController deleteMessage:self];
 }
 
 /* validateMenuItem
@@ -730,7 +731,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 
 		articleArray = [NSMutableArray arrayWithCapacity:rowIndexes.count];
 		while (rowIndex != NSNotFound) {
-			[articleArray addObject:self.controller.articleController.allArticles[rowIndex]];
+			[articleArray addObject:self.articleController.allArticles[rowIndex]];
 			rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
 		}
 	}
@@ -748,9 +749,9 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 -(BOOL)becomeFirstResponder
 {
     NSInteger currentSelectedRow = articleList.selectedRow;
-	if (currentSelectedRow >= 0 && currentSelectedRow < self.controller.articleController.allArticles.count) {
+	if (currentSelectedRow >= 0 && currentSelectedRow < self.articleController.allArticles.count) {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:currentSelectedRow] byExtendingSelection:NO];
-    } else if (self.controller.articleController.allArticles.count != 0u) {
+    } else if (self.articleController.allArticles.count != 0u) {
 		[articleList selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
     }
 	[NSApp.mainWindow makeFirstResponder:articleList];
@@ -765,7 +766,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 {
 	if (theEvent.characters.length == 1) {
 		unichar keyChar = [theEvent.characters characterAtIndex:0];
-		if ([self.controller handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
+		if ([self.appController handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
 			return;
 		}
 	}


### PR DESCRIPTION
This removes the public ArticleController property on AppController. The objects that relied on this property get their own ArticleController property. This needs further improvements, maybe a delegate pattern, but I decided not to do more here, because it might be worth exploring using a hierarchy of view controllers (especially important for NSStoryboard).