### PR TITLE
Decouple more ArticleController code from AppController 

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		F6B7BC3624A2A9A40051D76F /* FMDB in Frameworks */ = {isa = PBXBuildFile; productRef = F6B7BC3524A2A9A40051D76F /* FMDB */; };
 		F6C136582D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss in Resources */ = {isa = PBXBuildFile; fileRef = F6C136572D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss */; };
 		F6C1365A2D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss in Resources */ = {isa = PBXBuildFile; fileRef = F6C136592D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss */; };
+		F6C983002E11ABD4005BA1F8 /* NSResponder+EventHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C982FF2E11ABD4005BA1F8 /* NSResponder+EventHandler.m */; };
 		F6C9DA70271BB3BB00FC3027 /* RSSFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C9DA6F271BB3BB00FC3027 /* RSSFeed.m */; };
 		F6C9DA73271BB55000FC3027 /* AtomFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C9DA72271BB55000FC3027 /* AtomFeed.m */; };
 		F6CAA59A2C5D87BA00590858 /* ActionPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = F6CAA5992C5D87BA00590858 /* ActionPlugin.m */; };
@@ -617,6 +618,8 @@
 		F6BD1FDD2C9D7E2E0075D04F /* LICENCE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENCE.md; sourceTree = "<group>"; };
 		F6C136572D01C0D0009E42F8 /* RSSFeedWithItemElementUnderRSSElement.rss */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = RSSFeedWithItemElementUnderRSSElement.rss; sourceTree = "<group>"; };
 		F6C136592D01C3E2009E42F8 /* RSSFeedWithItemElementUnderRSSAndChannelElement.rss */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = RSSFeedWithItemElementUnderRSSAndChannelElement.rss; sourceTree = "<group>"; };
+		F6C982FE2E11ABD4005BA1F8 /* NSResponder+EventHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSResponder+EventHandler.h"; sourceTree = "<group>"; };
+		F6C982FF2E11ABD4005BA1F8 /* NSResponder+EventHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSResponder+EventHandler.m"; sourceTree = "<group>"; };
 		F6C9DA6E271BB3BB00FC3027 /* RSSFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSSFeed.h; sourceTree = "<group>"; };
 		F6C9DA6F271BB3BB00FC3027 /* RSSFeed.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSSFeed.m; sourceTree = "<group>"; };
 		F6C9DA71271BB55000FC3027 /* AtomFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AtomFeed.h; sourceTree = "<group>"; };
@@ -1377,6 +1380,8 @@
 				F6A464BA272F47BE0071E3F6 /* NSKeyedUnarchiver+Compatibility.m */,
 				3A23F13315276935008AF863 /* NSNotificationAdditions.h */,
 				4350283D165DE7F60018EDB7 /* NSNotificationAdditions.m */,
+				F6C982FE2E11ABD4005BA1F8 /* NSResponder+EventHandler.h */,
+				F6C982FF2E11ABD4005BA1F8 /* NSResponder+EventHandler.m */,
 				AAF3B14006095E7B0025CC7F /* StringExtensions.h */,
 				AAF3B14106095E7B0025CC7F /* StringExtensions.m */,
 				031E082E19DFA3A900194F9F /* SubscriptionModel.h */,
@@ -1824,6 +1829,7 @@
 				F6D282621F1A87A900FF865E /* PopUpButtonToolbarItem.swift in Sources */,
 				435026E6165DD8BE0018EDB7 /* ArticleRef.m in Sources */,
 				F6D0089C1EF95C9D008F2D3B /* InfoPanelManager.m in Sources */,
+				F6C983002E11ABD4005BA1F8 /* NSResponder+EventHandler.m in Sources */,
 				F6C9DA73271BB55000FC3027 /* AtomFeed.m in Sources */,
 				4350283E165DE7F60018EDB7 /* NSNotificationAdditions.m in Sources */,
 				2FEA5829291FD511008C42D3 /* Criteria+NSPredicate.swift in Sources */,

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		F6A7DE381E47138B0017BE5E /* Vienna.html in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE321E47138B0017BE5E /* Vienna.html */; };
 		F6A7DE4A1E4717970017BE5E /* shared in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DE491E4717970017BE5E /* shared */; };
 		F6A7DE4F1E471A7F0017BE5E /* Vienna.help in Resources */ = {isa = PBXBuildFile; fileRef = F6A7DDCA1E470E980017BE5E /* Vienna.help */; };
+		F6A82C172E1584F300B26F6C /* ArticleListConstants.h in Sources */ = {isa = PBXBuildFile; fileRef = F6A82C162E1584F300B26F6C /* ArticleListConstants.h */; };
 		F6AC41AC25A4FAF6007DED7B /* FeedDiscovererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AC41AB25A4FAF6007DED7B /* FeedDiscovererTests.swift */; };
 		F6AFC16D2CAFCD2E00106E80 /* SettingsTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AFC16C2CAFCD2E00106E80 /* SettingsTabViewController.swift */; };
 		F6B059E02961D0A100F6E31B /* JSONFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B059DF2961D0A000F6E31B /* JSONFeed.swift */; };
@@ -603,6 +604,7 @@
 		F6A7DEA61E471E3C0017BE5E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = nl; path = nl.lproj/advanced.html; sourceTree = "<group>"; };
 		F6A7DEAA1E471E410017BE5E /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = sv; path = sv.lproj/advanced.html; sourceTree = "<group>"; };
 		F6A7DEAD1E471E450017BE5E /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "zh-Hant"; path = "zh-Hant.lproj/advanced.html"; sourceTree = "<group>"; };
+		F6A82C162E1584F300B26F6C /* ArticleListConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArticleListConstants.h; sourceTree = "<group>"; };
 		F6AC41AB25A4FAF6007DED7B /* FeedDiscovererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDiscovererTests.swift; sourceTree = "<group>"; };
 		F6AFC16C2CAFCD2E00106E80 /* SettingsTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTabViewController.swift; sourceTree = "<group>"; };
 		F6B059DF2961D0A000F6E31B /* JSONFeed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONFeed.swift; sourceTree = "<group>"; };
@@ -1055,6 +1057,7 @@
 				4350284E165DE9DF0018EDB7 /* ArticleController.h */,
 				4350284F165DE9DF0018EDB7 /* ArticleController.m */,
 				4350284D165DE9DF0018EDB7 /* ArticleBaseView.h */,
+				F6A82C162E1584F300B26F6C /* ArticleListConstants.h */,
 				43502852165DE9DF0018EDB7 /* ArticleListView.h */,
 				43502853165DE9DF0018EDB7 /* ArticleListView.m */,
 				43502885165DE9DF0018EDB7 /* EnclosureView.h */,
@@ -1833,6 +1836,7 @@
 				F6C9DA73271BB55000FC3027 /* AtomFeed.m in Sources */,
 				4350283E165DE7F60018EDB7 /* NSNotificationAdditions.m in Sources */,
 				2FEA5829291FD511008C42D3 /* Criteria+NSPredicate.swift in Sources */,
+				F6A82C172E1584F300B26F6C /* ArticleListConstants.h in Sources */,
 				2F82DCB725CEFC2800F00EE8 /* URL+Blank.swift in Sources */,
 				F633157626ED73CB008A3673 /* URLFormatter.swift in Sources */,
 				F6CAA5A42C5D8B9A00590858 /* ScriptPlugin.m in Sources */,

--- a/Vienna/Interfaces/Base.lproj/MainWindowController.xib
+++ b/Vienna/Interfaces/Base.lproj/MainWindowController.xib
@@ -10,10 +10,6 @@
         <customObject id="-2" userLabel="Window Controller" customClass="MainWindowController" customModule="Vienna" customModuleProvider="target">
             <connections>
                 <outlet property="articleListView" destination="971" id="OE4-G3-4mz"/>
-                <outlet property="filterDisclosureView" destination="cTN-D0-dY2" id="sKF-FL-hKC"/>
-                <outlet property="filterDisclosureView2" destination="jsc-Kj-wj8" id="Zjf-Wd-fF4"/>
-                <outlet property="filterSearchField" destination="1304" id="n8w-oi-CCg"/>
-                <outlet property="filterSearchField2" destination="a7v-eM-oW1" id="1gv-eS-8ME"/>
                 <outlet property="outlineView" destination="Kk7-ax-B3r" id="bhW-7c-vBp"/>
                 <outlet property="placeholderDetailView" destination="9MG-Tu-1xT" id="hUt-Ea-jcm"/>
                 <outlet property="splitView" destination="993" id="adu-5b-ldR"/>
@@ -682,6 +678,7 @@
                                     </constraints>
                                     <connections>
                                         <outlet property="filterByLabel" destination="1305" id="Toc-r7-JYz"/>
+                                        <outlet property="filterSearchField" destination="1304" id="y4g-c6-bjr"/>
                                         <outlet property="filterViewPopUp" destination="1306" id="1322"/>
                                     </connections>
                                 </visualEffectView>
@@ -757,6 +754,8 @@
                 <outlet property="articleList" destination="977" id="996"/>
                 <outlet property="contentStackView" destination="rHW-hk-9Of" id="oce-W6-yQd"/>
                 <outlet property="enclosureView" destination="1288" id="1296"/>
+                <outlet property="filterBarDisclosureView" destination="cTN-D0-dY2" id="qZr-ua-Z8z"/>
+                <outlet property="filterBarView" destination="1300" id="zs8-c4-p8E"/>
                 <outlet property="splitView2" destination="972" id="998"/>
             </connections>
             <point key="canvasLocation" x="1065.5" y="-628.5"/>
@@ -896,6 +895,7 @@
                                     </constraints>
                                     <connections>
                                         <outlet property="filterByLabel" destination="FDm-UJ-4O9" id="u9z-Rg-07U"/>
+                                        <outlet property="filterSearchField" destination="a7v-eM-oW1" id="mVr-ga-JOc"/>
                                         <outlet property="filterViewPopUp" destination="Ymd-v7-5ML" id="v4W-E6-1vU"/>
                                     </connections>
                                 </visualEffectView>
@@ -970,6 +970,8 @@
             </constraints>
             <connections>
                 <outlet property="articleList" destination="NgO-hM-mCz" id="x5w-1V-UjV"/>
+                <outlet property="filterBarDisclosureView" destination="jsc-Kj-wj8" id="BQJ-3w-VaI"/>
+                <outlet property="filterBarView" destination="oq7-In-wpt" id="Rok-UH-lSc"/>
             </connections>
             <point key="canvasLocation" x="1066" y="109"/>
         </customView>

--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -31,8 +31,6 @@
 @class SearchMethod;
 @class Database;
 @class Article;
-@class UnifiedDisplayView;
-@class ArticleListView;
 @protocol Browser;
 
 @interface AppController : NSObject <NSApplicationDelegate> {
@@ -43,8 +41,6 @@
 @property (nonatomic) IBOutlet SPUStandardUpdaterController *sparkleController;
 @property (nonatomic) PluginManager *pluginManager;
 @property (nonatomic, weak) id<Browser> browser;
-@property (nonatomic, weak) UnifiedDisplayView *unifiedListView;
-@property (nonatomic, weak) ArticleListView *articleListView;
 @property (nonatomic) NewSubscription *rssFeed;
 @property (nonatomic) FoldersTree *foldersTree;
 @property (readonly, nonatomic) NSMenu *searchFieldMenu;
@@ -103,9 +99,6 @@
 -(IBAction)useCurrentStyleForArticles:(id)sender;
 -(IBAction)useWebPageForArticles:(id)sender;
 -(IBAction)keyboardShortcutsHelp:(id)sender;
--(IBAction)unifiedLayout:(id)sender;
--(IBAction)reportLayout:(id)sender;
--(IBAction)condensedLayout:(id)sender;
 -(IBAction)downloadEnclosure:(id)sender;
 -(IBAction)showHideFilterBar:(id)sender;
 -(IBAction)hideFilterBar:(id)sender;
@@ -143,5 +136,8 @@
 -(void)performAllArticlesSearch;
 -(void)performWebPageSearch;
 -(void)searchArticlesWithString:(NSString *)searchString;
+
+// FIXME: Refactor
+- (void)updateFilterBarStateForLayout:(NSInteger)layout;
 
 @end

--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -113,7 +113,7 @@
 -(void)showUnreadCountOnApplicationIconAndWindowTitle;
 -(void)openURLFromString:(NSString *)urlString inPreferredBrowser:(BOOL)openInPreferredBrowserFlag;
 -(void)openURL:(NSURL *)url inPreferredBrowser:(BOOL)openInPreferredBrowserFlag;
--(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags;
+-(BOOL)handleKeyDown:(NSEvent *)event;
 -(void)openURLInDefaultBrowser:(NSURL *)url;
 -(void)handleRSSLink:(NSString *)linkPath;
 -(void)selectFolder:(NSInteger)folderId;

--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -26,7 +26,6 @@
 
 @class FoldersTree;
 @class NewSubscription;
-@class DisclosureView;
 @class PluginManager;
 @class SearchMethod;
 @class Database;
@@ -50,7 +49,6 @@
 -(IBAction)deleteMessage:(id)sender;
 -(IBAction)deleteFolder:(id)sender;
 -(IBAction)searchUsingToolbarTextField:(id)sender;
--(IBAction)searchUsingFilterField:(id)sender;
 -(IBAction)markAllRead:(id)sender;
 -(IBAction)markAllSubscriptionsRead:(id)sender;
 -(IBAction)markUnread:(id)sender;
@@ -100,8 +98,6 @@
 -(IBAction)useWebPageForArticles:(id)sender;
 -(IBAction)keyboardShortcutsHelp:(id)sender;
 -(IBAction)downloadEnclosure:(id)sender;
--(IBAction)showHideFilterBar:(id)sender;
--(IBAction)hideFilterBar:(id)sender;
 -(IBAction)setFocusToSearchField:(id)sender;
 -(IBAction)localPerformFindPanelAction:(id)sender;
 -(IBAction)keepFoldersArranged:(id)sender;
@@ -122,7 +118,6 @@
 -(void)markSelectedFoldersRead:(NSArray *)arrayOfFolders;
 -(void)doSafeInitialisation;
 -(void)clearUndoStack;
-@property (nonatomic, copy) NSString *filterString;
 @property (nonatomic, copy) NSString *searchString;
 @property (nonatomic, readonly) Article *selectedArticle;
 @property (nonatomic, readonly) NSInteger currentFolderId;
@@ -131,13 +126,9 @@
 -(void)runAppleScript:(NSString *)scriptName;
 @property (readonly, nonatomic) NSArray *folders;
 -(void)blogWithExternalEditor:(NSString *)externalEditorBundleIdentifier;
--(void)updateStatusBarFilterButtonVisibility;
 -(void)performWebSearch:(SearchMethod *)searchMethod;
 -(void)performAllArticlesSearch;
 -(void)performWebPageSearch;
 -(void)searchArticlesWithString:(NSString *)searchString;
-
-// FIXME: Refactor
-- (void)updateFilterBarStateForLayout:(NSInteger)layout;
 
 @end

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1847,16 +1847,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			[self setFocusToSearchField:self];
 			return YES;
 			
-// FIXME: Reimplement
-//		case 'f':
-//		case 'F':
-//			if (!self.filterBarVisible) {
-//				[self setPersistedFilterBarState:YES withAnimation:YES];
-//			} else {
-//				[self.mainWindow makeFirstResponder:self.filterSearchField];
-//			}
-//			return YES;
-			
 		case '>':
 		case '.':
 			[self goForward:self];

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1930,8 +1930,13 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  * Support special key codes. If we handle the key, return YES otherwise
  * return NO to allow the framework to pass it on for default processing.
  */
--(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags
+-(BOOL)handleKeyDown:(NSEvent *)event
 {
+    if (event.type != NSEventTypeKeyDown && event.characters.length != 1) {
+        return NO;
+    }
+    unichar keyChar = [event.characters characterAtIndex:0];
+    NSEventModifierFlags flags = event.modifierFlags;
 	switch (keyChar) {
 		case NSLeftArrowFunctionKey:
             if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) {

--- a/Vienna/Sources/Main window/ArticleBaseView.h
+++ b/Vienna/Sources/Main window/ArticleBaseView.h
@@ -22,6 +22,8 @@
 
 @class ArticleView;
 @class Article;
+@class DisclosureView;
+@class FilterView;
 
 @protocol ArticleBaseView
     @property (readonly, nonatomic) BOOL selectFirstUnreadInFolder;
@@ -34,4 +36,8 @@
 	@property (readonly, nonatomic) NSArray *markedArticleRange;
 	-(void)saveTableSettings;
 	-(void)ensureSelectedArticle;
+
+@property (readonly, nonatomic) DisclosureView *filterBarDisclosureView;
+@property (readonly, nonatomic) FilterView *filterBarView;
+
 @end

--- a/Vienna/Sources/Main window/ArticleContentView.swift
+++ b/Vienna/Sources/Main window/ArticleContentView.swift
@@ -13,9 +13,6 @@ protocol ArticleContentView {
     var listView: (any ArticleViewDelegate)? { get set }
     var articles: [Article] { get set }
 
-    @objc(keyDown:)
-    func keyDown(with event: NSEvent)
-
     // MARK: visual settings
 
     func resetTextSize()

--- a/Vienna/Sources/Main window/ArticleController.h
+++ b/Vienna/Sources/Main window/ArticleController.h
@@ -37,7 +37,7 @@
  * article view. Thus all control of the article view now passes through the article
  * controller.
  */
-@interface ArticleController : NSViewController
+@interface ArticleController : NSViewController <NSMenuItemValidation>
 
 @property (nonatomic) FoldersTree * foldersTree;
 @property (nonatomic) ArticleListView *articleListView;
@@ -82,4 +82,9 @@
 -(void)goBack;
 @property (nonatomic, readonly) BOOL canGoForward;
 @property (nonatomic, readonly) BOOL canGoBack;
+
+- (IBAction)reportLayout:(id)sender;
+- (IBAction)condensedLayout:(id)sender;
+- (IBAction)unifiedLayout:(id)sender;
+
 @end

--- a/Vienna/Sources/Main window/ArticleController.h
+++ b/Vienna/Sources/Main window/ArticleController.h
@@ -22,6 +22,7 @@
 
 #import "BaseView.h"
 #import "ArticleBaseView.h"
+#import "ArticleListConstants.h"
 
 @class Article;
 @class ArticleListView;
@@ -61,7 +62,6 @@
 -(void)displayFirstUnread;
 -(void)displayNextUnread;
 -(void)displayNextFolderWithUnread;
-@property (readonly, nonatomic) NSString *searchPlaceholderString;
 -(void)reloadArrayOfArticles;
 -(void)displayFolder:(NSInteger)newFolderId;
 -(void)refilterArrayOfArticles;
@@ -86,5 +86,9 @@
 - (IBAction)reportLayout:(id)sender;
 - (IBAction)condensedLayout:(id)sender;
 - (IBAction)unifiedLayout:(id)sender;
+
+// MARK: Filter bar
+
+@property (readonly, nonatomic) NSString *filterModeLabel;
 
 @end

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -1207,6 +1207,38 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
     }
 }
 
+// MARK: Event handling
+
+- (BOOL)vna_canHandleEvent:(NSEvent *)event
+{
+    if (event.type != NSEventTypeKeyDown && event.characters.length != 1) {
+        return [super vna_canHandleEvent:event];
+    }
+    unichar keyChar = [event.characters characterAtIndex:0];
+    if (keyChar == 'f' || keyChar == 'F') {
+        return YES;
+    }
+    return [super vna_canHandleEvent:event];
+}
+
+- (BOOL)vna_handleEvent:(NSEvent *)event
+{
+    if (event.type != NSEventTypeKeyDown && event.characters.length != 1) {
+        return [super vna_handleEvent:event];
+    }
+    unichar keyChar = [event.characters characterAtIndex:0];
+    if (keyChar == 'f' || keyChar == 'F') {
+        if (self.filterBarDisclosureView.isDisclosed) {
+            [self.view.window makeFirstResponder:self.filterBarSearchField];
+        } else {
+            [self setFilterBarState:YES withAnimation:YES];
+            Preferences.standardPreferences.showFilterBar = YES;
+        }
+        return YES;
+    }
+    return [super vna_handleEvent:event];
+}
+
 // MARK: Key-value observation
 
 - (void)observeValueForKeyPath:(NSString *)keyPath

--- a/Vienna/Sources/Main window/ArticleListConstants.h
+++ b/Vienna/Sources/Main window/ArticleListConstants.h
@@ -1,0 +1,31 @@
+//
+//  ArticleListConstants.h
+//  Vienna
+//
+//  Copyright 2025 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@import Foundation;
+
+/// Filtering options
+typedef NS_ENUM(NSInteger, VNAFilter) {
+    VNAFilterAll,
+    VNAFilterUnread,
+    VNAFilterLastRefresh,
+    VNAFilterToday,
+    VNAFilterTime48h,
+    VNAFilterFlagged,
+    VNAFilterUnreadOrFlagged,
+} NS_SWIFT_NAME(Filter);

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -24,6 +24,7 @@
 #import "Preferences.h"
 #import "Constants.h"
 #import "DateFormatterExtension.h"
+#import "DisclosureView.h"
 #import "ArticleController.h"
 #import "StringExtensions.h"
 #import "HelperFunctions.h"
@@ -43,6 +44,9 @@ NSString * const MAPref_ShowEnclosureBar = @"ShowEnclosureBar";
 static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverContext;
 
 @interface ArticleListView ()
+
+@property (readwrite, nonatomic) IBOutlet DisclosureView *filterBarDisclosureView;
+@property (readwrite, nonatomic) IBOutlet FilterView *filterBarView;
 
 @property (weak, nonatomic) IBOutlet NSStackView *contentStackView;
 @property (weak, nonatomic) IBOutlet EnclosureView *enclosureView;

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -746,15 +746,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	return YES;
 }
 
-/* handleKeyDown [delegate]
- * Support special key codes. If we handle the key, return YES otherwise
- * return NO to allow the framework to pass it on for default processing.
- */
--(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags
-{
-	return [self.appController handleKeyDown:keyChar withFlags:flags];
-}
-
 /* selectedArticle
  * Returns the selected article, or nil if no article is selected.
  */

--- a/Vienna/Sources/Main window/FolderView.m
+++ b/Vienna/Sources/Main window/FolderView.m
@@ -25,6 +25,7 @@
 #import "AppController.h"
 #import "FeedListCellView.h"
 #import "FoldersFilterable.h"
+#import "NSResponder+EventHandler.h"
 
 #define VNA_LOG os_log_create("--", "FolderView")
 
@@ -82,15 +83,12 @@ VNAFeedListRowHeight const VNAFeedListRowHeightMedium = 28.0;
     return [super validateProposedFirstResponder:responder forEvent:event];
 }
 
-- (void)keyDown:(NSEvent *)theEvent
+- (void)keyDown:(NSEvent *)event
 {
-    if (theEvent.characters.length == 1) {
-        unichar keyChar = [theEvent.characters characterAtIndex:0];
-        if ([APPCONTROLLER handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
-            return;
-        }
+    if ([self vna_handleEvent:event]) {
+        return;
     }
-    [super keyDown:theEvent];
+    [super keyDown:event];
 }
 
 - (void)setDataSource:(id<NSOutlineViewDataSource>)aSource

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -21,6 +21,8 @@ import Cocoa
 
 final class MainWindowController: NSWindowController {
 
+    @objc weak var articleController: ArticleController!
+
     // MARK: Transitional outlets
 
     @IBOutlet private(set) var splitView: NSSplitView!
@@ -54,6 +56,13 @@ final class MainWindowController: NSWindowController {
 
         splitView.addSubview(browser.view)
         placeholderDetailView.removeFromSuperview()
+
+        self.articleController.articleListView = self.articleListView
+        self.articleController.unifiedListView = self.unifiedDisplayView
+        self.articleListView?.appController = NSApp.appController
+        self.unifiedDisplayView?.appController = NSApp.appController
+        self.articleListView?.articleController = self.articleController
+        self.unifiedDisplayView?.articleController = self.articleController
     }
 
     // MARK: Subtitle
@@ -254,6 +263,15 @@ final class MainWindowController: NSWindowController {
             sharingService.delegate = self
             sharingService.perform(withItems: shareableItems)
         }
+    }
+
+    // MARK: Responder chain
+
+    override func supplementalTarget(forAction action: Selector, sender: Any?) -> Any? {
+        if self.browser.activeTab == nil && articleController.responds(to: action) {
+            return articleController
+        }
+        return super.supplementalTarget(forAction: action, sender: sender)
     }
 
     // MARK: Observation

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -261,6 +261,13 @@ final class MainWindowController: NSWindowController {
         return super.supplementalTarget(forAction: action, sender: sender)
     }
 
+    override func supplementalHandler(for event: NSEvent) -> NSResponder? {
+        if self.articleController.canHandle(event) {
+            return self.articleController
+        }
+        return self
+    }
+
     override func handle(_ event: NSEvent) -> Bool {
         return NSApp.appController.handleKeyDown(event)
     }

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -29,10 +29,6 @@ final class MainWindowController: NSWindowController {
     @IBOutlet private(set) var outlineView: FolderView?
     @IBOutlet private(set) var articleListView: ArticleListView?
     @IBOutlet private(set) var unifiedDisplayView: UnifiedDisplayView?
-    @IBOutlet private(set) var filterDisclosureView: DisclosureView?
-    @IBOutlet private(set) var filterDisclosureView2: DisclosureView?
-    @IBOutlet private(set) var filterSearchField: NSSearchField?
-    @IBOutlet private(set) var filterSearchField2: NSSearchField?
 
     @objc private(set) var toolbarSearchField: NSSearchField?
     @IBOutlet private(set) weak var placeholderDetailView: NSView!
@@ -160,15 +156,6 @@ final class MainWindowController: NSWindowController {
     }
 
     // MARK: Actions
-
-    @IBAction private func changeFiltering(_ sender: NSMenuItem) { // TODO: This should be handled by ArticleController
-        Preferences.standard.filterMode = sender.tag
-        if sender.tag == Filter.all.rawValue {
-            currentFilter = ""
-        } else {
-            currentFilter = sender.title
-        }
-    }
 
     @IBAction private func toggleStatusBar(_ sender: AnyObject) {
         statusBarState(disclosed: !statusBar.isDisclosed)
@@ -298,9 +285,6 @@ extension MainWindowController: NSMenuItemValidation {
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
-        case #selector(changeFiltering(_:)):
-            menuItem.state = menuItem.tag == Preferences.standard.filterMode ? .on : .off
-            return browser.activeTab == nil
         case #selector(performSharingService(_:)), #selector(invokeSharingServicePicker(_:)):
             return hasShareableItems
         case #selector(toggleStatusBar(_:)):
@@ -349,6 +333,9 @@ extension MainWindowController: NSWindowDelegate {
         }
 
         observationTokens = [
+            articleController.observe(\.filterModeLabel, options: .initial) { [weak self] controller, _ in
+                self?.currentFilter = controller.filterModeLabel
+            },
             OpenReader.shared.observe(\.statusMessage, options: [.initial, .new]) { [weak self] manager, change in
                 if change.newValue is String {
                     self?.statusLabel.stringValue = manager.statusMessage

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -274,6 +274,10 @@ final class MainWindowController: NSWindowController {
         return super.supplementalTarget(forAction: action, sender: sender)
     }
 
+    override func handle(_ event: NSEvent) -> Bool {
+        return NSApp.appController.handleKeyDown(event)
+    }
+
     // MARK: Observation
 
     private var observationTokens: [NSKeyValueObservation] = []

--- a/Vienna/Sources/Main window/MessageListView.h
+++ b/Vienna/Sources/Main window/MessageListView.h
@@ -44,8 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTableColumnHeaderImage:(NSImage *)image
           forColumnWithIdentifier:(NSUserInterfaceItemIdentifier)identifier;
 
-- (void)keyDown:(NSEvent *)theEvent;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -20,6 +20,7 @@
 
 #import "MessageListView.h"
 #import "AppController.h"
+#import "NSResponder+EventHandler.h"
 
 @implementation MessageListView
 
@@ -36,19 +37,12 @@
     tableColumn.dataCell = imageCell;
 }
 
-/* keyDown
- * Here is where we handle special keys when the article list view
- * has the focus so we can do custom things.
- */
--(void)keyDown:(NSEvent *)theEvent
+-(void)keyDown:(NSEvent *)event
 {
-	if (theEvent.characters.length == 1) {
-		unichar keyChar = [theEvent.characters characterAtIndex:0];
-		if ([APPCONTROLLER handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
-			return;
-		}
-	}
-	[super keyDown:theEvent];
+    if ([self vna_handleEvent:event]) {
+        return;
+    }
+    [super keyDown:event];
 }
 
 /* copy

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -22,6 +22,7 @@
 #import "ArticleController.h"
 #import "AppController.h"
 #import "ArticleCellView.h"
+#import "DisclosureView.h"
 #import "Preferences.h"
 #import "Constants.h"
 #import "StringExtensions.h"
@@ -43,6 +44,8 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 
 @interface UnifiedDisplayView () <CustomWKHoverUIDelegate>
 
+@property (readwrite, nonatomic) IBOutlet DisclosureView *filterBarDisclosureView;
+@property (readwrite, nonatomic) IBOutlet FilterView *filterBarView;
 @property (nonatomic) OverlayStatusBar *statusBar;
 
 -(void)initTableView;

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -29,6 +29,7 @@
 #import "Article.h"
 #import "Folder.h"
 #import "Database.h"
+#import "NSResponder+EventHandler.h"
 #import "Vienna-Swift.h"
 
 #define LISTVIEW_CELL_IDENTIFIER		@"ArticleCellView"
@@ -299,15 +300,6 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
     NSString * guid = self.selectedArticle.guid;
 	[prefs setInteger:self.articleController.currentFolderId forKey:MAPref_CachedFolderID];
 	[prefs setString:(guid != nil ? guid : @"") forKey:MAPref_CachedArticleGUID];
-}
-
-/* handleKeyDown [delegate]
- * Support special key codes. If we handle the key, return YES otherwise
- * return NO to allow the framework to pass it on for default processing.
- */
--(BOOL)handleKeyDown:(unichar)keyChar withFlags:(NSUInteger)flags
-{
-	return [self.appController handleKeyDown:keyChar withFlags:flags];
 }
 
 /* canDeleteMessageAtRow
@@ -758,19 +750,12 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
     return YES;
 }
 
-/* keyDown
- * Here is where we handle special keys when this view
- * has the focus so we can do custom things.
- */
--(void)keyDown:(NSEvent *)theEvent
+-(void)keyDown:(NSEvent *)event
 {
-	if (theEvent.characters.length == 1) {
-		unichar keyChar = [theEvent.characters characterAtIndex:0];
-		if ([self.appController handleKeyDown:keyChar withFlags:theEvent.modifierFlags]) {
-			return;
-		}
-	}
-	[self interpretKeyEvents:@[theEvent]];
+    if ([self vna_handleEvent:event]) {
+        return;
+    }
+    [super keyDown:event];
 }
 
 // MARK: Key-value observation

--- a/Vienna/Sources/Main window/WebKitArticleTab.swift
+++ b/Vienna/Sources/Main window/WebKitArticleTab.swift
@@ -113,7 +113,6 @@ class WebKitArticleTab: BrowserTab, ArticleContentView {
             let openInPreferredBrower = !navigationAction.modifierFlags.contains(.option)
             // TODO: maybe we need to add an api that opens a clicked link in foreground to the AppController
             NSApp.appController.open(navigationAction.request.url, inPreferredBrowser: openInPreferredBrower)
-            NSApp.mainWindow?.makeFirstResponder((NSApp.appController.articleListView).mainView)
         } else {
             decisionHandler(.allow)
         }

--- a/Vienna/Sources/Main window/WebKitArticleView.swift
+++ b/Vienna/Sources/Main window/WebKitArticleView.swift
@@ -79,12 +79,8 @@ class WebKitArticleView: CustomWKWebView, ArticleContentView, WKNavigationDelega
                 finishHandler()
             }
         }
-        if interceptKey, let pressedKeys = event.characters, pressedKeys.count == 1 {
-            let pressedKey = (pressedKeys as NSString).character(at: 0)
-            // give app controller preference when handling commands
-            if NSApp.appController.handleKeyDown(pressedKey, withFlags: event.modifierFlags.rawValue) {
-                return
-            }
+        if interceptKey && handle(event) {
+            return
         }
         super.keyDown(with: event)
     }

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -24,6 +24,7 @@
 @import Sparkle;
 
 #import "Article.h"
+#import "ArticleListConstants.h"
 #import "Constants.h"
 #import "DownloadItem.h"
 #import "FeedListConstants.h"
@@ -69,7 +70,6 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
     BOOL useJavaScript;
     BOOL showAppInStatusBar;
     BOOL showStatusBar;
-    BOOL showFilterBar;
     BOOL shouldSaveFeedSource;
     BOOL syncGoogleReader;
     BOOL prefersGoogleNewSubscription;
@@ -135,7 +135,6 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 		textSizeMultiplier = [userPrefs doubleForKey:MAPref_ActiveTextSizeMultiplier];
 		showFolderImages = [self boolForKey:MAPref_ShowFolderImages];
 		showStatusBar = [self boolForKey:MAPref_ShowStatusBar];
-		showFilterBar = [self boolForKey:MAPref_ShowFilterBar];
 		useJavaScript = [self boolForKey:MAPref_UseJavaScript];
 		showAppInStatusBar = [self boolForKey:MAPref_ShowAppInStatusBar];
 		shouldSaveFeedSource = [self boolForKey:MAPref_ShouldSaveFeedSource];
@@ -1002,19 +1001,15 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
  */
 -(BOOL)showFilterBar
 {
-	return showFilterBar;
+    return [self boolForKey:MAPref_ShowFilterBar];
 }
 
 /* setShowFilterBar
  * Specifies whether the filter bar is shown or hidden.
  */
--(void)setShowFilterBar:(BOOL)show
+-(void)setShowFilterBar:(BOOL)showFilterBar
 {
-	if (showFilterBar != show) {
-		showFilterBar = show;
-		[self setBool:showFilterBar forKey:MAPref_ShowFilterBar];
-		[[NSNotificationCenter defaultCenter] postNotificationName:MA_Notify_FilterBarChanged object:nil];
-	}
+    [self setBool:showFilterBar forKey:MAPref_ShowFilterBar];
 }
 
 /* feedSourcesFolder

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -35,7 +35,6 @@ extern NSNotificationName const MA_Notify_ConcurrentDownloadsChange;
 extern NSNotificationName const MA_Notify_DownloadCompleted;
 extern NSNotificationName const MA_Notify_DownloadsListChange;
 extern NSNotificationName const MA_Notify_EditFolder;
-extern NSNotificationName const MA_Notify_FilterBarChanged;
 extern NSNotificationName const MA_Notify_FolderAdded;
 extern NSNotificationName const MA_Notify_FolderDescriptionChanged; // Unused
 extern NSNotificationName const MA_Notify_FolderHomePageChanged; // Unused

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -35,7 +35,6 @@ NSNotificationName const MA_Notify_ConcurrentDownloadsChange = @"MA_Notify_Concu
 NSNotificationName const MA_Notify_DownloadCompleted = @"MA_Notify_DownloadCompleted";
 NSNotificationName const MA_Notify_DownloadsListChange = @"MA_Notify_DownloadsListChange";
 NSNotificationName const MA_Notify_EditFolder = @"MA_Notify_EditFolder";
-NSNotificationName const MA_Notify_FilterBarChanged = @"MA_Notify_FilterBarChanged";
 NSNotificationName const MA_Notify_FolderAdded = @"MA_Notify_FolderAdded";
 NSNotificationName const MA_Notify_FolderDescriptionChanged = @"MA_Notify_FolderDescriptionChanged";
 NSNotificationName const MA_Notify_FolderHomePageChanged = @"MA_Notify_FolderHomePageChanged";

--- a/Vienna/Sources/Shared/Constants.swift
+++ b/Vienna/Sources/Shared/Constants.swift
@@ -23,18 +23,6 @@ enum NewArticlesNotification: Int {
     case bounce = 2
 }
 
-/// Filtering options
-@objc(VNAFilter)
-enum Filter: Int {
-    case all = 0
-    case unread = 1
-    case lastRefresh = 2
-    case today = 3
-    case time48h = 4
-    case flagged = 5
-    case unreadOrFlagged = 6
-}
-
 /// Refresh folder options
 @objc(VNARefresh)
 enum Refresh: Int {

--- a/Vienna/Sources/Shared/NSResponder+EventHandler.h
+++ b/Vienna/Sources/Shared/NSResponder+EventHandler.h
@@ -1,15 +1,14 @@
 //
-//  BaseView.h
+//  NSResponder+EventHandler.h
 //  Vienna
 //
-//  Created by Steve on 5/6/06.
-//  Copyright (c) 2004-2005 Steve Palmer. All rights reserved.
+//  Copyright 2025 Eitot
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+//  https://www.apache.org/licenses/LICENSE-2.0
 //
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,16 +19,12 @@
 
 @import Cocoa;
 
-@protocol BaseView
-@required
-	-(void)performFindPanelAction:(NSInteger)tag;
-	@property (nonatomic, readonly) NSView *mainView;
-@optional
-	-(void)updateAlternateMenuTitle;
-	@property (readonly, nonatomic) NSString *title;
-	-(IBAction)handleGoForward:(id)sender;
-	-(IBAction)handleGoBack:(id)sender;
-	@property (nonatomic, readonly) BOOL canGoForward;
-	@property (nonatomic, readonly) BOOL canGoBack;
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSResponder (EventHandler)
+
+- (BOOL)vna_handleEvent:(NSEvent *)event NS_SWIFT_NAME(handle(_:));
+
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Shared/NSResponder+EventHandler.h
+++ b/Vienna/Sources/Shared/NSResponder+EventHandler.h
@@ -23,7 +23,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSResponder (EventHandler)
 
+/// Handles the event and returns `YES` if handled successfully. The default
+/// implementation first sends `-vna_supplementalHandlerForEvent:` to its next
+/// responder and passes the message to it, if not `nil`. Otherwise, it passes
+/// the message to its next responder recursively, ultimately returning `NO` if
+/// there are no more responders.
 - (BOOL)vna_handleEvent:(NSEvent *)event NS_SWIFT_NAME(handle(_:));
+
+/// Whether the receiver can handle the event. The default implementation
+/// returns `NO`.
+- (BOOL)vna_canHandleEvent:(NSEvent *)event NS_SWIFT_NAME(canHandle(_:));
+
+/// Returns a supplemental handler for the event or `nil` if there is none.
+/// The default implementation returns `nil`.
+- (nullable NSResponder *)vna_supplementalHandlerForEvent:(NSEvent *)event
+    NS_SWIFT_NAME(supplementalHandler(for:));
 
 @end
 

--- a/Vienna/Sources/Shared/NSResponder+EventHandler.m
+++ b/Vienna/Sources/Shared/NSResponder+EventHandler.m
@@ -23,7 +23,21 @@
 
 - (BOOL)vna_handleEvent:(NSEvent *)event
 {
+    NSResponder *supplementalHandler = [self.nextResponder vna_supplementalHandlerForEvent:event];
+    if (supplementalHandler) {
+        return [supplementalHandler vna_handleEvent:event];
+    }
     return [self.nextResponder vna_handleEvent:event];
+}
+
+- (BOOL)vna_canHandleEvent:(NSEvent *)event
+{
+    return NO;
+}
+
+- (nullable NSResponder *)vna_supplementalHandlerForEvent:(NSEvent *)event
+{
+    return nil;
 }
 
 @end

--- a/Vienna/Sources/Shared/NSResponder+EventHandler.m
+++ b/Vienna/Sources/Shared/NSResponder+EventHandler.m
@@ -1,0 +1,29 @@
+//
+//  NSResponder+EventHandler.m
+//  Vienna
+//
+//  Copyright 2025 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "NSResponder+EventHandler.h"
+
+@implementation NSResponder (EventHandler)
+
+- (BOOL)vna_handleEvent:(NSEvent *)event
+{
+    return [self.nextResponder vna_handleEvent:event];
+}
+
+@end

--- a/Vienna/Sources/Vienna-Bridging-Header.h
+++ b/Vienna/Sources/Vienna-Bridging-Header.h
@@ -1,5 +1,6 @@
 #import "AppController.h"
 #import "Article.h"
+#import "ArticleController.h"
 #import "ArticleConverter.h"
 #import "ArticleListView.h"
 #import "ArticleViewDelegate.h"

--- a/Vienna/Sources/Vienna-Bridging-Header.h
+++ b/Vienna/Sources/Vienna-Bridging-Header.h
@@ -11,6 +11,7 @@
 #import "FolderView.h"
 #import "HelperFunctions.h"
 #import "NSFileManager+Paths.h"
+#import "NSResponder+EventHandler.h"
 #import "OpenReader.h"
 #import "PluginManager.h"
 #import "Preferences.h"


### PR DESCRIPTION
This moves some of the ArticleController-related code into ArticleController itself, particularly the code that sets the layout (horizontal/vertical and unified layout) and handles the filter bar. This reduces some of the responsibilities of AppController that can reasonably be handled by ArticleController.

I had to implement solutions for NSResponder and keyboard events to keep the existing functionality:
-  Vienna's main window controller uses `supplementalTarget(forAction:sender:)` to catch responder messages that "fall through" to prevent them from passing onto AppController. E.g. when the first responder doesn't implement the action, then previously AppController would handle it and also validate the menu item. Now, the main window controller attempts to pass the action to the correct responder first so that it can handle it and perform validation. This can be expanded to include more responders (e.g. FoldersTree) and more actions in the future, piece by piece.
- I created a category for NSResponder to add some helper methods for key event handling so that it works similarly to  `supplementalTarget(forAction:sender:)`. Unfortunately, `-keyDown:` cannot simply be passed down the responder chain, because there is no way to know whether a certain object implements it, thereby unintentionally disabling a key event that Vienna doesn't explicitly handle, such as using the arrow keys. NSResponder doesn't seem to have a way to do this safely, so I instead created my own solution. This allows us to implement key events in the object that implements the action for which the key event is meant and therefore avoid doing everything in AppController.

> [!NOTE]
> This PR builds on #1961 