### PR TITLE
Reset UnifiedDisplayView table style to `fullWidth`

### DIFF
--- a/Vienna/Interfaces/Base.lproj/MainWindowController.xib
+++ b/Vienna/Interfaces/Base.lproj/MainWindowController.xib
@@ -916,7 +916,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="701" height="627"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
-                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="NgO-hM-mCz" customClass="ExtendedTableView">
+                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="NgO-hM-mCz" customClass="ExtendedTableView">
                                         <rect key="frame" x="0.0" y="0.0" width="701" height="627"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <size key="intercellSpacing" width="3" height="2"/>


### PR DESCRIPTION
Fixes an error in #1961. 

NSTableView's `automatic` table style will use the `inset` style when the enclosing scroll view has no border, whereas it will use the `fullWidth` style when there is a border. The style should be set to `fullWidth`, so that the table keeps its previous style.