### PR TITLE
Remove private `_developerExtrasEnabled` property

### DIFF
--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -56,12 +56,6 @@ class CustomWKWebView: WKWebView {
             prefs._isFullScreenEnabled = true
         }
 
-        #if DEBUG
-        if prefs.responds(to: #selector(setter: WKPreferences._developerExtrasEnabled)) {
-            prefs._developerExtrasEnabled = true
-        }
-        #endif
-
         usesMinimumFontSizeObservation = Preferences.standard
             .observe(\.enableMinimumFontSize, options: .initial) { preferences, _ in
                 guard !preferences.enableMinimumFontSize else {

--- a/Vienna/Sources/Main window/WKPreferences+Private.h
+++ b/Vienna/Sources/Main window/WKPreferences+Private.h
@@ -21,10 +21,6 @@
 
 @interface WKPreferences (Private)
 
-#ifdef DEBUG
-@property (setter=_setDeveloperExtrasEnabled:, nonatomic) BOOL _developerExtrasEnabled;
-#endif
-
 // This is implemented by WKPreferences.elementFullscreenEnabled as of
 // macOS 12.3.
 @property (setter=_setFullScreenEnabled:, nonatomic) BOOL _fullScreenEnabled


### PR DESCRIPTION
This has never worked correctly for WKWebView (see discussion at #1523). In macOS 12.3 you can use Safari's developer menu to debug the web view, causing the web inspector menu items to appear as well.