### PR TITLE
Remove unnecessary clang diagnostic ignore pragma

### DIFF
--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -352,12 +352,9 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 
     if ([userPrefs objectForKey:folderListFontKey]) {
         NSData *archive = [self objectForKey:folderListFontKey];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         NSFont *font = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSFont class]
                                                          fromData:archive
                                                             error:NULL];
-#pragma clang diagnostic pop
         if (font && font.pointSize <= 11.0) {
             [userPrefs setInteger:VNAFeedListSizeModeTiny
                            forKey:MAPref_FeedListSizeMode];


### PR DESCRIPTION
This was omitted in 60cc8b8a2e3ad49e8502edc1a95c6400565b820a.