### PR TITLE
Configure URLSession to wait for connectivity

### DIFF
--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -96,6 +96,7 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
         config.HTTPAdditionalHeaders = @{@"User-Agent": userAgent()};
         config.HTTPMaximumConnectionsPerHost = 6;
         config.HTTPShouldUsePipelining = YES;
+        config.waitsForConnectivity = YES;
         _urlSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:[NSOperationQueue mainQueue]];
 
         NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];


### PR DESCRIPTION
This might mitigate #2005.

I tested this by disconnecting from the Wi-Fi network and then starting a manual refresh. The URLSession tasks won't be cancelled immediately. When I reconnect to a Wi-Fi network, the pending tasks resume and complete normally. According to the NSURLSession.h file, the maximum wait time is the same as `timeoutIntervalForResource`, which Vienna currently sets to 300 seconds.