### PR TITLE
Fix crash when the feed URL points to an HTML page

### DIFF
--- a/Vienna/Sources/Parsing/XMLFeedParser.m
+++ b/Vienna/Sources/Parsing/XMLFeedParser.m
@@ -43,6 +43,7 @@
                 case NSXMLParserGTRequiredError:
                 case NSXMLParserTagNameMismatchError:
                 case NSXMLParserEmptyDocumentError:
+                case NSXMLParserNAMERequiredError:
                     if (error) {
                         *error = xmlDocumentError;
                     }


### PR DESCRIPTION
Fix issue #2002 : Vienna crashes due to feed content being replaced by some HTML page