### PR TITLE
Improve and secure parsing of XML/XHTML mixes

### DIFF
--- a/Vienna/Sources/Parsing/XMLFeedParser.m
+++ b/Vienna/Sources/Parsing/XMLFeedParser.m
@@ -40,8 +40,6 @@
                 // NSXMLDocument's -initWithData:options:error
                 // when option NSXMLDocumentTidyXML is enabled
                 switch (xmlDocumentError.code) {
-                case NSXMLParserGTRequiredError:
-                case NSXMLParserTagNameMismatchError:
                 case NSXMLParserEmptyDocumentError:
                     if (error) {
                         *error = xmlDocumentError;
@@ -52,7 +50,8 @@
 
             // recover some cases like text encoding errors, non standard tags...
             xmlDocument = [[NSXMLDocument alloc] initWithData:xmlData
-                                                      options:NSXMLDocumentTidyXML | NSXMLNodeLoadExternalEntitiesNever
+                                                      options:NSXMLDocumentTidyXML | NSXMLDocumentTidyHTML |
+                                                      NSXMLNodeLoadExternalEntitiesNever
                                                         error:&xmlDocumentError];
         }
     } @catch (NSException * __unused) {


### PR DESCRIPTION
Fix issue #2002: Vienna crashes when the NSXMLDocument parser tries to parse a particular HTML page with the NSXMLDocumentTidyXML option.

Also fixes issue #1545: problem parsing feeds which contain HTML tags instead of their XHTML equivalents, without reopening issue #1073: crash when attempting to fetch https://news.ycombinator.com/item?id=16264662