### PR TITLE
Fix NSTableHeaderCell image drawing bug in macOS 26

### DIFF
--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -32,6 +32,12 @@
     NSTableColumn *tableColumn = [self tableColumnWithIdentifier:identifier];
     NSTableHeaderCell *headerCell = tableColumn.headerCell;
     headerCell.image = image;
+    // In macOS 26, the cell's image is not drawn. Enabling this property seems
+    // to address this problem. However, it causes the image to be drawn skewed
+    // on older versions of macOS.
+    if (@available(macOS 26, *)) {
+        headerCell.bezeled = YES;
+    }
 
     NSImageCell *imageCell = [[NSImageCell alloc] init];
     tableColumn.dataCell = imageCell;


### PR DESCRIPTION
Resolves #1996 

<img width="175" height="65" alt="Scherm­afbeelding 2025-11-16 om 23 11 17" src="https://github.com/user-attachments/assets/7bd9dd9e-bfb3-48fe-97ca-c0f8c7572d06" />


NSTableHeaderCell descends from NSTextFieldCell and ultimately NSCell. NSImageCell is not an ancestor of NSTableHeaderCell. The `image` property is inherited from NSCell. Using NSTextFieldCell's `bezeled` property will cause the image to be draw again, without affecting the cell's style.

This needs testing on < macOS 26