### PR TITLE
Fix warning as a result of -makeFirstResponder: message

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -805,7 +805,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
         for (NSURL * url in urls) {
 			(void)[self.browser createNewTab:url inBackground:openInBackground load:true];
         }
-        [self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
+        NSView *mainView = ((NSView<BaseView> *)self.browser.primaryTab.view).mainView;
+        if ([mainView.window isEqual:self.mainWindow]) {
+            [self.mainWindow makeFirstResponder:mainView];
+        }
 	} else {
 		[self openURLsInDefaultBrowser:urls];
 	}


### PR DESCRIPTION
AppKit warns about a potential crash when making a view first responder when it (seemingly) is not in the window's view hierarchy. The warning appears when using the "Open Article Page" menu item or clicking on a link in the article viewer, while having the "open links in the background" setting disabled.

The warning appears since 81b3c4c8c29f36c98046c4a543b151cf295e6587.

Below is the log (note the "different window ((null))").  I am not sure why MessageListView (ultimately NSView) returns a `nil` reference to `window`. I suspect that when the browser opens and switches to a different tab, the primary tab's view (which contains the MessageListView) is removed from the view hierarchy, including the window itself.

I haven't observed any behavioural changes between 81b3c4c8c29f36c98046c4a543b151cf295e6587 and the code before it.

```
ERROR: Setting <MessageListView: 0xc4f6e8a00> as the first responder for window <Vienna.MainWindow: 0xc505bd680> windowNumber=29ea, but it is in a different window ((null))! This would eventually crash when the view is freed. The first responder will be set to nil.
(
	0   AppKit                              0x000000019a559014 -[NSWindow _validateFirstResponder:] + 348
	1   AppKit                              0x000000019a5590e8 -[NSWindow _setFirstResponder:] + 28
	2   AppKit                              0x000000019a558ab4 -[NSWindow _realMakeFirstResponder:] + 516
	3   Vienna.debug.dylib                  0x000000010321937c -[AppController openURLs:inPreferredBrowser:] + 1028
	4   Vienna.debug.dylib                  0x0000000103219538 -[AppController openURL:inPreferredBrowser:] + 264
	5   Vienna.debug.dylib                  0x000000010331cd90 $s6Vienna16WebKitArticleTabC7webView_15decidePolicyFor15decisionHandlerySo05WKWebG0C_So18WKNavigationActionCySo0noI0VctF + 996
	6   Vienna.debug.dylib                  0x000000010331cef4 $s6Vienna16WebKitArticleTabC7webView_15decidePolicyFor15decisionHandlerySo05WKWebG0C_So18WKNavigationActionCySo0noI0VctFTo + 164
	7   WebKit                              0x00000001bf391d14 _ZN6WebKit15NavigationState16NavigationClient31decidePolicyForNavigationActionERNS_12WebPageProxyEON3WTF3RefIN3API16NavigationActionENS4_12RawPtrTraitsIS7_EENS4_21DefaultRefDerefTraitsIS7_EEEEONS5_INS_27WebFramePolicyListenerProxyENS8_ISE_EENSA_ISE_EEEE + 924
	8   WebKit                              0x00000001bf7b2868 _ZN6WebKit12WebPageProxy31decidePolicyForNavigationActionEON3WTF3RefINS_15WebProcessProxyENS1_12RawPtrTraitsIS3_EENS1_21DefaultRefDerefTraitsIS3_EEEERNS_13WebFrameProxyEONS_20NavigationActionDataEONS1_17CompletionHandlerIFvONS_14PolicyDecisionEEEE + 5624
	9   WebKit                              0x00000001bf7b10a4 _ZN6WebKit12WebPageProxy36decidePolicyForNavigationActionAsyncERN3IPC10ConnectionEONS_20NavigationActionDataEON3WTF17CompletionHandlerIFvONS_14PolicyDecisionEEEE + 280
	10  WebKit                              0x00000001bf1e6f28 _ZN6WebKit12WebPageProxy17didReceiveMessageERN3IPC10ConnectionERNS1_7DecoderE + 12764
	11  WebKit                              0x00000001bfd919f4 _ZN3IPC18MessageReceiverMap15dispatchMessageERNS_10ConnectionERNS_7DecoderE + 264
	12  WebKit                              0x00000001bf8485f8 _ZN6WebKit15WebProcessProxy15dispatchMessageERN3IPC10ConnectionERNS1_7DecoderE + 40
	13  WebKit                              0x00000001bf237598 _ZN6WebKit15WebProcessProxy17didReceiveMessageERN3IPC10ConnectionERNS1_7DecoderE + 1408
	14  WebKit                              0x00000001bfd67f6c _ZN3IPC10Connection15dispatchMessageEN3WTF9UniqueRefINS_7DecoderEEE + 296
	15  WebKit                              0x00000001bfd68498 _ZN3IPC10Connection24dispatchIncomingMessagesEv + 532
	16  JavaScriptCore                      0x00000001b6ae9964 _ZN3WTF7RunLoop11performWorkEv + 552
	17  JavaScriptCore                      0x00000001b6aeb394 _ZN3WTF7RunLoop11performWorkEPv + 36
	18  CoreFoundation                      0x00000001954609f8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
	19  CoreFoundation                      0x000000019546098c __CFRunLoopDoSource0 + 172
	20  CoreFoundation                      0x00000001954606f8 __CFRunLoopDoSources0 + 232
	21  CoreFoundation                      0x000000019545f388 __CFRunLoopRun + 820
	22  CoreFoundation                      0x0000000195519e34 _CFRunLoopRunSpecificWithOptions + 532
	23  HIToolbox                           0x00000001a1f4f790 RunCurrentEventLoopInMode + 316
	24  HIToolbox                           0x00000001a1f52ab8 ReceiveNextEventCommon + 488
	25  HIToolbox                           0x00000001a20dcb64 _BlockUntilNextEventMatchingListInMode + 48
	26  AppKit                              0x0000000199d78b5c _DPSBlockUntilNextEventMatchingListInMode + 236
	27  AppKit                              0x0000000199872e48 _DPSNextEvent + 588
	28  AppKit                              0x000000019a33dd0c -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 688
	29  AppKit                              0x000000019a33da18 -[NSApplication(NSEventRouting) nextEventMatchingMask:untilDate:inMode:dequeue:] + 72
	30  AppKit                              0x000000019986b780 -[NSApplication run] + 368
	31  AppKit                              0x00000001998576dc NSApplicationMain + 880
	32  Vienna.debug.dylib                  0x00000001031b26c8 __debug_main_executable_dylib_entry_point + 52
	33  dyld                                0x0000000194ff9d54 start + 7184
)
```