### PR TITLE
Fix relative URLs referring to article's URL

### DIFF
--- a/Vienna/Sources/Parsing/AtomFeed.m
+++ b/Vienna/Sources/Parsing/AtomFeed.m
@@ -136,11 +136,8 @@
 
             // Look for the xml:base attribute, and use absolute url or stack relative url
             NSString *entryBase = [NSString vna_stringByCleaningURLString:[atomChildElement attributeForName:@"xml:base"].stringValue];
-            if (entryBase == nil) {
-                entryBase = linkBase;
-            }
 
-            NSURL *entryBaseURL = (entryBase != nil) ? [NSURL URLWithString:entryBase] : nil;
+            NSURL *entryBaseURL = [entryBase isEqualToString:@""] ? nil : [NSURL URLWithString:entryBase];
             if ((entryBaseURL != nil) && (linkBaseURL != nil) && (entryBaseURL.scheme == nil)) {
                 entryBaseURL = [NSURL URLWithString:entryBase relativeToURL:linkBaseURL];
                 if (entryBaseURL != nil) {
@@ -323,6 +320,10 @@
             // if we didn't find an author, set it to the default one
             if ([newFeedItem.authors isEqualToString:@""]) {
                 newFeedItem.authors = defaultAuthor;
+            }
+
+            if ([entryBase isEqualToString:@""]) {
+                entryBase = newFeedItem.url ? newFeedItem.url : linkBase;
             }
 
             // Do relative IMG, IFRAME and A tags fixup

--- a/Vienna/Sources/Parsing/RSSFeed.m
+++ b/Vienna/Sources/Parsing/RSSFeed.m
@@ -342,9 +342,9 @@
             }
 
             // Do relative IMG, IFRAME and A tags fixup
-            [articleBody vna_fixupRelativeImgTags:self.homePageURL];
-            [articleBody vna_fixupRelativeIframeTags:self.homePageURL];
-            [articleBody vna_fixupRelativeAnchorTags:self.homePageURL];
+            [articleBody vna_fixupRelativeImgTags:newFeedItem.url];
+            [articleBody vna_fixupRelativeIframeTags:newFeedItem.url];
+            [articleBody vna_fixupRelativeAnchorTags:newFeedItem.url];
             newFeedItem.content = SafeString(articleBody);
 
             // Add this item in the proper location in the array


### PR DESCRIPTION
When base URL is not explicitly set, we refer to article's URL if it is defined, otherwise to homepage's URL.

Issue #2047