### PR TITLE
Disable several SwiftLint rules to avoid collisions with Swift Format

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,11 +7,14 @@ included:
 # Rules
 
 disabled_rules:
+  - closure_parameter_position
   - cyclomatic_complexity
   - file_length
   - function_body_length
   - line_length
+  - opening_brace
   - todo
+  - trailing_comma
 
 opt_in_rules:
   - attributes


### PR DESCRIPTION
#2045 introduced a SwiftLint warning. This resolves that warning.