### PR TITLE
Disable menu images forced on us by macOS Tahoe

### DIFF
--- a/Vienna/Sources/Preferences window/Preferences.h
+++ b/Vienna/Sources/Preferences window/Preferences.h
@@ -144,6 +144,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *syncingAppId;
 @property (nonatomic, copy) NSString *syncingAppKey;
 
+// apply Tahoe menu images
+@property (nonatomic) BOOL menuEnableActionImages;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Preferences window/Preferences.m
+++ b/Vienna/Sources/Preferences window/Preferences.m
@@ -139,6 +139,9 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 		shouldSaveFeedSource = [self boolForKey:MAPref_ShouldSaveFeedSource];
 		concurrentDownloads = [self integerForKey:MAPref_ConcurrentDownloads];
         _userAgentName = [self stringForKey:MAPref_UserAgentName];
+        // if there isn't a choice already set, this saves
+        // the default into Preferences file
+        self.menuEnableActionImages = [userPrefs boolForKey:MAPref_MenuEnableActionImages];
 
         // Archived objects
         searchMethod = [NSKeyedUnarchiver unarchivedObjectOfClass:[SearchMethod class]
@@ -239,6 +242,7 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 	defaultValues[MAPref_ShouldSaveFeedSourceBackup] = boolNo;
     defaultValues[MAPref_ShowDetailsOnFeedCredentialsDialog] = boolNo;
     defaultValues[MAPref_ShowEnclosureBar] = boolYes;
+    defaultValues[MAPref_MenuEnableActionImages] = boolNo;
 
     // Archives
     defaultValues[MAPref_ArticleListFont] = [NSKeyedArchiver archivedDataWithRootObject:defaultFont
@@ -1005,6 +1009,22 @@ static NSString * const MA_FeedSourcesFolder_Name = @"Sources";
 -(void)setShowFilterBar:(BOOL)showFilterBar
 {
     [self setBool:showFilterBar forKey:MAPref_ShowFilterBar];
+}
+
+/* menuEnableActionImages
+ * Returns whether we apply icons to menu items
+ */
+-(BOOL)menuEnableActionImages
+{
+    return [self boolForKey:MAPref_MenuEnableActionImages];
+}
+
+/* setMenuEnableActionImages
+ * Specifies whether the filter bar is shown or hidden.
+ */
+-(void)setMenuEnableActionImages:(BOOL)menuEnableActionImages
+{
+    [self setBool:menuEnableActionImages forKey:MAPref_MenuEnableActionImages];
 }
 
 /* feedSourcesFolder

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -110,6 +110,7 @@ extern NSString * const MAPref_ShowDetailsOnFeedCredentialsDialog;
 extern NSString * const MAPref_ShowEnclosureBar;
 extern NSString * const MAPref_FeedListSizeMode;
 extern NSString * const MAPref_ShowFeedsWithUnreadItemsInBold;
+extern NSString * const MAPref_MenuEnableActionImages;
 
 extern NSInteger const MA_Default_BackTrackQueueSize;
 extern float const MA_Default_Read_Interval;

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -107,6 +107,7 @@ NSString * const MAPref_SyncingAppId = @"SyncingAppId";
 NSString * const MAPref_SyncingAppKey = @"SyncingAppKey";
 NSString * const MAPref_AlwaysAcceptBetas = @"AlwayAcceptBetas";
 NSString * const MAPref_UserAgentName = @"UserAgentName";
+NSString * const MAPref_MenuEnableActionImages = @"NSMenuEnableActionImages";
 
 NSInteger const MA_Default_BackTrackQueueSize = 20;
 NSInteger const MA_Default_MinimumFontSize = 9;


### PR DESCRIPTION
Macintosh Human Interface Guidelines from 1992 states that you should not overload the user with complex icons

Credit : NetNewsWire (Modules / RSCore / Sources / RSCoreObjC)

https://tonsky.me/blog/tahoe-icons/