### PR TITLE
Add NSTableHeaderCell subclass to address image drawing bug in macOS 26

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		F6EB26031E58D37100570B22 /* DirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EB26021E58D37100570B22 /* DirectoryMonitor.swift */; };
 		F6F12AFD25ABDDE3005B2DCE /* NSFileManager+Paths.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F12AFC25ABDDE3005B2DCE /* NSFileManager+Paths.m */; };
 		F6F2029F2D19DD3A004BB948 /* SubscribeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F2029E2D19DD3A004BB948 /* SubscribeViewController.m */; };
+		F6F844EA2F0C6EBF00A8D8D6 /* TableHeaderCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F844E92F0C6EBF00A8D8D6 /* TableHeaderCell.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -686,6 +687,8 @@
 		F6F12AFC25ABDDE3005B2DCE /* NSFileManager+Paths.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "NSFileManager+Paths.m"; sourceTree = "<group>"; };
 		F6F2029D2D19DD3A004BB948 /* SubscribeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SubscribeViewController.h; sourceTree = "<group>"; };
 		F6F2029E2D19DD3A004BB948 /* SubscribeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SubscribeViewController.m; sourceTree = "<group>"; };
+		F6F844E82F0C6EBF00A8D8D6 /* TableHeaderCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TableHeaderCell.h; sourceTree = "<group>"; };
+		F6F844E92F0C6EBF00A8D8D6 /* TableHeaderCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TableHeaderCell.m; sourceTree = "<group>"; };
 		F6FEBCFE2CA06980005E3788 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Predicates.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -923,6 +926,8 @@
 				43502853165DE9DF0018EDB7 /* ArticleListView.m */,
 				43502873165DE9DF0018EDB7 /* MessageListView.h */,
 				43502874165DE9DF0018EDB7 /* MessageListView.m */,
+				F6F844E82F0C6EBF00A8D8D6 /* TableHeaderCell.h */,
+				F6F844E92F0C6EBF00A8D8D6 /* TableHeaderCell.m */,
 				3A7BD0DB1989AC7700E9444B /* VNAVerticallyCenteredTextFieldCell.h */,
 				3A7BD0DC1989AC7700E9444B /* VNAVerticallyCenteredTextFieldCell.m */,
 				4350287B165DE9DF0018EDB7 /* ProgressTextCell.h */,
@@ -1990,6 +1995,7 @@
 				435028AE165DE9E00018EDB7 /* ProgressTextCell.m in Sources */,
 				793C95331C42A0DD00984D4E /* FoldersFilterable.m in Sources */,
 				F6F2029F2D19DD3A004BB948 /* SubscribeViewController.m in Sources */,
+				F6F844EA2F0C6EBF00A8D8D6 /* TableHeaderCell.m in Sources */,
 				3AB95743258DBC5A00C54E83 /* Browser.swift in Sources */,
 				435028AF165DE9E00018EDB7 /* RefreshManager.m in Sources */,
 				F6AFC16D2CAFCD2E00106E80 /* SettingsTabViewController.swift in Sources */,

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -21,6 +21,7 @@
 #import "MessageListView.h"
 
 #import "NSResponder+EventHandler.h"
+#import "TableHeaderCell.h"
 
 @implementation MessageListView
 
@@ -30,14 +31,11 @@
           forColumnWithIdentifier:(NSUserInterfaceItemIdentifier)identifier
 {
     NSTableColumn *tableColumn = [self tableColumnWithIdentifier:identifier];
-    NSTableHeaderCell *headerCell = tableColumn.headerCell;
-    headerCell.image = image;
-    // In macOS 26, the cell's image is not drawn. Enabling this property seems
-    // to address this problem. However, it causes the image to be drawn skewed
-    // on older versions of macOS.
+
     if (@available(macOS 26, *)) {
-        headerCell.bezeled = YES;
+        tableColumn.headerCell = [[VNATableHeaderCell alloc] init];
     }
+    tableColumn.headerCell.image = image;
 
     NSImageCell *imageCell = [[NSImageCell alloc] init];
     tableColumn.dataCell = imageCell;

--- a/Vienna/Sources/Main window/TableHeaderCell.h
+++ b/Vienna/Sources/Main window/TableHeaderCell.h
@@ -1,0 +1,29 @@
+//
+//  TableHeaderCell.h
+//  Vienna
+//
+//  Copyright 2026 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@import Cocoa;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_AVAILABLE_MAC(26)
+@interface VNATableHeaderCell : NSTableHeaderCell
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Vienna/Sources/Main window/TableHeaderCell.m
+++ b/Vienna/Sources/Main window/TableHeaderCell.m
@@ -1,0 +1,36 @@
+//
+//  ImageTableHeaderCell.m
+//  Vienna
+//
+//  Copyright 2026 Eitot
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "TableHeaderCell.h"
+
+@implementation VNATableHeaderCell
+
+- (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+{
+    // In macOS 26, image cells are not drawn correctly. The reason for this
+    // appears to be that the interior cell frame is collapsed. By overriding
+    // height and Y coordinate, the cell appears to be drawn correctly.
+    if (self.type == NSImageCellType) {
+        cellFrame.size.height = self.cellSize.height;
+        cellFrame.origin.y = 0.0;
+    }
+    [super drawInteriorWithFrame:cellFrame inView:controlView];
+}
+
+@end


### PR DESCRIPTION
An alternative fix for #1996 

I think this solution is more robust than #2031. When using the `UIDesignRequiresCompatibility` Info.plist key to use the previous UI design, the images are squished when `bezeled` is enabled. With this PR, the icons are drawn and look correctly with both the previous UI and the Tahoe UI.