### PR TITLE
Add margin constraint to download button of EnclosureView

### DIFF
--- a/Vienna/Interfaces/Base.lproj/MainWindowController.xib
+++ b/Vienna/Interfaces/Base.lproj/MainWindowController.xib
@@ -538,6 +538,7 @@
                 <outlet property="fileImage" destination="1289" id="1294"/>
                 <outlet property="filenameField" destination="1292" id="1298"/>
                 <outlet property="filenameLabel" destination="1290" id="1299"/>
+                <outlet property="stackViewTrailingConstraint" destination="v5m-a9-btO" id="hIA-hH-1PZ"/>
             </connections>
             <point key="canvasLocation" x="-186" y="42.5"/>
         </customView>

--- a/Vienna/Sources/Main window/EnclosureView.m
+++ b/Vienna/Sources/Main window/EnclosureView.m
@@ -31,6 +31,8 @@
 
 @interface EnclosureView ()
 
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *stackViewTrailingConstraint;
+
 -(IBAction)openFile:(id)sender;
 
 @end
@@ -64,6 +66,16 @@
 -(void)awakeFromNib
 {
 	[filenameField setCanCopyURLs:YES];
+
+    if (@available(macOS 26, *)) {
+        // Constrain the download button to the trailing layout margin.
+        NSLayoutXAxisAnchor *marginAnchor = self.layoutMarginsGuide.trailingAnchor;
+        NSLayoutXAxisAnchor *downloadButtonAnchor = downloadButton.trailingAnchor;
+        [marginAnchor constraintEqualToAnchor:downloadButtonAnchor].active = YES;
+
+        // Disable the existing layout constraint to avoid conflicts.
+        self.stackViewTrailingConstraint.active = NO;
+    }
 }
 
 /* handleDownloadCompleted


### PR DESCRIPTION
With the larger corner radius in macOS 26, the download button is a bit too close to the corner. By using margin layout guides, the button is pushed a little to the left. I have tested the new NSLayoutRegion API as well which is meant to be used for these cases, however, it puts the button even further to the left, which looks worse.

<img width="153" height="67" alt="Scherm­afbeelding 2026-02-08 om 20 47 52" src="https://github.com/user-attachments/assets/e3e71214-47a7-44e7-9039-09f78a5d835c" />
