### PR TITLE
Add Cocoa binding to "Check for Updates" menu item

### DIFF
--- a/Vienna/Interfaces/Base.lproj/Application.storyboard
+++ b/Vienna/Interfaces/Base.lproj/Application.storyboard
@@ -33,6 +33,7 @@
                                         <menuItem title="Check for Updates" id="1104">
                                             <connections>
                                                 <action selector="checkForUpdates:" target="LzF-8y-hiG" id="1176"/>
+                                                <binding destination="LzF-8y-hiG" name="enabled" keyPath="updater.canCheckForUpdates" id="CC1-3R-dew"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="143"/>


### PR DESCRIPTION
This accompanies the `‑checkForUpdates:` method invoked by the menu item and disables the menu item if `‑checkForUpdates:` cannot be invoked, e.g. because an update is in progress.