### PR TITLE
Send Database setup code before the view hierarchy is loaded

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -232,6 +232,12 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
  */
 -(void)applicationDidFinishLaunching:(NSNotification *)aNot
 {
+    // Initialize the database
+    if ((db = [Database sharedManager]) == nil) {
+        [NSApp terminate:nil];
+        return;
+    }
+
 	self.mainWindowController = [[MainWindowController alloc] initWithWindowNibName:@"MainWindowController"];
     self.mainWindowController.articleController = self.articleController;
 	self.mainWindow = self.mainWindowController.window;
@@ -265,12 +271,6 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 	[nc addObserver:self selector:@selector(handleUpdateUnreadCount:) name:MA_Notify_FoldersUpdated object:nil];
 	//Open Reader Notifications
     [nc addObserver:self selector:@selector(handleOpenReaderAuthFailed:) name:MA_Notify_OpenReaderAuthFailed object:nil];
-
-	// Initialize the database
-	if ((db = [Database sharedManager]) == nil) {
-		[NSApp terminate:nil];
-		return;
-	}
 
 	// Initialize the Sort By and Columns menu
 	[self initSortMenu];


### PR DESCRIPTION
Resolves #2082 

This avoids a crash when any parts of the view hierarchy reference the database before it finishes loading. The database might not have loaded yet, because it awaits input from the user, e.g. when the database needs to be updated.