### PR TITLE
Maintain article to preserve after filtering

### DIFF
--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -566,7 +566,6 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 	if (guidOfArticleToPreserve != nil) {
 		[filteredArray addObject:articleToPreserve];
 	}
-	articleToPreserve = nil;
 	
 	return [filteredArray copy];
 }


### PR DESCRIPTION
Fix issue #2076 : article currently selected in a smart or group folder was not systematically preserved but could be filtered out during feed refreshes