### PR TITLE
Prefer use of SCNetworkReachability for macOS < 15

### DIFF
--- a/Vienna/Sources/Shared/HelperFunctions.m
+++ b/Vienna/Sources/Shared/HelperFunctions.m
@@ -221,7 +221,7 @@ NSString * userAgent(void) {
 // https://developer.apple.com/library/archive/samplecode/Reachability/Introduction/Intro.html
 BOOL VNANetworkIsReachable(void)
 {
-    if (@available(macOS 10.14, *)) {
+    if (@available(macOS 15, *)) {
         static VNANetworkMonitor *monitor = nil;
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{


### PR DESCRIPTION
NWPathMonitor seems to have issues on older macOS, especially on Intel machines (Invalid address or Symbol missing…), which leads to crashes at Vienna launch.
As SCNetworkReachability API was officially supported from Mac OS X 10.3 to macOS 14.4, we stick to its use for older versions of macOS.

Issue #2094