### PR TITLE
Use FeedDiscoverer to enable browser's RSS button

### DIFF
--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -80,7 +80,7 @@ extension BrowserTab: RSSSource {
             self?.webView.evaluateJavaScript(BrowserTab.extractHTMLSource) { result, error in
                 defer { finishHandler() }
                 if let html = result as? String, let data = html.data(using: .utf8), let baseUrl = self?.url, error == nil {
-                    let discoverer = FeedDiscoverer.init(data: data, baseURL: baseUrl)
+                    let discoverer = FeedDiscoverer(data: data, baseURL: baseUrl)
                     self?.rssUrls = discoverer.feedURLs().map(\.absoluteURL)
                 } else {
                     // error or conversion problem


### PR DESCRIPTION
This adds the discovery of JSON Feeds to BrowserTab. This also prepares future improvements for handling multiple links, as FeedDiscoverer can provide additional informations which could be used as hints for the user.