### PR TITLE
Prevent duplicate folders when launching Vienna the first time

### DIFF
--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -764,7 +764,12 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 		}
 	}
 	
-	TreeNode __unused * newNode = [[TreeNode alloc] init:node atIndex:childIndex folder:newFolder canHaveChildren:NO];
+    if (![self.rootNode nodeFromID:newFolder.itemId]) {
+        TreeNode * __unused newNode = [[TreeNode alloc] init:node
+                                                     atIndex:childIndex
+                                                      folder:newFolder
+                                             canHaveChildren:NO];
+    }
 	[self reloadFolderItem:node reloadChildren:YES];
 	[self selectFolder:newFolder.itemId];
 }


### PR DESCRIPTION
Fixes #2024 

The `handleFolderAdded:` callback is sent _after_ the tree nodes for the demo feeds were added, resulting in duplicates. This only seems to happen during first launch, not on subsequent launches and also not when additional feeds are added.

We may have to review the code in `‑[FoldersTree reloadDatabase:]` and `‑[FoldersTree loadTree:rootNode:]` as well (which is the code responsible for creating tree nodes).