### PR TITLE
Add Vim-inspired Ctrl-E/Ctrl-Y line scrolling in article pane

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1683,15 +1683,41 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(BOOL)handleKeyDown:(NSEvent *)event
 {
-    if (event.type != NSEventTypeKeyDown && event.characters.length != 1) {
+    if (event.type != NSEventTypeKeyDown || event.characters.length != 1) {
         return NO;
     }
-    unichar keyChar = [event.characters characterAtIndex:0];
-    NSEventModifierFlags flags = event.modifierFlags;
+	unichar keyChar = [event.characters characterAtIndex:0];
+	NSEventModifierFlags flags = event.modifierFlags;
+    NSEventModifierFlags relevantFlags = flags & NSEventModifierFlagDeviceIndependentFlagsMask;
+
+    if (relevantFlags == NSEventModifierFlagControl &&
+        (keyChar == 0x05 ||
+         [[event.charactersIgnoringModifiers lowercaseString] isEqualToString:@"e"])) {
+        id<Tab> activeBrowserTab = self.browser.activeTab;
+        if (activeBrowserTab == nil) {
+            // We are in the article view.
+            [self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
+            [self.articleController.mainArticleView scrollLineDownDetails];
+            return YES;
+        }
+    }
+
+    if (relevantFlags == NSEventModifierFlagControl &&
+        (keyChar == 0x19 ||
+         [[event.charactersIgnoringModifiers lowercaseString] isEqualToString:@"y"])) {
+        id<Tab> activeBrowserTab = self.browser.activeTab;
+        if (activeBrowserTab == nil) {
+            // We are in the article view.
+            [self.mainWindow makeFirstResponder:((NSView<BaseView> *)self.browser.primaryTab.view).mainView];
+            [self.articleController.mainArticleView scrollLineUpDetails];
+            return YES;
+        }
+    }
+
 	switch (keyChar) {
 		case NSLeftArrowFunctionKey:
             if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) {
-				return NO;
+					return NO;
 			} else {
 				if (self.mainWindow.firstResponder == ((NSView<BaseView> *)self.browser.primaryTab.view).mainView) {
 					[self.mainWindow makeFirstResponder:self.foldersTree.mainView];

--- a/Vienna/Sources/Main window/ArticleBaseView.h
+++ b/Vienna/Sources/Main window/ArticleBaseView.h
@@ -28,6 +28,8 @@
 @protocol ArticleBaseView <BaseView>
     @property (readonly, nonatomic) BOOL selectFirstUnreadInFolder;
     @property (readonly, nonatomic) BOOL viewNextUnreadInFolder;
+    -(void)scrollLineDownDetails;
+    -(void)scrollLineUpDetails;
 	-(void)scrollDownDetailsOrNextUnread;
 	-(void)scrollUpDetailsOrGoBack;
 	-(void)scrollToArticle:(NSString *)guid;

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -849,7 +849,17 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
         ArticleController * articleController = self.articleController;
         [articleController markReadByArray:self.markedArticleRange readFlag:YES];
         [articleController displayNextUnread];
-    }
+	}
+}
+
+-(void)scrollLineDownDetails
+{
+    [(NSView *)articleText scrollLineDown:nil];
+}
+
+-(void)scrollLineUpDetails
+{
+    [(NSView *)articleText scrollLineUp:nil];
 }
 
 -(void)scrollUpDetailsOrGoBack

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -251,6 +251,14 @@ extension BrowserTab: Tab {
         self.webView.scrollPageUp(sender)
     }
 
+    override func scrollLineDown(_ sender: Any?) {
+        self.webView.scrollLineDown(sender)
+    }
+
+    override func scrollLineUp(_ sender: Any?) {
+        self.webView.scrollLineUp(sender)
+    }
+
     func searchFor(_ searchString: String, action: NSFindPanelAction) {
         if #available(macOS 11, *) {
             let configuration = WKFindConfiguration()

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -394,6 +394,16 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
     }
 }
 
+- (void)scrollLineDownDetails
+{
+    [articleList scrollLineDown:nil];
+}
+
+- (void)scrollLineUpDetails
+{
+    [articleList scrollLineUp:nil];
+}
+
 - (void)scrollUpDetailsOrGoBack
 {
     NSScrollView *scrollView = [articleList enclosingScrollView];


### PR DESCRIPTION

This adds Vim-inspired keyboard shortcuts for line-wise scrolling in the article pane.

- `Ctrl-E` scrolls the article pane down by one line
- `Ctrl-Y` scrolls the article pane up by one line

The implementation follows the existing keyboard handling path in `AppController`.

- Vim-style navigation keys make it easier to read articles from the keyboard:
    1. Use (already existing) Up/Down (or Karabiner-remapped k/j) to choose prev/next article.
    2. Use Ctrl-E/Ctrl-Y to quickly scroll the article body.
