### PR TITLE
Change Database class initialisation process

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -955,7 +955,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	NSMenu * sortSubmenu = [NSMenu new];
 	
 	// Add the fields which are sortable to the menu.
-	for (Field * field in [db arrayOfFields]) {
+	for (Field *field in db.fields) {
         if (field.customizationOptions & VNAFieldCustomizationSorting) {
             NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:field.displayName
                                                               action:@selector(changeSortColumn:)
@@ -986,7 +986,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)initColumnsMenu
 {
 	NSMenu * columnsSubMenu = [NSMenu new];
-	for (Field * field in [db arrayOfFields]) {
+	for (Field *field in db.fields) {
         if (field.customizationOptions & VNAFieldCustomizationVisibility) {
             NSMenuItem *menuItem =
                 [[NSMenuItem alloc] initWithTitle:field.displayName

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -230,7 +230,8 @@ static void *VNAAppControllerObserverContext = &VNAAppControllerObserverContext;
 -(void)applicationDidFinishLaunching:(NSNotification *)aNot
 {
     // Initialize the database
-    if ((db = [Database sharedManager]) == nil) {
+    db = Database.sharedManager;
+    if (!db || ![db loadDatabaseStore]) {
         [NSApp terminate:nil];
         return;
     }

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -41,6 +41,22 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 
 @property (class, readonly, nonatomic) Database *sharedManager NS_SWIFT_NAME(shared);
 
+/**
+ Loads the database store.
+
+ This method performs these operations in order:
+  1. Retrieve and create if necessary the database path.
+  2. Load the database queue and ask if necessary to relocate the database.
+  3. Perform a SQLite3 `quick_check` and alert if issues are found.
+  4. Depending on the database version:
+     - perform a database migration,
+     - alert that the database is too old or
+     - set up an initial database.
+ @return `YES` if the database is loaded and has the current version or `NO`
+   if any of the operations failed.
+ */
+- (BOOL)loadDatabaseStore;
+
 @property(nonatomic) Folder * trashFolder;
 @property(nonatomic) Folder * searchFolder;
 @property (copy, nonatomic) NSString *searchString;

--- a/Vienna/Sources/Database/Database.h
+++ b/Vienna/Sources/Database/Database.h
@@ -71,8 +71,7 @@ extern NSNotificationName const VNADatabaseDidDeleteFolderNotification;
 -(void)close;
 
 // Fields functions
--(void)addField:(NSString *)name type:(NSInteger)type sqlField:(NSString *)sqlField visible:(BOOL)visible width:(NSInteger)width;
--(NSArray *)arrayOfFields;
+@property (readonly, nonatomic) NSArray<Field *> *fields;
 -(Field *)fieldByName:(NSString *)name;
 
 // Folder functions

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -39,15 +39,14 @@
 @interface Database ()
 
 @property (nonatomic) BOOL initializedfoldersDict;
-@property (nonatomic) NSMutableArray *fieldsOrdered;
-@property (nonatomic) NSMutableDictionary *fieldsByName;
+@property (readwrite, nonatomic) NSArray<Field *> *fields;
+@property (nonatomic) NSDictionary<NSString *, Field *> *fieldsByName;
 @property (nonatomic) NSMutableDictionary *foldersDict;
 @property (nonatomic) FMDatabaseQueue *databaseQueue;
 @property (nonatomic) NSMutableDictionary<NSNumber *, CriteriaTree *> *smartfoldersDict;
 @property (readwrite, nonatomic) BOOL readOnly;
 @property (readwrite, nonatomic) NSInteger countOfUnread;
 
-- (void)initaliseFields;
 - (NSString *)relocateLockedDatabase:(NSString *)path;
 - (CriteriaTree *)criteriaForFolder:(NSInteger)folderId;
 - (NSArray *)arrayOfSubFolders:(Folder *)folder;
@@ -76,7 +75,6 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         _searchFolder = nil;
         _searchString = @"";
         _foldersDict = [[NSMutableDictionary alloc] init];
-        [self initaliseFields];
     }
     return self;
 }
@@ -318,73 +316,6 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     return YES;
 }
 
-/*!
- *  Initialise the mappings between the names of
- *  the database fields and the model fields
- */
--(void)initaliseFields {
-    self.fieldsByName = [[NSMutableDictionary alloc] init];
-    self.fieldsOrdered = [[NSMutableArray alloc] init];
-    
-    [self addField:MA_Field_Read type:VNAFieldTypeFlag sqlField:@"read_flag" visible:YES width:17];
-    [self addField:MA_Field_Flagged type:VNAFieldTypeFlag sqlField:@"marked_flag" visible:YES width:17];
-    [self addField:MA_Field_HasEnclosure type:VNAFieldTypeFlag sqlField:@"hasenclosure_flag" visible:YES width:17];
-    [self addField:MA_Field_Deleted type:VNAFieldTypeFlag sqlField:@"deleted_flag" visible:NO width:15];
-    [self addField:MA_Field_GUID type:VNAFieldTypeInteger sqlField:@"message_id" visible:NO width:72];
-    [self addField:MA_Field_Subject type:VNAFieldTypeString sqlField:@"title" visible:YES width:472];
-    [self addField:MA_Field_Folder type:VNAFieldTypeFolder sqlField:@"folder_id" visible:NO width:130];
-    [self addField:MA_Field_LastUpdate type:VNAFieldTypeDate sqlField:@"date" visible:YES width:152];
-    [self addField:MA_Field_PublicationDate type:VNAFieldTypeDate sqlField:@"createddate" visible:NO width:152];
-    [self addField:MA_Field_Parent type:VNAFieldTypeInteger sqlField:@"parent_id" visible:NO width:72];
-    [self addField:MA_Field_Author type:VNAFieldTypeString sqlField:@"sender" visible:YES width:138];
-    [self addField:MA_Field_Link type:VNAFieldTypeString sqlField:@"link" visible:NO width:138];
-    [self addField:MA_Field_Text type:VNAFieldTypeString sqlField:@"text" visible:NO width:152];
-    [self addField:MA_Field_Summary type:VNAFieldTypeString sqlField:@"summary" visible:NO width:152];
-    [self addField:MA_Field_Headlines type:VNAFieldTypeString sqlField:@"" visible:NO width:100];
-    [self addField:MA_Field_Enclosure type:VNAFieldTypeString sqlField:@"enclosure" visible:NO width:100];
-    [self addField:MA_Field_EnclosureDownloaded type:VNAFieldTypeFlag sqlField:@"enclosuredownloaded_flag" visible:NO width:100];
-
-	//set user friendly and localizable names for some fields
-	[self fieldByName:MA_Field_Read].displayName = NSLocalizedString(@"Read", @"Data field name visible in menu/smart folder definition");
-	[self fieldByName:MA_Field_Flagged].displayName = NSLocalizedString(@"Flagged", @"Data field name visible in menu/smart folder definition");
-	[self fieldByName:MA_Field_HasEnclosure].displayName = NSLocalizedString(@"Enclosure", @"Data field name (Y/N) visible in menu/smart folder definition");
-	[self fieldByName:MA_Field_Enclosure].displayName = NSLocalizedString(@"Enclosure URL", @"Data field name (URL) visible in menu/article list");
-	[self fieldByName:MA_Field_Deleted].displayName = NSLocalizedString(@"Deleted", @"Data field name visible in smart folder definition");
-	[self fieldByName:MA_Field_Subject].displayName = NSLocalizedString(@"Subject", @"Data field name visible in menu/article list/smart folder definition");
-	[self fieldByName:MA_Field_Folder].displayName = NSLocalizedString(@"Folder", @"Data field name visible in menu/article list/smart folder definition");
-	[self fieldByName:MA_Field_LastUpdate].displayName = NSLocalizedString(@"Last Update", @"Data field name visible in menu/article list/smart folder definition");
-	[self fieldByName:MA_Field_PublicationDate].displayName = NSLocalizedString(@"Date Published", @"Data field name visible in menu/article list/smart folder definition");
-	[self fieldByName:MA_Field_Author].displayName = NSLocalizedString(@"Author", @"Data field name visible in menu/article list/smart folder definition");
-	[self fieldByName:MA_Field_Text].displayName = NSLocalizedString(@"Text", @"Data field name visible in smart folder definition");
-	[self fieldByName:MA_Field_Summary].displayName = NSLocalizedString(@"Summary", @"Pseudo field name visible in menu/article list");
-	[self fieldByName:MA_Field_Headlines].displayName = NSLocalizedString(@"Headlines", @"Pseudo field name visible in article list");
-	[self fieldByName:MA_Field_Link].displayName = NSLocalizedString(@"Link", @"Data field name visible in menu/article list");
-
-    // Disable visibility customization for some fields
-    [self fieldByName:MA_Field_Text].customizationOptions &= ~VNAFieldCustomizationVisibility;
-    [self fieldByName:MA_Field_GUID].customizationOptions &= ~VNAFieldCustomizationVisibility;
-    [self fieldByName:MA_Field_Deleted].customizationOptions &= ~VNAFieldCustomizationVisibility;
-    [self fieldByName:MA_Field_Parent].customizationOptions &= ~VNAFieldCustomizationVisibility;
-    [self fieldByName:MA_Field_Headlines].customizationOptions &= ~VNAFieldCustomizationVisibility;
-    [self fieldByName:MA_Field_EnclosureDownloaded].customizationOptions &= ~VNAFieldCustomizationVisibility;
-
-    // Disable resizing for some fields
-    [self fieldByName:MA_Field_Read].customizationOptions &= ~VNAFieldCustomizationResizing;
-    [self fieldByName:MA_Field_Flagged].customizationOptions &= ~VNAFieldCustomizationResizing;
-    [self fieldByName:MA_Field_HasEnclosure].customizationOptions &= ~VNAFieldCustomizationResizing;
-
-    // Disable sorting for some fields
-    [self fieldByName:MA_Field_Parent].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_GUID].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_Deleted].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_Headlines].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_Summary].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_Link].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_Text].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_EnclosureDownloaded].customizationOptions &= ~VNAFieldCustomizationSorting;
-    [self fieldByName:MA_Field_Enclosure].customizationOptions &= ~VNAFieldCustomizationSorting;
-}
-
 /* relocateLockedDatabase
  * Tell the user that the database could not be created at the path specified by path
  * and prompt for an alternative location. Opens and returns the new location if we were successful.
@@ -480,29 +411,172 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
     return _countOfUnread;
 }
 
-/* addField
- * Add the specified field to our fields array.
- */
--(void)addField:(NSString *)name type:(NSInteger)type sqlField:(NSString *)sqlField visible:(BOOL)visible width:(NSInteger)width
+- (NSArray<Field *> *)fields
 {
-	Field * field = [Field new];
-	if (field != nil) {
-		field.name = name;
-		field.type = type;
-		field.visible = visible;
-		field.width = width;
-		field.sqlField = sqlField;
-		[self.fieldsOrdered addObject:field];
-		[self.fieldsByName setValue:field forKey:name];
-	}
+    if (_fields) {
+        return _fields;
+    }
+
+    _fields = @[
+        [[Field alloc] initWithName:MA_Field_Read
+                               type:VNAFieldTypeFlag
+                           sqlField:@"read_flag"
+                        displayName:NSLocalizedString(@"Read",
+                                                      @"Data field name visible in menu/smart folder definition")
+                            visible:YES
+                              width:17
+               customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationSorting)],
+        [[Field alloc] initWithName:MA_Field_Flagged
+                               type:VNAFieldTypeFlag
+                           sqlField:@"marked_flag"
+                        displayName:NSLocalizedString(@"Flagged",
+                                                      @"Data field name visible in menu/smart folder definition")
+                            visible:YES
+                              width:17
+               customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationSorting)],
+        [[Field alloc] initWithName:MA_Field_HasEnclosure
+                               type:VNAFieldTypeFlag
+                           sqlField:@"hasenclosure_flag"
+                        displayName:NSLocalizedString(@"Enclosure",
+                                                      @"Data field name (Y/N) visible in menu/smart folder definition")
+                            visible:YES
+                              width:17
+               customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationSorting)],
+        [[Field alloc] initWithName:MA_Field_Deleted
+                               type:VNAFieldTypeFlag
+                           sqlField:@"deleted_flag"
+                        displayName:NSLocalizedString(@"Deleted",
+                                                      @"Data field name visible in smart folder definition")
+                            visible:NO
+                              width:15
+               customizationOptions:VNAFieldCustomizationResizing],
+        [[Field alloc] initWithName:MA_Field_GUID
+                               type:VNAFieldTypeInteger
+                           sqlField:@"message_id"
+                        displayName:nil
+                            visible:NO
+                              width:72
+               customizationOptions:VNAFieldCustomizationResizing],
+        [[Field alloc] initWithName:MA_Field_Subject
+                               type:VNAFieldTypeString
+                           sqlField:@"title"
+                        displayName:NSLocalizedString(@"Subject",
+                                                      @"Data field name visible in menu/article list/smart folder definition")
+                            visible:YES
+                              width:472
+               customizationOptions:VNAFieldCustomizationAll],
+        [[Field alloc] initWithName:MA_Field_Folder
+                               type:VNAFieldTypeFolder
+                           sqlField:@"folder_id"
+                        displayName:NSLocalizedString(@"Folder",
+                                                      @"Data field name visible in menu/article list/smart folder definition")
+                            visible:NO
+                              width:130
+               customizationOptions:VNAFieldCustomizationAll],
+        [[Field alloc] initWithName:MA_Field_LastUpdate
+                               type:VNAFieldTypeDate
+                           sqlField:@"date"
+                        displayName:NSLocalizedString(@"Last Update",
+                                                      @"Data field name visible in menu/article list/smart folder definition")
+                            visible:YES
+                              width:152
+               customizationOptions:VNAFieldCustomizationAll],
+        [[Field alloc] initWithName:MA_Field_PublicationDate
+                               type:VNAFieldTypeDate
+                           sqlField:@"createddate"
+                        displayName:NSLocalizedString(@"Date Published",
+                                                      @"Data field name visible in menu/article list/smart folder definition")
+                            visible:NO
+                              width:152
+               customizationOptions:VNAFieldCustomizationAll],
+        [[Field alloc] initWithName:MA_Field_Parent
+                               type:VNAFieldTypeInteger
+                           sqlField:@"parent_id"
+                        displayName:nil
+                            visible:NO
+                              width:72
+               customizationOptions:VNAFieldCustomizationResizing],
+        [[Field alloc] initWithName:MA_Field_Author
+                               type:VNAFieldTypeString
+                           sqlField:@"sender"
+                        displayName:NSLocalizedString(@"Author",
+                                                      @"Data field name visible in menu/article list/smart folder definition")
+                            visible:YES
+                              width:138
+               customizationOptions:VNAFieldCustomizationAll],
+        [[Field alloc] initWithName:MA_Field_Link
+                               type:VNAFieldTypeString
+                           sqlField:@"link"
+                        displayName:NSLocalizedString(@"Link",
+                                                      @"Data field name visible in menu/article list")
+                            visible:NO
+                              width:138
+               customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationResizing)],
+        [[Field alloc] initWithName:MA_Field_Text
+                               type:VNAFieldTypeString
+                           sqlField:@"text"
+                        displayName:NSLocalizedString(@"Text",
+                                                      @"Data field name visible in smart folder definition")
+                            visible:NO
+                              width:152
+               customizationOptions:VNAFieldCustomizationResizing],
+        [[Field alloc] initWithName:MA_Field_Summary
+                               type:VNAFieldTypeString
+                           sqlField:@"summary"
+                        displayName:NSLocalizedString(@"Summary",
+                                                      @"Pseudo field name visible in menu/article list")
+                            visible:NO
+                              width:152
+               customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationResizing)],
+        [[Field alloc] initWithName:MA_Field_Headlines
+                               type:VNAFieldTypeString
+                           sqlField:@""
+                        displayName:NSLocalizedString(@"Headlines",
+                                                      @"Pseudo field name visible in article list")
+                            visible:NO
+                              width:100
+               customizationOptions:VNAFieldCustomizationResizing],
+        [[Field alloc] initWithName:MA_Field_Enclosure
+                               type:VNAFieldTypeString
+                           sqlField:@"enclosure"
+                        displayName:NSLocalizedString(@"Enclosure URL",
+                                                      @"Data field name (URL) visible in menu/article list")
+                            visible:NO
+                              width:100
+               customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationResizing)],
+        [[Field alloc] initWithName:MA_Field_EnclosureDownloaded
+                               type:VNAFieldTypeFlag
+                           sqlField:@"enclosuredownloaded_flag"
+                        displayName:nil
+                            visible:NO
+                              width:100
+               customizationOptions:VNAFieldCustomizationResizing],
+    ];
+    return _fields;
 }
 
-/* arrayOfFields
- * Return the array of fields.
- */
--(NSArray *)arrayOfFields
+- (NSDictionary<NSString *, Field *> *)fieldsByName
 {
-	return self.fieldsOrdered;
+    if (_fieldsByName) {
+        return _fieldsByName;
+    }
+
+    NSArray *fields = self.fields;
+    NSMutableArray *names = [NSMutableArray array];
+    [fields enumerateObjectsUsingBlock:^(Field *field,
+                                         NSUInteger index,
+                                         BOOL *stop) {
+        @try {
+            [names addObject:field.name];
+        } @catch (NSException *exception) {
+            os_log_fault(VNA_LOG,
+                         "%{public}s %{public}@",
+                         __PRETTY_FUNCTION__, exception.description);
+            NSLog(@"Unexpected nil value: %@", exception);
+        }
+    }];
+    _fieldsByName = [[NSDictionary alloc] initWithObjects:fields forKeys:names];
+    return _fieldsByName;
 }
 
 /* fieldByTitle

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -66,14 +66,7 @@ static NSInteger const VNACurrentDatabaseVersion = 27;
 NSNotificationName const VNADatabaseWillDeleteFolderNotification = @"Database Will Delete Folder";
 NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did Delete Folder";
 
-/*!
- *  initialise the Database object with a specific path
- *
- *  @param dbPath the path to the database we want to initialise
- *
- *  @return an initialised Database object
- */
-- (instancetype)initWithDatabaseAtPath:(NSString *)dbPath
+- (instancetype)init
 {
     self = [super init];
     if (self) {
@@ -84,49 +77,46 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         _searchString = @"";
         _foldersDict = [[NSMutableDictionary alloc] init];
         [self initaliseFields];
-        _databaseQueue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
-        // If we did not succeed getting read/write+create status,
-        // then we need to prompt the user for a different location.
-        if (_databaseQueue == nil) {
-        	dbPath = [self relocateLockedDatabase:dbPath];
-        	if (dbPath != nil) {
-        		_databaseQueue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
-        	}
-        }
-        if (![self initialiseDatabase]) {
-			self = nil;
-		}
     }
     return self;
 }
 
-
-/* sharedManager
- * Returns the single instance of the database manager.
- */
-+ (instancetype)sharedManager {
-    static id sharedMyManager = nil;
++ (Database *)sharedManager
+{
+    static Database *sharedManager;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedMyManager = [[Database alloc] initWithDatabaseAtPath:[Database databasePath]];
+        sharedManager = [[Database alloc] init];
     });
-    
-    return sharedMyManager;
+    return sharedManager;
 }
 
+- (BOOL)loadDatabaseStore
+{
+    NSString *path = [Database databasePath];
+    if (!path) {
+        return NO;
+    }
 
-/*!
- *  Initialise the Vienna database. Create the initial database if
- *  necessary, otherwise migrate to the correct version if it is out of date
- *
- *  @return YES if the database is at the correct version and good to go
- */
-- (BOOL)initialiseDatabase {
+    FMDatabaseQueue *databaseQueue = [[FMDatabaseQueue alloc] initWithPath:path];
+    // If we did not succeed getting read/write+create status,
+    // then we need to prompt the user for a different location.
+    if (!databaseQueue) {
+        NSString *relocatedPath = [self relocateLockedDatabase:path];
+        if (relocatedPath) {
+            databaseQueue = [[FMDatabaseQueue alloc] initWithPath:relocatedPath];
+            if (!databaseQueue) {
+                return NO;
+            }
+        }
+    }
+    self.databaseQueue = databaseQueue;
+
     __block BOOL success = NO;
-    [self.databaseQueue inDatabase:^(FMDatabase *db) {
-                            success = [db executeStatements:@"PRAGMA quick_check;"];
+    [databaseQueue inDatabase:^(FMDatabase *db) {
+        success = [db executeStatements:@"PRAGMA quick_check;"];
     }];
-    if (self.databaseQueue && !success) {
+    if (!success) {
         NSAlert * alert = [NSAlert new];
         alert.alertStyle = NSAlertStyleCritical;
         alert.messageText = NSLocalizedString(@"Vienna's database seems to be corrupted. Would you like to quit Vienna or continue anyway?",
@@ -135,7 +125,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
             [NSString stringWithFormat:NSLocalizedString(
                  @"Vienna may not work as expected if the database is corrupted. We recommend you quit Vienna and either restore the database (%@) from a backup or attempt a sqlite3 recovery.",
                  @"Informative text of an alert"),
-             self.databaseQueue.path.lastPathComponent];
+             databaseQueue.path.lastPathComponent];
         [alert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"quitVienna.button",
                                                                     nil,
                                                                     NSBundle.mainBundle,
@@ -175,7 +165,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
 
         [self backupDatabase];
 
-        [self.databaseQueue inDatabase:^(FMDatabase *db) {
+        [databaseQueue inDatabase:^(FMDatabase *db) {
             // Migrate the database to the newest version
             // TODO: move this into transaction so we can rollback on failure
             [Database migrateDatabase:db fromVersion:databaseVersion];
@@ -193,7 +183,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
         NSAlert *alert = [NSAlert new];
         alert.alertStyle = NSAlertStyleCritical;
         alert.messageText = NSLocalizedString(@"The database file format has changed", nil);
-        alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.", nil), self.databaseQueue.path];
+        alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"The database (%@) file format is not supported by this version of Vienna. Delete or rename the file and restart Vienna.", nil), databaseQueue.path];
         [alert runModal];
         return NO;
     } else if (databaseVersion == 0) {

--- a/Vienna/Sources/Database/Database.m
+++ b/Vienna/Sources/Database/Database.m
@@ -452,11 +452,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                customizationOptions:VNAFieldCustomizationResizing],
         [[Field alloc] initWithName:MA_Field_GUID
                                type:VNAFieldTypeInteger
-                           sqlField:@"message_id"
-                        displayName:nil
-                            visible:NO
-                              width:72
-               customizationOptions:VNAFieldCustomizationResizing],
+                           sqlField:@"message_id"],
         [[Field alloc] initWithName:MA_Field_Subject
                                type:VNAFieldTypeString
                            sqlField:@"title"
@@ -491,11 +487,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                customizationOptions:VNAFieldCustomizationAll],
         [[Field alloc] initWithName:MA_Field_Parent
                                type:VNAFieldTypeInteger
-                           sqlField:@"parent_id"
-                        displayName:nil
-                            visible:NO
-                              width:72
-               customizationOptions:VNAFieldCustomizationResizing],
+                           sqlField:@"parent_id"],
         [[Field alloc] initWithName:MA_Field_Author
                                type:VNAFieldTypeString
                            sqlField:@"sender"
@@ -546,11 +538,7 @@ NSNotificationName const VNADatabaseDidDeleteFolderNotification = @"Database Did
                customizationOptions:(VNAFieldCustomizationVisibility | VNAFieldCustomizationResizing)],
         [[Field alloc] initWithName:MA_Field_EnclosureDownloaded
                                type:VNAFieldTypeFlag
-                           sqlField:@"enclosuredownloaded_flag"
-                        displayName:nil
-                            visible:NO
-                              width:100
-               customizationOptions:VNAFieldCustomizationResizing],
+                           sqlField:@"enclosuredownloaded_flag"],
     ];
     return _fields;
 }

--- a/Vienna/Sources/Database/Field.h
+++ b/Vienna/Sources/Database/Field.h
@@ -48,6 +48,10 @@ typedef NS_OPTIONS(NSUInteger, VNAFieldCustomizationOptions) {
                        width:(NSInteger)width
         customizationOptions:(VNAFieldCustomizationOptions)customizationOptions;
 
+- (instancetype)initWithName:(NSString *)name
+                        type:(VNAFieldType)type
+                    sqlField:(NSString *)sqlField;
+
 /// The field name is the unlocalised display name; useful for writing to data
 /// files where sysName isn't appropriate.
 @property (copy, nonatomic) NSString *name;

--- a/Vienna/Sources/Database/Field.h
+++ b/Vienna/Sources/Database/Field.h
@@ -33,9 +33,20 @@ typedef NS_OPTIONS(NSUInteger, VNAFieldCustomizationOptions) {
     VNAFieldCustomizationVisibility = 1 << 0,
     VNAFieldCustomizationResizing = 1 << 1,
     VNAFieldCustomizationSorting = 1 << 2,
+    VNAFieldCustomizationAll = (VNAFieldCustomizationVisibility |
+                                VNAFieldCustomizationResizing |
+                                VNAFieldCustomizationSorting)
 } NS_SWIFT_NAME(Field.CustomizationOptions);
 
 @interface Field : NSObject <NSSecureCoding>
+
+- (instancetype)initWithName:(NSString *)name
+                        type:(VNAFieldType)type
+                    sqlField:(NSString *)sqlField
+                 displayName:(NSString *)displayName
+                     visible:(BOOL)isVisible
+                       width:(NSInteger)width
+        customizationOptions:(VNAFieldCustomizationOptions)customizationOptions;
 
 /// The field name is the unlocalised display name; useful for writing to data
 /// files where sysName isn't appropriate.

--- a/Vienna/Sources/Database/Field.m
+++ b/Vienna/Sources/Database/Field.m
@@ -33,19 +33,23 @@ static NSString * const VNACodingKeyCustomizationOptions = @"customizationOption
 
 // MARK: Initialization
 
-- (instancetype)init
+- (instancetype)initWithName:(NSString *)name
+                        type:(VNAFieldType)type
+                    sqlField:(NSString *)sqlField
+                 displayName:(NSString *)displayName
+                     visible:(BOOL)isVisible
+                       width:(NSInteger)width
+        customizationOptions:(VNAFieldCustomizationOptions)customizationOptions
 {
     self = [super init];
     if (self) {
-        _name = nil;
-        _displayName = nil;
-        _sqlField = nil;
-        _type = VNAFieldTypeInteger;
-        _width = 20;
-        _visible = NO;
-        _customizationOptions = (VNAFieldCustomizationVisibility |
-                                 VNAFieldCustomizationResizing |
-                                 VNAFieldCustomizationSorting);
+        _name = [name copy];
+        _type = type;
+        _sqlField = [sqlField copy];
+        _displayName = [displayName copy];
+        _visible = isVisible;
+        _width = width;
+        _customizationOptions = customizationOptions;
     }
     return self;
 }

--- a/Vienna/Sources/Database/Field.m
+++ b/Vienna/Sources/Database/Field.m
@@ -54,6 +54,19 @@ static NSString * const VNACodingKeyCustomizationOptions = @"customizationOption
     return self;
 }
 
+- (instancetype)initWithName:(NSString *)name
+                        type:(VNAFieldType)type
+                    sqlField:(NSString *)sqlField
+{
+    self = [super init];
+    if (self) {
+        _name = [name copy];
+        _type = type;
+        _sqlField = [sqlField copy];
+    }
+    return self;
+}
+
 // MARK: Overrides
 
 - (NSString *)description

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -360,7 +360,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
  */
 -(void)updateVisibleColumns
 {
-	NSArray * fields = [[Database sharedManager] arrayOfFields];
+	NSArray *fields = Database.sharedManager.fields;
 	NSInteger count = fields.count;
 	NSInteger index;
 
@@ -511,8 +511,7 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	NSMutableArray * dataArray = [[NSMutableArray alloc] init];
 	
 	// Create the new columns
-	
-	for (Field * field in  [[Database sharedManager] arrayOfFields]) {
+	for (Field *field in Database.sharedManager.fields) {
 		[dataArray addObject:field.name];
 		[dataArray addObject:@(field.isVisible)];
 		[dataArray addObject:@(field.width)];


### PR DESCRIPTION
This is a followup to #2083.

I believe it is not a good idea to call all the database setup code within the `dispatch_once` block of the singleton initialiser. I have seen several instances where an exception is thrown or the app will just crash if objects that are meant to be accessed on the main thread are accessed from within that block.

In anticipation of #2063 I investigated which database code is accessed during the loading process of the view hierarchy and found that only the `arrayOfFields`/`fieldByName` accessors are read, which don't require the SQLite database to be loaded. I therefore reduced the Database initialiser to just initialise the class and ivars and moved the database setup code into a separate `‑loadDatabaseStore` method that is called from `‑applicationDidFinishLaunching:`. I made `arrayOfFields`/​`fieldByName` lazily loaded and simplified the Field initialisation code by adding a convenience initialiser.