### PR TITLE
Enable hasDestructiveAction property of certain NSAlert buttons

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2038,6 +2038,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
                                                                     NSBundle.mainBundle,
                                                                     @"Delete",
                                                                     @"Title of a button on an alert")];
+        if (@available(macOS 11, *)) {
+            alert.buttons.lastObject.hasDestructiveAction = YES;
+        }
         [alert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"cancel.button",
                                                                     nil,
                                                                     NSBundle.mainBundle,

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -1167,6 +1167,9 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
                                                                     NSBundle.mainBundle,
                                                                     @"Delete",
                                                                     @"Title of a button on an alert")];
+        if (@available(macOS 11, *)) {
+            alert.buttons.lastObject.hasDestructiveAction = YES;
+        }
         [alert addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"cancel.button",
                                                                     nil,
                                                                     NSBundle.mainBundle,


### PR DESCRIPTION
This will highlight the "Delete" buttons in red instead of the accent colour on macOS 11+. I've applied this only to alerts that are triggered by pressing the delete key.

<img width="294" height="179" alt="image" src="https://github.com/user-attachments/assets/2f77078b-1447-4b2a-bf03-3e27e6bbc057" />
