### PR TITLE
Make AppleScript run in default quality of service

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -916,7 +916,7 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 -(void)runAppleScript:(NSString *)scriptName
 {
     NSString *baseScriptName = scriptName.lastPathComponent.stringByDeletingPathExtension;
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
         NSDictionary *errorDictionary;
         NSURL *scriptURL = [NSURL fileURLWithPath:scriptName];
         NSAppleScript *appleScript = [[NSAppleScript alloc] initWithContentsOfURL:scriptURL error:&errorDictionary];


### PR DESCRIPTION
Avoid priority inversion as main thread is running in default quality-of-service class.

Reverse commit 06376b7