### PR TITLE
Rename property that shadows an AppKit property of a different type

### DIFF
--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1249,11 +1249,11 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
     id<Tab> activeBrowserTab = self.browser.activeTab;
     if (activeBrowserTab) {
-        return activeBrowserTab.textSelection;
+        return activeBrowserTab.selectedText;
     } else {
-        id target = [NSApp targetForAction:@selector(textSelection)];
+        id target = [NSApp targetForAction:@selector(selectedText)];
         if (target) {
-            return [target textSelection];
+            return [target selectedText];
         }
     }
     return @"";

--- a/Vienna/Sources/Main window/BrowserTab.swift
+++ b/Vienna/Sources/Main window/BrowserTab.swift
@@ -213,8 +213,8 @@ extension BrowserTab: Tab {
         }
     }
 
-    var textSelection: String {
-        webView.textSelection
+    var selectedText: String {
+        webView.selectedText
     }
 
     var html: String {

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -48,7 +48,7 @@ class CustomWKWebView: WKWebView {
     var canScrollUp: Bool {
         evaluateScrollPossibilities().scrollUpPossible
     }
-    @objc var textSelection: String {
+    @objc var selectedText: String {
         getTextSelection()
     }
 

--- a/Vienna/Sources/Main window/Tab.swift
+++ b/Vienna/Sources/Main window/Tab.swift
@@ -24,7 +24,7 @@ protocol Tab {
 
     var tabUrl: URL? { get set }
     var title: String? { get }
-    var textSelection: String { get }
+    var selectedText: String { get }
     var html: String { get }
     var isLoading: Bool { get }
 


### PR DESCRIPTION
This is a build warning in Xcode 27. The `textSelection` signature is now a protocol property that returns an NSTextSelection object instead of an NSString.