### PR TITLE
Do not ignore Package.resolved and restrict Sparkle to version 2.9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ xcuserdata/
 
 # SwiftPM
 .build/
-Package.resolved
 
 # Vienna
 Vienna/Localizations/

--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -2805,8 +2805,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.8.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.9.0;
 			};
 		};
 		F6B7BC3424A2A9A40051D76F /* XCRemoteSwiftPackageReference "fmdb" */ = {

--- a/Vienna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vienna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "fmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ccgus/fmdb",
+      "state" : {
+        "revision" : "1227a3fa2b9916bfd75fe380eb45cd210e69e251",
+        "version" : "2.7.12"
+      }
+    },
+    {
+      "identity" : "mmtabbarview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ViennaRSS/MMTabBarView",
+      "state" : {
+        "branch" : "v/1.5.4",
+        "revision" : "3ad4bb0feb4a51d447591be132a25df153d5afc0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
Sparkle has updated its main branch for Xcode 27, meaning that future releases (2.10.x) will require macOS 12, which isn't the minimum deployment of Vienna (but see #2140 for further discussion). This PR ensures that version 2.10.x won't be used as long as Vienna supports older macOS versions.  

I also propose to revert 923e5443fcaab20d52e2a4ee80136b0550a7239f and include Package.resolved again. I think the reason why it was added to .gitignore was the unstable file format of Package.resolved, but it has since been stable. I believe knowing which package version is used at any point is preferable to keep control over which version is included in a release.