### PR TITLE
Improve cache management to speed feed refreshes

### DIFF
--- a/Vienna/Sources/Models/Folder.h
+++ b/Vienna/Sources/Models/Folder.h
@@ -69,7 +69,7 @@ typedef NS_OPTIONS(NSUInteger, VNAFolderFlag) {
     VNAFolderFlagBuggySync       = 1 << 7
 };
 
-@interface Folder : NSObject <NSCacheDelegate>
+@interface Folder : NSObject
 
 - (instancetype)initWithId:(NSInteger)itemId
                   parentId:(NSInteger)parentId

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -617,10 +617,11 @@
         NSArray * myArray = [[Database sharedManager] minimalCacheForFolder:self.itemId];
         for (Article * myArticle in myArray) {
             NSString * guid = myArticle.guid;
-            myArticle.status = [self retrieveKnownStatusForGuid:guid];
-            [self.cachedArticles setObject:myArticle forKey:guid];
-            if (![self.cachedGuids containsObject:guid]) {
-                [self.cachedGuids addObject:guid];
+            if (![self.cachedArticles objectForKey:guid]) {
+                [self.cachedArticles setObject:myArticle forKey:guid];
+                if (![self.cachedGuids containsObject:guid]) {
+                    [self.cachedGuids addObject:guid];
+                }
             }
         }
         self.isCached = YES;

--- a/Vienna/Sources/Models/Folder.m
+++ b/Vienna/Sources/Models/Folder.m
@@ -70,7 +70,6 @@
 		_containsBodies = NO;
 		_hasPassword = NO;
 		_cachedArticles = [NSCache new];
-		_cachedArticles.delegate = self;
 		_cachedGuids = [NSMutableArray array];
 		_attributes = [NSMutableDictionary dictionary];
 		self.name = newName;
@@ -849,13 +848,4 @@
 	return [NSString stringWithFormat:@"Folder id %li (%@)", (long)self.itemId, self.name];
 }
 
-#pragma mark NSCacheDelegate
--(void)cache:(NSCache *)cache willEvictObject:(id)obj
-{
-    @synchronized(self) {
-        Article * theArticle = ((Article *)obj);
-        NSString * guid = theArticle.guid;
-        [self.cachedGuids removeObject:guid];
-    }
-}
 @end


### PR DESCRIPTION
Fix issues #2134 and #2137
According to my tests, these slowdowns were mostly noticeable when "Mark updated articles as new" was enabled, which triggered calls to `-ensureCache`

