### PR TITLE
Replace macOS 10.15 API with older API to avoid a crash

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -2455,6 +2455,7 @@
 					"-Wunused-macros",
 					"-Xclang",
 					"-analyzer-tidy-checker=readability-braces-around-statements,readability-misleading-indentation",
+					"-Werror=unguarded-availability",
 				);
 			};
 			name = Development;
@@ -2497,6 +2498,7 @@
 					"-Wunused-macros",
 					"-Xclang",
 					"-analyzer-tidy-checker=readability-braces-around-statements,readability-misleading-indentation",
+					"-Werror=unguarded-availability",
 				);
 			};
 			name = Deployment;

--- a/Vienna/Sources/Fetching/RefreshManager.m
+++ b/Vienna/Sources/Fetching/RefreshManager.m
@@ -597,13 +597,13 @@ typedef NS_ENUM (NSInteger, Redirect301Status) {
             // "Cache-Control" HTTP header field.
             // See: RFC 9111, s 5.2.2.5
             NSString *cacheControlHeaderField =
-                [httpURLResponse valueForHTTPHeaderField:@"Cache-Control"];
+                httpURLResponse.allHeaderFields[@"Cache-Control"];
             NSRange noStoreDirectiveRange =
                 [cacheControlHeaderField rangeOfString:@"no-store"
                                                options:NSCaseInsensitiveSearch];
             if (noStoreDirectiveRange.length == 0) {
                 lastModifiedString =
-                    [httpURLResponse valueForHTTPHeaderField:@"Last-Modified"];
+                    httpURLResponse.allHeaderFields[@"Last-Modified"];
             }
         }
 


### PR DESCRIPTION
Fixed a crash as a result of #2147. This only affects the `stable` branch.

Unfortunately, xcodebuild/GitHub Actions didn't flag this. I turned the unguarded-availability warnings into an error now to hopefully flag such issues in the future.

@barijaona I pulled 3.10.7 from GitHub (I left a draft release) and the Sparkle feed. On SourceForge I marked the update as "staged" so that it doesn't appear on the website.