### PR TITLE
Turn unguarded-availability build warnings into errors

### DIFF
--- a/Vienna.xcodeproj/project.pbxproj
+++ b/Vienna.xcodeproj/project.pbxproj
@@ -2436,6 +2436,7 @@
 					"-Wunused-macros",
 					"-Xclang",
 					"-analyzer-tidy-checker=readability-braces-around-statements,readability-misleading-indentation",
+					"-Werror=unguarded-availability",
 				);
 			};
 			name = Development;
@@ -2481,6 +2482,7 @@
 					"-Wunused-macros",
 					"-Xclang",
 					"-analyzer-tidy-checker=readability-braces-around-statements,readability-misleading-indentation",
+					"-Werror=unguarded-availability",
 				);
 			};
 			name = Deployment;


### PR DESCRIPTION
If unavailable API calls are used, this should fail the build instead of showing a warning.