### PR TITLE
Make rss link detection safer

### DIFF
--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -81,7 +81,13 @@ extension BrowserTab: RSSSource {
                 finishHandler()
                 return
             }
+            var didFinish = false
             self.webView.evaluateJavaScript(BrowserTab.extractHTMLSource) { result, error in
+                guard !didFinish else {
+                    self.rssUrls = []
+                    return
+                }
+                didFinish = true
                 defer { finishHandler() }
                 if let html = result as? String, let data = html.data(using: .utf8), let baseUrl = self.url, error == nil {
                     let discoverer = FeedDiscoverer(data: data, baseURL: baseUrl)
@@ -89,6 +95,14 @@ extension BrowserTab: RSSSource {
                 } else {
                     // error or conversion problem
                     self.rssUrls = []
+                }
+            }
+            // Timeout fallback
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
+                if !didFinish {
+                    didFinish = true
+                    self.rssUrls = []
+                    finishHandler()
                 }
             }
         }

--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -77,14 +77,18 @@ extension BrowserTab: RSSSource {
         // use javascript to detect RSS feed link
         // TODO: deal with multiple links
         waitForAsyncExecution(until: DispatchTime.now() + DispatchTimeInterval.milliseconds(200)) { [weak self] finishHandler in
-            self?.webView.evaluateJavaScript(BrowserTab.extractHTMLSource) { result, error in
+            guard let self = self else {
+                finishHandler()
+                return
+            }
+            self.webView.evaluateJavaScript(BrowserTab.extractHTMLSource) { result, error in
                 defer { finishHandler() }
-                if let html = result as? String, let data = html.data(using: .utf8), let baseUrl = self?.url, error == nil {
+                if let html = result as? String, let data = html.data(using: .utf8), let baseUrl = self.url, error == nil {
                     let discoverer = FeedDiscoverer(data: data, baseURL: baseUrl)
-                    self?.rssUrls = discoverer.feedURLs().map(\.absoluteURL)
+                    self.rssUrls = discoverer.feedURLs().map(\.absoluteURL)
                 } else {
                     // error or conversion problem
-                    self?.rssUrls = []
+                    self.rssUrls = []
                 }
             }
         }

--- a/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
+++ b/Vienna/Sources/Main window/BrowserTab+RSSSource.swift
@@ -55,8 +55,8 @@ extension BrowserTab: RSSSource {
 
     @objc
     func viewDidLoadRss() {
-        registerNavigationEndHandler { [weak self] success in self?.handleNavigationEndRss(success: success) }
         refreshRSSState()
+        registerNavigationEndHandler { [weak self] success in self?.handleNavigationEndRss(success: success) }
     }
 
     func refreshRSSState() {

--- a/Vienna/Sources/Shared/AsyncHelper.swift
+++ b/Vienna/Sources/Shared/AsyncHelper.swift
@@ -22,7 +22,8 @@ import Foundation
 /// Gives an asynchronous call the ability to run like synchronously called. Calling the finishHandler signals that the execution has finished.
 /// - Parameters:
 ///   - waitingQueue: The queue that waits for the execution to finish
-///   - executingQueue: the queue where the execution shall happen. Must not be the same as queue!
+///   - executingQueue: the queue where the execution shall happen. Must not be the same as waitingQueue!
+///   - delay: delay before starting the execution block!
 ///   - deadline: when to stop waiting for the task to finish execution
 ///   - task: the code that shall be executed. ATTENTION: must call the finishHandler at some point!
 func waitForAsyncExecution(on waitingQueue: DispatchQueue = DispatchQueue.global(qos: .userInitiated), executingQueue: DispatchQueue = DispatchQueue.main, after delay: DispatchTime? = nil, until deadline: DispatchTime? = nil, _ task: @escaping (_ finishHandler: @escaping () -> Void) -> Void ) {


### PR DESCRIPTION
I still (very occasionally) see Vienna hanging on `waitForAsyncExecution` while attempting to detect RSS links (same issue that was already discussed in PR #2059).

The main risks appear to be Javascript timeouts and/or premature deallocation.
If approved, these changes should be backported to `stable` branch.