### PR TITLE
AppController: add Add Subscription menu item to the menu bar icon

### DIFF
--- a/Vienna/Interfaces/Base.lproj/Main.storyboard
+++ b/Vienna/Interfaces/Base.lproj/Main.storyboard
@@ -743,8 +743,8 @@ CA
                                                 <action selector="previousTab:" target="Ady-hI-5gd" id="uIb-HR-dbe"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Next Tab" keyEquivalent="" id="1009">
-                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                        <menuItem title="Next Tab" keyEquivalent="⇥" id="1009">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES"/>
                                             <connections>
                                                 <action selector="nextTab:" target="Ady-hI-5gd" id="dkJ-sH-L2U"/>
                                             </connections>
@@ -824,6 +824,13 @@ CA
                 <userDefaultsController representsSharedInstance="YES" id="6A7-UP-2hS"/>
                 <menu id="JWi-Bw-kAV" userLabel="Dock Menu">
                     <items>
+                        <menuItem title="New Subscription…" id="K3b-Qm-MH7">
+                            <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="newSubscription:" target="Ady-hI-5gd" id="qgd-xT-lQd"/>
+                            </connections>
+                        </menuItem>
+                        <menuItem isSeparatorItem="YES" id="lKD-wr-Syu"/>
                         <menuItem title="Refresh All Subscriptions" id="6yn-y8-lF1">
                             <connections>
                                 <action selector="refreshAllSubscriptions:" target="Ady-hI-5gd" id="Whj-Tj-DBA"/>
@@ -1151,7 +1158,7 @@ CA
                                     <autoresizingMask key="autoresizingMask"/>
                                     <clipView key="contentView" copiesOnScroll="NO" id="TOX-JT-adF">
                                         <rect key="frame" x="0.0" y="0.0" width="701" height="308"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <autoresizingMask key="autoresizingMask"/>
                                         <subviews>
                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" autosaveColumns="NO" rowHeight="15" headerView="1386" id="977" customClass="MessageListView">
                                                 <rect key="frame" x="0.0" y="0.0" width="701" height="285"/>
@@ -1205,7 +1212,7 @@ CA
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <clipView key="contentView" id="emU-La-Fur">
                                 <rect key="frame" x="0.0" y="0.0" width="701" height="677"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="NgO-hM-mCz">
                                         <rect key="frame" x="0.0" y="0.0" width="701" height="677"/>

--- a/Vienna/Interfaces/mul.lproj/Main.xcstrings
+++ b/Vienna/Interfaces/mul.lproj/Main.xcstrings
@@ -19594,6 +19594,18 @@
         }
       }
     },
+    "K3b-Qm-MH7.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"New Subscription…\"; ObjectID = \"K3b-Qm-MH7\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Subscription…"
+          }
+        }
+      }
+    },
     "kCi-pf-mkc.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Smart Quotes\"; ObjectID = \"kCi-pf-mkc\";",
       "extractionState" : "extracted_with_value",

--- a/Vienna/Resources/Localizable.xcstrings
+++ b/Vienna/Resources/Localizable.xcstrings
@@ -3700,6 +3700,9 @@
         }
       }
     },
+    "Add Subscription…" : {
+      "comment" : "Title of a menu item in Dock"
+    },
     "Add to Safari Reading List" : {
       "comment" : "Toolbar item palette label",
       "localizations" : {

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1303,6 +1303,10 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
                                  action:@selector(openVienna:)
                           keyEquivalent:@""];
         [statusBarMenu addItem:[NSMenuItem separatorItem]];
+		[statusBarMenu addItemWithTitle:NSLocalizedString(@"Add Subscription…", @"Title of a menu item in menu bar icon")
+								 action:@selector(newSubscription:)
+						  keyEquivalent:@""];
+		[statusBarMenu addItem:[NSMenuItem separatorItem]];
 		[statusBarMenu addItemWithTitle:NSLocalizedString(@"Refresh All Subscriptions", @"Title of a menu item")
 								 action:@selector(refreshAllSubscriptions:)
 						  keyEquivalent:@""];
@@ -1893,6 +1897,16 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
  */
 -(IBAction)newSubscription:(id)sender
 {
+    // This can be triggered from the menu bar icon while Vienna is in the
+    // background, so activate the app and show the main window before
+    // presenting the sheet on it.
+    if (@available(macOS 14, *)) {
+        [NSApp activate];
+    } else {
+        [NSApp activateIgnoringOtherApps:YES];
+    }
+
+    [self showMainWindow:self];
     VNASubscribeViewController *viewController = [VNASubscribeViewController instantiateFromStoryboard];
     [self.mainWindow.contentViewController presentViewControllerAsSheet:viewController];
 }


### PR DESCRIPTION
Add an "Add Subscription…" item to the menu bar icon menu. It reuses -newSubscription:, which now activates the app and shows the main window first so the sheet has a window to attach to when triggered from the background.