### PR TITLE
Log a folder name when its conversion fails

### DIFF
--- a/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
+++ b/Vienna/Sources/Criteria/Criteria+NSPredicate.swift
@@ -331,6 +331,7 @@ extension Criteria: PredicateConvertible {
         guard let database = Database.shared, let folder = database.folder(fromName: value) else {
             // no error, since it is possible that a folder was renamed or deleted
             // without considering the smart folder referencing it
+            NSLog("[Criteria] Could not resolve folder name '\(value)' in test or conversion. Renamed or deleted?")
             return ""
         }
 


### PR DESCRIPTION
I had some tests fail and a hard time understanding why...
(It turned out that I had renamed the "BBC World News" folder)