### PR TITLE
Add/fix support for Control-Tab and Control-Shift-Tab keyboard shortcuts

### DIFF
--- a/Vienna/Interfaces/Base.lproj/Main.storyboard
+++ b/Vienna/Interfaces/Base.lproj/Main.storyboard
@@ -737,16 +737,16 @@ CA
                                                 <action selector="viewArticlesTab:" target="Ady-hI-5gd" id="p4V-jV-gaL"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Previous Tab" keyEquivalent="" id="1008">
-                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                        <menuItem title="Previous Tab" keyEquivalent="⇥" id="1008">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" control="YES"/>
                                             <connections>
-                                                <action selector="previousTab:" target="Ady-hI-5gd" id="uIb-HR-dbe"/>
+                                                <action selector="selectPreviousTab:" target="Ady-hI-5gd" id="k5L-ag-kk0"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Next Tab" keyEquivalent="⇥" id="1009">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES"/>
                                             <connections>
-                                                <action selector="nextTab:" target="Ady-hI-5gd" id="dkJ-sH-L2U"/>
+                                                <action selector="selectNextTab:" target="Ady-hI-5gd" id="Nax-N4-rt0"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="1077"/>
@@ -1097,7 +1097,7 @@ CA
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="5Fc-hn-Xm4">
                                         <rect key="frame" x="0.0" y="0.0" width="942" height="22"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="350" translatesAutoresizingMaskIntoConstraints="NO" id="917">
+                                            <textField focusRingType="none" verticalHuggingPriority="750" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="350" translatesAutoresizingMaskIntoConstraints="NO" id="917">
                                                 <rect key="frame" x="419" y="4" width="104" height="14"/>
                                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" id="1367">
                                                     <font key="font" metaFont="smallSystem"/>
@@ -1267,7 +1267,7 @@ CA
                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="3" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RFH-Us-xJO">
                                     <rect key="frame" x="58" y="10" width="300" height="31"/>
                                     <subviews>
-                                        <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1290">
+                                        <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1290">
                                             <rect key="frame" x="-2" y="17" width="304" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" id="1373">
                                                 <font key="font" metaFont="smallSystemBold"/>
@@ -1275,7 +1275,7 @@ CA
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1292" customClass="DSClickableURLTextField">
+                                        <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1292" customClass="DSClickableURLTextField">
                                             <rect key="frame" x="-2" y="0.0" width="304" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="1375">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -1377,7 +1377,7 @@ CA
                                                                     <rect key="frame" x="-1" y="0.0" width="20" height="20"/>
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="a3L-k0-Hh3"/>
                                                                 </imageView>
-                                                                <textField identifier="TextField" horizontalHuggingPriority="249" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JQW-he-OfP">
+                                                                <textField identifier="TextField" focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JQW-he-OfP">
                                                                     <rect key="frame" x="20" y="1" width="180" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" title="Folder Name" id="RHN-51-qgk">
                                                                         <font key="font" metaFont="system"/>

--- a/Vienna/Sources/Application/AppController.h
+++ b/Vienna/Sources/Application/AppController.h
@@ -71,8 +71,6 @@
 -(IBAction)cancelAllRefreshes:(id)sender;
 -(IBAction)openStylesPage:(id)sender;
 -(IBAction)showMainWindow:(id)sender;
--(IBAction)previousTab:(id)sender;
--(IBAction)nextTab:(id)sender;
 -(IBAction)closeActiveTab:(id)sender;
 -(IBAction)closeAllTabs:(id)sender;
 - (IBAction)reopenLastClosedTab:(id)sender;

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -2245,22 +2245,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	[self.browser switchToPrimaryTab];
 }
 
-/* previousTab
- * Display the previous tab, if there is one.
- */
--(IBAction)previousTab:(id)sender
-{
-	[self.browser showPreviousTab];
-}
-
-/* nextTab
- * Display the next tab, if there is one.
- */
--(IBAction)nextTab:(id)sender
-{
-	[self.browser showNextTab];
-}
-
 /* closeAllTabs
  * Closes all tab windows.
  */
@@ -2858,10 +2842,6 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 	} else if (theAction == @selector(editFolder:)) {
 		Folder * folder = [db folderFromID:self.foldersTree.actualSelection];
 		return folder && (folder.type == VNAFolderTypeSmart || folder.type == VNAFolderTypeRSS) && !db.readOnly && isMainWindowVisible;
-	} else if (theAction == @selector(previousTab:)) {
-		return isMainWindowVisible && self.browser.browserTabCount > 1;
-	} else if (theAction == @selector(nextTab:)) {
-		return isMainWindowVisible && self.browser.browserTabCount > 1;
 	} else if (theAction == @selector(closeActiveTab:)) {
 		return isMainWindowVisible && !isArticleView;
 	} else if (theAction == @selector(closeAllTabs:)) {

--- a/Vienna/Sources/Application/AppController.m
+++ b/Vienna/Sources/Application/AppController.m
@@ -1707,8 +1707,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
     NSEventModifierFlags flags = event.modifierFlags;
 	switch (keyChar) {
 		case NSLeftArrowFunctionKey:
-            if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) {
-				return NO;
+            if ((flags & NSEventModifierFlagCommand) && (flags & NSEventModifierFlagOption)) {
+                [self.mainWindow selectPreviousTab:nil];
+                return YES;
 			} else {
 				if (self.mainWindow.firstResponder == ((NSView<BaseView> *)self.browser.primaryTab.view).mainView) {
 					[self.mainWindow makeFirstResponder:self.foldersTree.mainView];
@@ -1718,8 +1719,9 @@ withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 			return NO;
 			
 		case NSRightArrowFunctionKey:
-            if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagOption)) {
-				return NO;
+            if ((flags & NSEventModifierFlagCommand) && (flags & NSEventModifierFlagOption)) {
+                [self.mainWindow selectNextTab:nil];
+                return YES;
 			} else {
 				if (self.mainWindow.firstResponder == self.foldersTree.mainView) {
 					[self.browser switchToPrimaryTab];

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -64,6 +64,28 @@ class CustomWKWebView: WKWebView {
         self.window?.selectPreviousTab(sender)
     }
 
+    // work around WKWebView also intercepting Command–Option–Left and Command–Option–Right
+    // and have them act as legacy key combos for switching between tabs
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isCommandOption = flags.contains(.command) && flags.contains(.option)
+        let leftArrowKeyCode: UInt16 = 123
+        let rightArrowKeyCode: UInt16 = 124
+
+        if isCommandOption {
+            if event.keyCode == leftArrowKeyCode {
+                // Handle Command-Option-Left
+                self.window?.selectPreviousTab(nil)
+                return true
+            } else if event.keyCode == rightArrowKeyCode {
+                // Handle Command-Option-Right
+                self.window?.selectNextTab(nil)
+                return true
+            }
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
     private let usesMinimumFontSizeObservation: NSKeyValueObservation
     private let minimumFontSizeObservation: NSKeyValueObservation
     private var useJavaScriptObservation: NSKeyValueObservation?

--- a/Vienna/Sources/Main window/CustomWKWebView.swift
+++ b/Vienna/Sources/Main window/CustomWKWebView.swift
@@ -52,6 +52,18 @@ class CustomWKWebView: WKWebView {
         getTextSelection()
     }
 
+    // for some reason, WKWebView intercepts ⌃ ⇥ and ⌃ ⇧ ⇥ without passing them down the NSReponder chain
+    // cf. https://stackoverflow.com/a/72404941/1615647
+    @objc
+    func selectNextKeyView(_ sender: Any?) {
+        self.window?.selectNextTab(sender)
+    }
+
+    @objc
+    func selectPreviousKeyView(_ sender: Any?) {
+        self.window?.selectPreviousTab(sender)
+    }
+
     private let usesMinimumFontSizeObservation: NSKeyValueObservation
     private let minimumFontSizeObservation: NSKeyValueObservation
     private var useJavaScriptObservation: NSKeyValueObservation?

--- a/Vienna/Sources/Main window/MainWindow.swift
+++ b/Vienna/Sources/Main window/MainWindow.swift
@@ -42,4 +42,15 @@ final class MainWindow: NSWindow {
         }
     }
 
+    override func selectNextTab(_ sender: Any?) {
+        if let browser = MainWindowController.shared.browser {
+            browser.showNextTab()
+        }
+    }
+
+    override func selectPreviousTab(_ sender: Any?) {
+        if let browser = MainWindowController.shared.browser {
+            browser.showPreviousTab()
+        }
+    }
 }

--- a/Vienna/Sources/Main window/MainWindow.swift
+++ b/Vienna/Sources/Main window/MainWindow.swift
@@ -37,7 +37,13 @@ final class MainWindow: NSWindow {
             }
 
             return true
-        } else {
+        } else if menuItem.action == #selector(selectNextTab(_:)) || menuItem.action == #selector(selectPreviousTab(_:))  {
+            if let count = MainWindowController.shared.browser?.browserTabCount {
+                return count > 1
+            } else {
+                return false
+            }
+       } else {
             return super.validateMenuItem(menuItem)
         }
     }


### PR DESCRIPTION
Issue #1952: use the keyboard shortcuts described in Apple's documentation 
https://support.apple.com/guide/mac-help/use-tabs-in-windows-mchla4695cce/mac

Maintain Alt-Command-Left Arrow and Alt-Command-Right Arrow as Firefox and Chrome do.