### PR TITLE
Resolve undefined behaviour sanitiser warning

### DIFF
--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -556,8 +556,8 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 	NSString * guidOfArticleToPreserve = articleToPreserve.guid;
 	
 	NSInteger filterMode = [Preferences standardPreferences].filterMode;
-	for (NSInteger index = filteredArray.count - 1; index >= 0; --index) {
-		Article * article = filteredArray[index];
+	for (NSInteger index = filteredArray.count; index > 0; --index) {
+		Article * article = filteredArray[index - 1];
 		if (guidOfArticleToPreserve != nil
 			&& article.folderId == articleToPreserve.folderId 
 			&& [article.guid isEqualToString:guidOfArticleToPreserve]) {


### PR DESCRIPTION
The undefined behaviour sanitiser warns about an integer underflow as a result of subtracting 1 from `count` (an unsigned integer).