### PR TITLE
Modernize copy/paste, drag n'drop & sharing services

### DIFF
--- a/Vienna/Interfaces/Base.lproj/Main.storyboard
+++ b/Vienna/Interfaces/Base.lproj/Main.storyboard
@@ -1097,7 +1097,7 @@ CA
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="5Fc-hn-Xm4">
                                         <rect key="frame" x="0.0" y="0.0" width="942" height="22"/>
                                         <subviews>
-                                            <textField focusRingType="none" verticalHuggingPriority="750" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="350" translatesAutoresizingMaskIntoConstraints="NO" id="917">
+                                            <textField verticalHuggingPriority="750" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="350" translatesAutoresizingMaskIntoConstraints="NO" id="917">
                                                 <rect key="frame" x="419" y="4" width="104" height="14"/>
                                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" id="1367">
                                                     <font key="font" metaFont="smallSystem"/>
@@ -1158,7 +1158,7 @@ CA
                                     <autoresizingMask key="autoresizingMask"/>
                                     <clipView key="contentView" copiesOnScroll="NO" id="TOX-JT-adF">
                                         <rect key="frame" x="0.0" y="0.0" width="701" height="308"/>
-                                        <autoresizingMask key="autoresizingMask"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" autosaveColumns="NO" rowHeight="15" headerView="1386" id="977" customClass="MessageListView">
                                                 <rect key="frame" x="0.0" y="0.0" width="701" height="285"/>
@@ -1212,9 +1212,9 @@ CA
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <clipView key="contentView" id="emU-La-Fur">
                                 <rect key="frame" x="0.0" y="0.0" width="701" height="677"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="NgO-hM-mCz">
+                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="NgO-hM-mCz" customClass="MessageListView">
                                         <rect key="frame" x="0.0" y="0.0" width="701" height="677"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <size key="intercellSpacing" width="3" height="2"/>
@@ -1267,7 +1267,7 @@ CA
                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="3" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RFH-Us-xJO">
                                     <rect key="frame" x="58" y="10" width="300" height="31"/>
                                     <subviews>
-                                        <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1290">
+                                        <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1290">
                                             <rect key="frame" x="-2" y="17" width="304" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" id="1373">
                                                 <font key="font" metaFont="smallSystemBold"/>
@@ -1275,7 +1275,7 @@ CA
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1292" customClass="DSClickableURLTextField">
+                                        <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="14" preferredMaxLayoutWidth="9000" translatesAutoresizingMaskIntoConstraints="NO" id="1292" customClass="DSClickableURLTextField">
                                             <rect key="frame" x="-2" y="0.0" width="304" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="1375">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -1377,7 +1377,7 @@ CA
                                                                     <rect key="frame" x="-1" y="0.0" width="20" height="20"/>
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="a3L-k0-Hh3"/>
                                                                 </imageView>
-                                                                <textField identifier="TextField" focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JQW-he-OfP">
+                                                                <textField identifier="TextField" horizontalHuggingPriority="249" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JQW-he-OfP">
                                                                     <rect key="frame" x="20" y="1" width="180" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" title="Folder Name" id="RHN-51-qgk">
                                                                         <font key="font" metaFont="system"/>

--- a/Vienna/Sources/Main window/ArticleBaseView.h
+++ b/Vienna/Sources/Main window/ArticleBaseView.h
@@ -34,6 +34,7 @@
 	-(void)refreshFolder:(NSInteger)refreshFlag;
 	@property (nonatomic, readonly) Article *selectedArticle;
 	@property (readonly, nonatomic) NSArray *markedArticleRange;
+	@property (readonly, nonatomic) NSArray *itemsForMarkedRange;
 	-(void)saveTableSettings;
 	-(void)ensureSelectedArticle;
 

--- a/Vienna/Sources/Main window/ArticleController.h
+++ b/Vienna/Sources/Main window/ArticleController.h
@@ -55,6 +55,7 @@
 @property (nonatomic, readonly) NSInteger currentFolderId;
 @property (nonatomic, readonly) Article *selectedArticle;
 @property (readonly, nonatomic) NSArray *markedArticleRange;
+@property (readonly, nonatomic) NSArray *itemsForMarkedRange;
 -(void)saveTableSettings;
 -(void)sortArticles;
 @property (readonly, nonatomic) NSArray *allArticles;

--- a/Vienna/Sources/Main window/ArticleController.m
+++ b/Vienna/Sources/Main window/ArticleController.m
@@ -233,6 +233,13 @@ static void *VNAArticleControllerObserverContext = &VNAArticleControllerObserver
 	return mainArticleView.markedArticleRange;
 }
 
+/* itemsForMarkedRange
+ */
+-(NSArray *)itemsForMarkedRange
+{
+    return mainArticleView.itemsForMarkedRange;
+}
+
 /* saveTableSettings
  * Save selected article and folder
  * and, for relevant layouts, table settings

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1427,6 +1427,13 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	return [articleArray copy];
 }
 
+/* itemsForMarkedRange
+ */
+-(NSArray *)itemsForMarkedRange
+{
+    return [articleList sharingItems];
+}
+
 /* dealloc
  * Clean up behind ourself.
  */

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1361,22 +1361,17 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 }
 
 /* copyTableSelection
- * This is the common copy selection code. We build an array of dictionary entries each of
- * which include details of each selected article in the standard RSS item format defined by
- * Ranchero NetNewsWire. See http://ranchero.com/netnewswire/rssclipboard.php for more details.
  */
 -(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-	NSMutableArray * arrayOfArticles = [[NSMutableArray alloc] init];
 	NSMutableArray * arrayOfURLs = [[NSMutableArray alloc] init];
 	NSMutableArray * arrayOfTitles = [[NSMutableArray alloc] init];
 	NSMutableString * fullHTMLText = [[NSMutableString alloc] init];
 	NSMutableString * fullPlainText = [[NSMutableString alloc] init];
-	Database * db = [Database sharedManager];
 	NSInteger count = rowIndexes.count;
 	
 	// Set up the pasteboard
-	[pboard declareTypes:@[VNAPasteboardTypeRSSItem, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML]
+	[pboard declareTypes:@[VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML]
                    owner:self];
     if (count == 1) {
         [pboard addTypes:@[NSPasteboardTypeURL, VNAPasteboardTypeURLName]
@@ -1391,22 +1386,12 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound) {
 		Article * thisArticle = self.articleController.allArticles[msgIndex];
-		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
 		NSString * msgTitle = thisArticle.title;
 		NSString * msgLink = thisArticle.link;
 		
 		[arrayOfURLs addObject:msgLink];
 		[arrayOfTitles addObject:msgTitle];
-
-		NSMutableDictionary * articleDict = [NSMutableDictionary dictionary];
-		[articleDict setValue:msgTitle forKey:@"rssItemTitle"];
-		[articleDict setValue:msgLink forKey:@"rssItemLink"];
-		[articleDict setValue:msgText forKey:@"rssItemDescription"];
-		[articleDict setValue:folder.name forKey:@"sourceName"];
-		[articleDict setValue:folder.homePage forKey:@"sourceHomeURL"];
-		[articleDict setValue:folder.feedURL forKey:@"sourceRSSURL"];
-		[arrayOfArticles addObject:articleDict];
 
 		// Plain text
         [fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
@@ -1430,7 +1415,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	[fullHTMLText appendString:@"</body></html>"];
 
 	// Put string on the pasteboard for external drops.
-	[pboard setPropertyList:arrayOfArticles forType:VNAPasteboardTypeRSSItem];
 	[pboard setPropertyList:@[arrayOfURLs, arrayOfTitles] forType:VNAPasteboardTypeWebURLsWithTitles];
 	[pboard setString:fullPlainText forType:NSPasteboardTypeString];
     [pboard setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1360,66 +1360,83 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	}
 }
 
+// This is the common pasteboard code for an article item
+- (id<NSPasteboardWriting>)pasteboardWriterForIndex:(NSUInteger)msgIndex
+{
+    NSPasteboardItem *pboardItem = [[NSPasteboardItem alloc] init];
+
+    Article *thisArticle = self.articleController.allArticles[msgIndex];
+    NSString *msgTitle = thisArticle.title;
+    NSString *msgLink = thisArticle.link;
+
+    if (msgLink) {
+        [pboardItem setString:thisArticle.link forType:NSPasteboardTypeURL];
+    }
+    if (msgTitle) {
+        [pboardItem setString:msgTitle forType:VNAPasteboardTypeURLName];
+    }
+    // Plain text
+    NSString *fullPlainText = [NSString stringWithFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
+    [pboardItem setString:fullPlainText forType:NSPasteboardTypeString];
+
+    // For HTML, this hack is needed for multiple selections
+    // because some apps will only recognize the first HTML element
+    // while others will require that the numbers match
+    if (msgIndex == articleList.selectedRowIndexes.firstIndex) {
+        [self addHTMLRecapToPasteboardItem:pboardItem];
+    } else {
+        [pboardItem setString:@"" forType:NSPasteboardTypeHTML];
+    }
+
+    return pboardItem;
+}
+
+// This creates recapitulative type attached to the first item of the selection
+- (void)addHTMLRecapToPasteboardItem:(NSPasteboardItem *)pboardItem
+{
+    NSIndexSet *rowIndexes = articleList.selectedRowIndexes;
+    NSMutableString *fullHTMLText = [NSMutableString stringWithFormat:@"<!DOCTYPE html><html><head>"
+                                                                      @"<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\"></head><body>"];
+
+    NSUInteger rowIndex = rowIndexes.firstIndex;
+    while (rowIndex != NSNotFound) {
+        Article *article = self.articleController.allArticles[rowIndex];
+
+        [fullHTMLText appendFormat:@"<header><div class=\"info\"><a href=\"%@\">%@</a></div></header>"
+                                    "<div class=\"articleBodyStyle\">%@</div><br>",
+                                   article.link, article.title, article.body];
+        rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
+    }
+
+    [fullHTMLText appendString:@"</body></html>"];
+    [pboardItem setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];
+}
+
 /* copyTableSelection
  */
 -(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-	NSMutableArray * arrayOfURLs = [[NSMutableArray alloc] init];
-	NSMutableArray * arrayOfTitles = [[NSMutableArray alloc] init];
-	NSMutableString * fullHTMLText = [[NSMutableString alloc] init];
-	NSMutableString * fullPlainText = [[NSMutableString alloc] init];
 	NSInteger count = rowIndexes.count;
-	
-	// Set up the pasteboard
-	[pboard declareTypes:@[VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML]
-                   owner:self];
-    if (count == 1) {
-        [pboard addTypes:@[NSPasteboardTypeURL, VNAPasteboardTypeURLName]
-                   owner:self];
-    }
+	NSMutableArray * pbItems = [NSMutableArray arrayWithCapacity:count];
 
-	// Open the HTML string
-	[fullHTMLText appendString:@"<html style=\"font-family:sans-serif;\">"
-                                "<head><meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\"></head><body>"];
-	
+	// Set up the pasteboard
+	[pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
+
+	NSInteger countOfItems = 0;
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound) {
-		Article * thisArticle = self.articleController.allArticles[msgIndex];
-		NSString * msgText = thisArticle.body;
-		NSString * msgTitle = thisArticle.title;
-		NSString * msgLink = thisArticle.link;
-		
-		[arrayOfURLs addObject:msgLink];
-		[arrayOfTitles addObject:msgTitle];
-
-		// Plain text
-        [fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
-		
-		// Add HTML version too.
-		[fullHTMLText appendFormat:@"<div class=\"info\"><a href=\"%@\">%@</a><div>"
-                                    "<div class=\"articleBodyStyle\">%@</div><br>", msgLink, msgTitle, msgText];
-		
-		if (count == 1) {
-            [pboard setString:msgLink forType:NSPasteboardTypeURL];
-			[pboard setString:msgTitle forType:VNAPasteboardTypeURLName];
-			
-			// Write the link to the pastboard.
-			[[NSURL URLWithString:msgLink] writeToPasteboard:pboard];
+		NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self pasteboardWriterForIndex:msgIndex];
+		if (pboardItem.types) {
+			[pbItems addObject:pboardItem];
+		    ++countOfItems;
 		}
 
 		msgIndex = [rowIndexes indexGreaterThanIndex:msgIndex];
 	}
-	
-	// Close the HTML string
-	[fullHTMLText appendString:@"</body></html>"];
 
-	// Put string on the pasteboard for external drops.
-	[pboard setPropertyList:@[arrayOfURLs, arrayOfTitles] forType:VNAPasteboardTypeWebURLsWithTitles];
-	[pboard setString:fullPlainText forType:NSPasteboardTypeString];
-    [pboard setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];
-
-	return YES;
+	[pboard writeObjects:pbItems];
+	return countOfItems > 0;
 }
 
 /* markedArticleRange

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -54,7 +54,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 @property (nonatomic) IBOutlet EnclosureView *enclosureView;
 
 -(void)initTableView;
--(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard;
 -(void)setTableViewFont;
 -(void)showSortDirection;
 -(void)handleReadingPaneChange:(NSNotification *)notification;
@@ -1401,33 +1400,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 
     [fullHTMLText appendString:@"</body></html>"];
     [pboardItem setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];
-}
-
-/* copyTableSelection
- */
--(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
-{
-	NSInteger count = rowIndexes.count;
-	NSMutableArray * pbItems = [NSMutableArray arrayWithCapacity:count];
-
-	// Set up the pasteboard
-	[pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
-
-	NSInteger countOfItems = 0;
-	// Get all the articles that are being dragged
-	NSUInteger msgIndex = rowIndexes.firstIndex;
-	while (msgIndex != NSNotFound) {
-		NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self pasteboardWriterForIndex:msgIndex];
-		if (pboardItem.types) {
-			[pbItems addObject:pboardItem];
-		    ++countOfItems;
-		}
-
-		msgIndex = [rowIndexes indexGreaterThanIndex:msgIndex];
-	}
-
-	[pboard writeObjects:pbItems];
-	return countOfItems > 0;
 }
 
 // Provides a pasteboard writer for dragging article items

--- a/Vienna/Sources/Main window/ArticleListView.m
+++ b/Vienna/Sources/Main window/ArticleListView.m
@@ -1320,15 +1320,6 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 	}
 }
 
-/* writeRowsWithIndexes
- * Called to initiate a drag from MessageListView. Use the common copy selection code to copy to
- * the pasteboard.
- */
--(BOOL)tableView:(NSTableView *)tv writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(nonnull NSPasteboard *)pboard
-{
-	return [self copyTableSelection:rowIndexes toPasteboard:pboard];
-}
-
 /* willDisplayCell
  * Hook before a cell is displayed to set the cell's loading HTML flag for 
  * the progress indicator.
@@ -1437,6 +1428,12 @@ static void *VNAArticleListViewObserverContext = &VNAArticleListViewObserverCont
 
 	[pboard writeObjects:pbItems];
 	return countOfItems > 0;
+}
+
+// Provides a pasteboard writer for dragging article items
+- (id<NSPasteboardWriting>)tableView:(NSTableView *)tableView pasteboardWriterForRow:(NSInteger)row
+{
+    return [self pasteboardWriterForIndex:row];
 }
 
 /* markedArticleRange

--- a/Vienna/Sources/Main window/FoldersFilterable.m
+++ b/Vienna/Sources/Main window/FoldersFilterable.m
@@ -56,10 +56,6 @@
     [_dataSource outlineView:outlineView draggingSession:session endedAtPoint:screenPoint operation:operation];
 }
 
-- (BOOL)outlineView:(NSOutlineView *)outlineView writeItems:(NSArray *)items toPasteboard:(NSPasteboard *)pasteboard {
-    return [_dataSource outlineView:outlineView writeItems:items toPasteboard:pasteboard];
-}
-
 - (void)outlineView:(NSOutlineView *)outlineView updateDraggingItemsForDrag:(id <NSDraggingInfo>)draggingInfo {
     [_dataSource outlineView:outlineView updateDraggingItemsForDrag:draggingInfo];
 }

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -825,69 +825,83 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 	[self.controller.browser switchToPrimaryTab];
 }
 
+// This is the common pasteboard code for a TreeNode item
+- (id<NSPasteboardWriting>)pasteboardWriterForItem:(id)item
+{
+    NSPasteboardItem *pboardItem = [[NSPasteboardItem alloc] init];
+    NSMutableArray *externalDragData = [NSMutableArray array];
+    NSMutableArray *internalDragData = [NSMutableArray array];
+    NSMutableArray *arrayOfURLs = [NSMutableArray array];
+    NSMutableArray *arrayOfTitles = [NSMutableArray array];
+
+    TreeNode *node = (TreeNode *)item;
+    Folder *folder = node.folder;
+    NSString *feedURL = folder.feedURL;
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+
+
+    if (folder.type == VNAFolderTypeRSS
+        || folder.type == VNAFolderTypeOpenReader
+        || folder.type == VNAFolderTypeSmart
+        || folder.type == VNAFolderTypeGroup
+        || folder.type == VNAFolderTypeSearch
+        || folder.type == VNAFolderTypeTrash)
+    {
+        [internalDragData addObject:@(node.nodeId)];
+    }
+
+    if (folder.type == VNAFolderTypeRSS
+        || folder.type == VNAFolderTypeOpenReader)
+    {
+        // dictionary entries include folder details in the standard
+        // RSS item format defined by Ranchero NetNewsWire.
+        // See http://ranchero.com/netnewswire/rssclipboard.php for more details.
+        [dict setValue:folder.name forKey:@"sourceName"];
+        [dict setValue:folder.description forKey:@"sourceDescription"];
+        [dict setValue:feedURL forKey:@"sourceRSSURL"];
+        [dict setValue:folder.homePage forKey:@"sourceHomeURL"];
+        [externalDragData addObject:dict];
+
+        NSURL *safariURL = [NSURL URLWithString:feedURL];
+        if (safariURL != nil && !safariURL.fileURL) {
+            NSString *urlString = feedURL;
+            if (![@"feed" isEqualToString:safariURL.scheme]) {
+                urlString = [NSString stringWithFormat:@"feed:%@", safariURL.resourceSpecifier];
+            }
+            [arrayOfURLs addObject:urlString];
+            [arrayOfTitles addObject:folder.name];
+        }
+    }
+    [pboardItem setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList];
+    [pboardItem setPropertyList:externalDragData forType:VNAPasteboardTypeRSSSource];
+    NSArray *webURLsWithTitles = @[arrayOfURLs, arrayOfTitles];
+    [pboardItem setPropertyList:webURLsWithTitles forType:VNAPasteboardTypeWebURLsWithTitles];
+    [pboardItem setString:feedURL forType:NSPasteboardTypeString];
+
+    return pboardItem;
+}
+
 /* copyTableSelection
- * This is the common copy selection code. We build an array of dictionary entries each of
- * which include details of each selected folder in the standard RSS item format defined by
- * Ranchero NetNewsWire. See http://ranchero.com/netnewswire/rssclipboard.php for more details.
  */
 -(BOOL)copyTableSelection:(NSArray *)items toPasteboard:(NSPasteboard *)pboard
 {
 	NSInteger count = items.count;
-	NSMutableArray * externalDragData = [NSMutableArray arrayWithCapacity:count];
-	NSMutableArray * internalDragData = [NSMutableArray arrayWithCapacity:count];
-	NSMutableString * stringDragData = [NSMutableString string];
-	NSMutableArray * arrayOfURLs = [NSMutableArray arrayWithCapacity:count];
-	NSMutableArray * arrayOfTitles = [NSMutableArray arrayWithCapacity:count];
+	NSMutableArray * pbItems = [NSMutableArray arrayWithCapacity:count];
 	NSInteger index;
 
 	// We'll create the types of data on the clipboard.
-	[pboard declareTypes:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString] owner:self];
+    [pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
 
-	// Create an array of NSNumber objects containing the selected folder IDs.
 	NSInteger countOfItems = 0;
 	for (index = 0; index < count; ++index) {
-		TreeNode * node = items[index];
-		Folder * folder = node.folder;
-
-		if (folder.type == VNAFolderTypeRSS
-            || folder.type == VNAFolderTypeOpenReader
-            || folder.type == VNAFolderTypeSmart
-            || folder.type == VNAFolderTypeGroup
-            || folder.type == VNAFolderTypeSearch
-            || folder.type == VNAFolderTypeTrash) {
-			[internalDragData addObject:@(node.nodeId)];
-			++countOfItems;
-		}
-
-		if (folder.type == VNAFolderTypeRSS
-            || folder.type == VNAFolderTypeOpenReader) {
-			NSString * feedURL = folder.feedURL;
-			
-			NSMutableDictionary * dict = [NSMutableDictionary dictionary];
-			[dict setValue:folder.name forKey:@"sourceName"];
-			[dict setValue:folder.description forKey:@"sourceDescription"];
-			[dict setValue:feedURL forKey:@"sourceRSSURL"];
-			[dict setValue:folder.homePage forKey:@"sourceHomeURL"];
-			[externalDragData addObject:dict];
-
-			[stringDragData appendFormat:@"%@\n", feedURL];
-			
-			NSURL * safariURL = [NSURL URLWithString:feedURL];
-			if (safariURL != nil && !safariURL.fileURL) {
-				if (![@"feed" isEqualToString:safariURL.scheme]) {
-					feedURL = [NSString stringWithFormat:@"feed:%@", safariURL.resourceSpecifier];
-				}
-				[arrayOfURLs addObject:feedURL];
-				[arrayOfTitles addObject:folder.name];
-			}
+		NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self pasteboardWriterForItem:items[index]];
+		if (pboardItem.types) {
+			[pbItems addObject:pboardItem];
+		    ++countOfItems;
 		}
 	}
 
-	// Copy the data to the pasteboard 
-	[pboard setPropertyList:externalDragData forType:VNAPasteboardTypeRSSSource];
-	[pboard setString:stringDragData forType:NSPasteboardTypeString];
-	[pboard setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList]; 
-	[pboard setPropertyList:@[arrayOfURLs, arrayOfTitles] forType:VNAPasteboardTypeWebURLsWithTitles];
+	[pboard writeObjects:pbItems];
 	return countOfItems > 0; 
 }
 
@@ -1348,12 +1362,10 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     return [node childByIndex:index];
 }
 
-// Collect the selected folders ready for dragging.
-- (BOOL)outlineView:(NSOutlineView *)outlineView
-         writeItems:(NSArray *)items
-       toPasteboard:(NSPasteboard *)pasteboard
+// Provides a pasteboard writer for dragging folder items
+- (id<NSPasteboardWriting>)outlineView:(NSOutlineView *)outlineView pasteboardWriterForItem:(id)item
 {
-    return [self copyTableSelection:items toPasteboard:pasteboard];
+    return [self pasteboardWriterForItem:item];
 }
 
 // MARK: - NSOutlineViewDelegate

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -32,6 +32,7 @@
 #import "Database.h"
 #import "TreeNode.h"
 #import "Folder.h"
+#import "SubscriptionModel.h"
 #import "Vienna-Swift.h"
 
 NSString * const MAPref_FeedListSizeMode = @"FeedListSizeMode";
@@ -1196,8 +1197,10 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     if ([type isEqualToString:NSPasteboardTypeURL] || [type isEqualToString:NSPasteboardTypeString]) {
         // This is possibly a URL that we'll handle as a potential feed subscription. It's
         // not our call to make though.
+        NSURL *targetURL = [NSURL URLWithString:[pb stringForType:type]];
+        targetURL = [[[SubscriptionModel alloc] init] verifiedFeedURLFromURL:targetURL];
         NSInteger predecessorId = (childIndex > 0) ? [node childByIndex:(childIndex - 1)].nodeId : 0;
-        [APPCONTROLLER createNewSubscription:[pb stringForType:type] underFolder:parentId afterChild:predecessorId];
+        [APPCONTROLLER createNewSubscription:targetURL.absoluteString underFolder:parentId afterChild:predecessorId];
         return YES;
     }
     if ([type isEqualToString:VNAPasteboardTypeFolderList]) {
@@ -1244,7 +1247,8 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
         BOOL result = [self moveFolders:array withOpenReaderSync:YES];
         return result;
     }
-    if ([type isEqualToString:@"WebURLsWithTitlesPboardType"]) {
+    if ([type isEqualToString:VNAPasteboardTypeWebURLsWithTitles]) {
+        // This is the legacy array of URLs / array of titles exported by Safari ("WebURLsWithTitlesPboardType")
         Database *dbManager = [Database sharedManager];
         NSArray *webURLsWithTitles = [pb propertyListForType:type];
         NSArray *arrayOfURLs = webURLsWithTitles[0];
@@ -1256,12 +1260,16 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
         for (index = 0; index < count; ++index) {
             NSString *feedTitle = arrayOfTitles[index];
             NSString *feedURL = arrayOfURLs[index];
-            NSURL *draggedURL = [NSURL URLWithString:feedURL];
-            if (draggedURL.scheme && [draggedURL.scheme isEqualToString:@"feed"]) {
-                feedURL = [NSString stringWithFormat:@"http:%@", draggedURL.resourceSpecifier];
+            NSURL *targetURL = [NSURL URLWithString:feedURL];
+            targetURL = [[[SubscriptionModel alloc] init] verifiedFeedURLFromURL:targetURL];
+            if (targetURL.scheme && [targetURL.scheme isEqualToString:@"feed"]) {
+                feedURL = [NSString stringWithFormat:@"http:%@", targetURL.resourceSpecifier];
+                targetURL = [NSURL URLWithString:feedURL];
+            } else {
+                feedURL = targetURL.absoluteString;
             }
 
-            if (![dbManager folderFromFeedURL:feedURL]) {
+            if (targetURL && ![dbManager folderFromFeedURL:feedURL]) {
                 NSInteger predecessorId = (childIndex > 0) ? [node childByIndex:(childIndex - 1)].nodeId : 0;
                 NSInteger newFolderId = [dbManager addRSSFolder:feedTitle underParent:parentId afterChild:predecessorId subscriptionURL:feedURL];
                 if (newFolderId > 0) {

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -97,7 +97,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     [self updateCellSize:[userDefaults integerForKey:MAPref_FeedListSizeMode]];
 
 	// Register for dragging
-	[self.outlineView registerForDraggedTypes:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString]];
+	[self.outlineView registerForDraggedTypes:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString]];
 	[self.outlineView setVerticalMotionCanBeginDrag:YES];
 	
 	// Make sure selected row is visible
@@ -829,7 +829,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 - (id<NSPasteboardWriting>)pasteboardWriterForItem:(id)item
 {
     NSPasteboardItem *pboardItem = [[NSPasteboardItem alloc] init];
-    NSMutableArray *externalDragData = [NSMutableArray array];
     NSMutableArray *internalDragData = [NSMutableArray array];
     NSMutableArray *arrayOfURLs = [NSMutableArray array];
     NSMutableArray *arrayOfTitles = [NSMutableArray array];
@@ -838,8 +837,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     TreeNode *node = (TreeNode *)item;
     Folder *folder = node.folder;
     NSString *feedURL = folder.feedURL;
-    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-
 
     if (folder.type == VNAFolderTypeRSS
         || folder.type == VNAFolderTypeOpenReader
@@ -854,15 +851,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     if (folder.type == VNAFolderTypeRSS
         || folder.type == VNAFolderTypeOpenReader)
     {
-        // dictionary entries include folder details in the standard
-        // RSS item format defined by Ranchero NetNewsWire.
-        // See http://ranchero.com/netnewswire/rssclipboard.php for more details.
-        [dict setValue:folder.name forKey:@"sourceName"];
-        [dict setValue:folder.description forKey:@"sourceDescription"];
-        [dict setValue:feedURL forKey:@"sourceRSSURL"];
-        [dict setValue:folder.homePage forKey:@"sourceHomeURL"];
-        [externalDragData addObject:dict];
-
         NSURL *safariURL = [NSURL URLWithString:feedURL];
         if (safariURL != nil && !safariURL.fileURL) {
             NSString *urlString = feedURL;
@@ -879,7 +867,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
         rtfData = [attributedString RTFFromRange:range documentAttributes:@{}];
     }
     [pboardItem setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList];
-    [pboardItem setPropertyList:externalDragData forType:VNAPasteboardTypeRSSSource];
     NSArray *webURLsWithTitles = @[arrayOfURLs, arrayOfTitles];
     [pboardItem setPropertyList:webURLsWithTitles forType:VNAPasteboardTypeWebURLsWithTitles];
     [pboardItem setString:feedURL forType:NSPasteboardTypeString];
@@ -1168,7 +1155,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
             proposedChildIndex:(NSInteger)index
 {
     NSPasteboard * pb = [info draggingPasteboard];
-    NSString * type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeURL, NSPasteboardTypeString]];
+    NSString * type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeURL, NSPasteboardTypeString]];
     NSDragOperation dragType = ([type isEqualToString:VNAPasteboardTypeFolderList]) ? NSDragOperationMove : NSDragOperationCopy;
 
     TreeNode * node = (TreeNode *)item;
@@ -1211,7 +1198,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 {
     __block NSInteger childIndex = index;
     NSPasteboard *pb = [info draggingPasteboard];
-    NSString *type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeURL, NSPasteboardTypeString]];
+    NSString *type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeURL, NSPasteboardTypeString]];
     TreeNode *node = item ? (TreeNode *)item : self.rootNode;
 
     NSInteger parentId = node.nodeId;
@@ -1270,51 +1257,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
         // Do the move
         BOOL result = [self moveFolders:array withOpenReaderSync:YES];
         return result;
-    }
-    if ([type isEqualToString:VNAPasteboardTypeRSSSource]) {
-        Database *dbManager = [Database sharedManager];
-        NSArray *arrayOfSources = [pb propertyListForType:type];
-        NSInteger count = arrayOfSources.count;
-        NSInteger index;
-
-        // This is an RSS drag using the protocol defined by Ranchero for NetNewsWire. See
-        // http://ranchero.com/netnewswire/rssclipboard.php for more details.
-        //
-        __block NSInteger folderToSelect = -1;
-        for (index = 0; index < count; ++index) {
-            NSDictionary *sourceItem = arrayOfSources[index];
-            NSString *feedTitle = [sourceItem valueForKey:@"sourceName"];
-            NSString *feedHomePage = [sourceItem valueForKey:@"sourceHomeURL"];
-            NSString *feedURL = [sourceItem valueForKey:@"sourceRSSURL"];
-            NSString *feedDescription = [sourceItem valueForKey:@"sourceDescription"];
-
-            if (feedURL && ![dbManager folderFromFeedURL:feedURL]) {
-                NSInteger predecessorId = (childIndex > 0) ? [node childByIndex:(childIndex - 1)].nodeId : 0;
-                NSInteger folderId = [dbManager addRSSFolder:feedTitle underParent:parentId afterChild:predecessorId subscriptionURL:feedURL];
-                if (feedDescription) {
-                    [dbManager setDescription:feedDescription forFolder:folderId];
-                }
-                if (feedHomePage) {
-                    [dbManager setHomePage:feedHomePage forFolder:folderId];
-                }
-                if (folderId > 0) {
-                    folderToSelect = folderId;
-                }
-                ++childIndex;
-            }
-        }
-
-        // If parent was a group, expand it now
-        if (parentId != VNAFolderTypeRoot) {
-            [self.outlineView expandItem:[self.rootNode nodeFromID:parentId]];
-        }
-
-        // Select a new folder
-        if (folderToSelect > 0) {
-            [self selectFolder:folderToSelect];
-        }
-
-        return YES;
     }
     if ([type isEqualToString:@"WebURLsWithTitlesPboardType"]) {
         Database *dbManager = [Database sharedManager];

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -835,31 +835,27 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 
     TreeNode *node = (TreeNode *)item;
     Folder *folder = node.folder;
-    NSString *feedURL = folder.feedURL;
 
-    if (folder.type == VNAFolderTypeRSS
-        || folder.type == VNAFolderTypeOpenReader
-        || folder.type == VNAFolderTypeSmart
-        || folder.type == VNAFolderTypeGroup
-        || folder.type == VNAFolderTypeSearch
-        || folder.type == VNAFolderTypeTrash)
+    if (folder.type != VNAFolderTypeRoot)
     {
         [internalDragData addObject:@(node.nodeId)];
+        [pboardItem setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList];
     }
 
     if (folder.type == VNAFolderTypeRSS
         || folder.type == VNAFolderTypeOpenReader)
     {
-        NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:folder.name];
-        NSRange range = NSMakeRange(0, folder.name.length);
+        NSString *feedURL = folder.feedURL;
+        NSString *folderTitle = folder.name;
+        [pboardItem setString:feedURL forType:NSPasteboardTypeString];
+        [pboardItem setString:feedURL forType:NSPasteboardTypeURL];
+        [pboardItem setString:folder.name forType:VNAPasteboardTypeURLName];
+        NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:folderTitle];
+        NSRange range = NSMakeRange(0, folderTitle.length);
         [attributedString addAttribute:NSLinkAttributeName value:feedURL range:range];
         rtfData = [attributedString RTFFromRange:range documentAttributes:@{}];
+        [pboardItem setData:rtfData forType:NSPasteboardTypeRTF];
     }
-    [pboardItem setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList];
-    [pboardItem setString:feedURL forType:NSPasteboardTypeString];
-    [pboardItem setString:feedURL forType:NSPasteboardTypeURL];
-    [pboardItem setString:folder.name forType:VNAPasteboardTypeURLName];
-    [pboardItem setData:rtfData forType:NSPasteboardTypeRTF];
 
     return pboardItem;
 }

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -833,6 +833,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     NSMutableArray *internalDragData = [NSMutableArray array];
     NSMutableArray *arrayOfURLs = [NSMutableArray array];
     NSMutableArray *arrayOfTitles = [NSMutableArray array];
+    NSData *rtfData;
 
     TreeNode *node = (TreeNode *)item;
     Folder *folder = node.folder;
@@ -871,6 +872,11 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
             [arrayOfURLs addObject:urlString];
             [arrayOfTitles addObject:folder.name];
         }
+
+        NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:folder.name];
+        NSRange range = NSMakeRange(0, folder.name.length);
+        [attributedString addAttribute:NSLinkAttributeName value:feedURL range:range];
+        rtfData = [attributedString RTFFromRange:range documentAttributes:@{}];
     }
     [pboardItem setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList];
     [pboardItem setPropertyList:externalDragData forType:VNAPasteboardTypeRSSSource];
@@ -879,6 +885,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     [pboardItem setString:feedURL forType:NSPasteboardTypeString];
     [pboardItem setString:feedURL forType:NSPasteboardTypeURL];
     [pboardItem setString:folder.name forType:VNAPasteboardTypeURLName];
+    [pboardItem setData:rtfData forType:NSPasteboardTypeRTF];
 
     return pboardItem;
 }

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -877,6 +877,8 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     NSArray *webURLsWithTitles = @[arrayOfURLs, arrayOfTitles];
     [pboardItem setPropertyList:webURLsWithTitles forType:VNAPasteboardTypeWebURLsWithTitles];
     [pboardItem setString:feedURL forType:NSPasteboardTypeString];
+    [pboardItem setString:feedURL forType:NSPasteboardTypeURL];
+    [pboardItem setString:folder.name forType:VNAPasteboardTypeURLName];
 
     return pboardItem;
 }
@@ -1159,7 +1161,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
             proposedChildIndex:(NSInteger)index
 {
     NSPasteboard * pb = [info draggingPasteboard];
-    NSString * type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString]];
+    NSString * type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeURL, NSPasteboardTypeString]];
     NSDragOperation dragType = ([type isEqualToString:VNAPasteboardTypeFolderList]) ? NSDragOperationMove : NSDragOperationCopy;
 
     TreeNode * node = (TreeNode *)item;
@@ -1202,7 +1204,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 {
     __block NSInteger childIndex = index;
     NSPasteboard *pb = [info draggingPasteboard];
-    NSString *type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString]];
+    NSString *type = [pb availableTypeFromArray:@[VNAPasteboardTypeFolderList, VNAPasteboardTypeRSSSource, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeURL, NSPasteboardTypeString]];
     TreeNode *node = item ? (TreeNode *)item : self.rootNode;
 
     NSInteger parentId = node.nodeId;
@@ -1211,7 +1213,7 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     }
 
     // Check the type
-    if ([type isEqualToString:NSPasteboardTypeString]) {
+    if ([type isEqualToString:NSPasteboardTypeURL] || [type isEqualToString:NSPasteboardTypeString]) {
         // This is possibly a URL that we'll handle as a potential feed subscription. It's
         // not our call to make though.
         NSInteger predecessorId = (childIndex > 0) ? [node childByIndex:(childIndex - 1)].nodeId : 0;

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1219,9 +1219,23 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
         return YES;
     }
     if ([type isEqualToString:VNAPasteboardTypeFolderList]) {
+        // This is an internal drag
         Database *db = [Database sharedManager];
         NSArray *arrayOfSources = [pb propertyListForType:type];
         NSInteger count = arrayOfSources.count;
+        // hack to extend drag if we have a multiple items selection being dragged
+        if (count == 1 && [self countOfSelectedFolders] > 1) {
+            NSMutableArray * selectedFolderIDs = [NSMutableArray array];
+            for (Folder *folder in self.selectedFolders) {
+                    [selectedFolderIDs addObject:@(folder.itemId)];
+            }
+            // verify there is a match between the selection and the dragged item
+            if ([selectedFolderIDs containsObject:arrayOfSources[0]]) {
+                arrayOfSources = selectedFolderIDs;
+                count = arrayOfSources.count;
+            }
+        }
+
         NSInteger index;
         NSInteger predecessorId = (childIndex > 0) ? [node childByIndex:(childIndex - 1)].nodeId : 0;
 

--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -830,8 +830,6 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
 {
     NSPasteboardItem *pboardItem = [[NSPasteboardItem alloc] init];
     NSMutableArray *internalDragData = [NSMutableArray array];
-    NSMutableArray *arrayOfURLs = [NSMutableArray array];
-    NSMutableArray *arrayOfTitles = [NSMutableArray array];
     NSData *rtfData;
 
     TreeNode *node = (TreeNode *)item;
@@ -851,24 +849,12 @@ static void *VNAFoldersTreeObserverContext = &VNAFoldersTreeObserverContext;
     if (folder.type == VNAFolderTypeRSS
         || folder.type == VNAFolderTypeOpenReader)
     {
-        NSURL *safariURL = [NSURL URLWithString:feedURL];
-        if (safariURL != nil && !safariURL.fileURL) {
-            NSString *urlString = feedURL;
-            if (![@"feed" isEqualToString:safariURL.scheme]) {
-                urlString = [NSString stringWithFormat:@"feed:%@", safariURL.resourceSpecifier];
-            }
-            [arrayOfURLs addObject:urlString];
-            [arrayOfTitles addObject:folder.name];
-        }
-
         NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:folder.name];
         NSRange range = NSMakeRange(0, folder.name.length);
         [attributedString addAttribute:NSLinkAttributeName value:feedURL range:range];
         rtfData = [attributedString RTFFromRange:range documentAttributes:@{}];
     }
     [pboardItem setPropertyList:internalDragData forType:VNAPasteboardTypeFolderList];
-    NSArray *webURLsWithTitles = @[arrayOfURLs, arrayOfTitles];
-    [pboardItem setPropertyList:webURLsWithTitles forType:VNAPasteboardTypeWebURLsWithTitles];
     [pboardItem setString:feedURL forType:NSPasteboardTypeString];
     [pboardItem setString:feedURL forType:NSPasteboardTypeURL];
     [pboardItem setString:folder.name forType:VNAPasteboardTypeURLName];

--- a/Vienna/Sources/Main window/MainWindowController.swift
+++ b/Vienna/Sources/Main window/MainWindowController.swift
@@ -174,23 +174,32 @@ final class MainWindowController: NSWindowController {
     var shareableItemsSubject = String()
 
     private var shareableItems: [any NSPasteboardWriting] {
-        var items = [URL]()
+        var items = [any NSPasteboardWriting]()
         if let activeTab = browser.activeTab, let url = activeTab.tabUrl {
-            items.append(url)
-            shareableItemsSubject = activeTab.title ?? NSLocalizedString("URL", comment: "URL")
+            items.append(url as NSURL)
+            let title = activeTab.title ?? NSLocalizedString("URL", comment: "URL")
+            items.append(title as NSString)
+            shareableItemsSubject = title
         } else {
-            if let articles = articleController?.markedArticleRange as? [Article] {
-                let links = articles.compactMap { $0.link }
-                let urls = links.compactMap { URL(string: $0) }
-                items = urls
-                if articles.count == 1 {
-                    shareableItemsSubject = articles[0].title ?? ""
+            if let pboardItems = articleController?.itemsForMarkedRange as? [NSPasteboardItem]
+            {
+                for pboardItem in pboardItems {
+                    if let urlString = pboardItem.string(forType: .URL), let url = URL(string: urlString)
+                    {
+                        items.append(url as NSURL)
+                    }
+                    if let text = pboardItem.string(forType: .string) {
+                        items.append(text as NSString)
+                    }
+                }
+                if pboardItems.count == 1 {
+                    shareableItemsSubject = pboardItems[0].string(forType: .urlName) ?? ""
                 } else {
-                    shareableItemsSubject = String(format: NSLocalizedString("%u articles", comment: ""), articles.count)
+                    shareableItemsSubject = String(format: NSLocalizedString("%u articles", comment: ""), pboardItems.count)
                 }
             }
         }
-        return items as [NSURL]
+        return items
     }
 
     private func toolbarItem(

--- a/Vienna/Sources/Main window/MessageListView.h
+++ b/Vienna/Sources/Main window/MessageListView.h
@@ -24,8 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MessageListViewDelegate <NSTableViewDelegate>
 
-- (BOOL)copyTableSelection:(NSIndexSet *)rowIndexes
-              toPasteboard:(NSPasteboard *)pboard;
+- (id<NSPasteboardWriting>)pasteboardWriterForIndex:(NSUInteger)msgIndex;
 
 @end
 

--- a/Vienna/Sources/Main window/MessageListView.h
+++ b/Vienna/Sources/Main window/MessageListView.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setTableColumnHeaderImage:(NSImage *)image
           forColumnWithIdentifier:(NSUserInterfaceItemIdentifier)identifier;
+- (NSArray<NSPasteboardItem *> *)sharingItems;
 
 @end
 

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -61,36 +61,28 @@
 -(IBAction)copy:(id)sender
 {
 	if (self.selectedRow >= 0) {
-		NSIndexSet * selectedRowIndexes = self.selectedRowIndexes;
-		[self copyTableSelection:selectedRowIndexes toPasteboard:NSPasteboard.generalPasteboard];
+		NSPasteboard * pboard = NSPasteboard.generalPasteboard;
+		[pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
+		[pboard writeObjects:[self sharingItems]];
 	}
 }
 
-/* copyTableSelection
- */
-- (BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
+- (NSArray<NSPasteboardItem *> *)sharingItems
 {
-    NSInteger count = rowIndexes.count;
-    NSMutableArray *pbItems = [NSMutableArray arrayWithCapacity:count];
+    NSIndexSet *rowIndexes = self.selectedRowIndexes;
+    NSMutableArray *pbItems = [NSMutableArray arrayWithCapacity:rowIndexes.count];
 
-    // Set up the pasteboard
-    [pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
-
-    NSInteger countOfItems = 0;
-    // Get all the articles that are being copied
+    // Get all the articles that are being copied or shared
     NSUInteger msgIndex = rowIndexes.firstIndex;
     while (msgIndex != NSNotFound) {
         NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self.delegate pasteboardWriterForIndex:msgIndex];
         if (pboardItem.types) {
             [pbItems addObject:pboardItem];
-            ++countOfItems;
         }
-
         msgIndex = [rowIndexes indexGreaterThanIndex:msgIndex];
     }
 
-    [pboard writeObjects:pbItems];
-    return countOfItems > 0;
+    return [pbItems copy];
 }
 
 /* validateMenuItem

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -81,7 +81,7 @@
 	return NO;
 }
 
-// Might as well allow text drags into other apps...
+// Allow drags into other apps
 -(NSDragOperation)draggingSession:(NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context
 {
     switch(context) {

--- a/Vienna/Sources/Main window/MessageListView.m
+++ b/Vienna/Sources/Main window/MessageListView.m
@@ -62,8 +62,35 @@
 {
 	if (self.selectedRow >= 0) {
 		NSIndexSet * selectedRowIndexes = self.selectedRowIndexes;
-		[self.delegate copyTableSelection:selectedRowIndexes toPasteboard:NSPasteboard.generalPasteboard];
+		[self copyTableSelection:selectedRowIndexes toPasteboard:NSPasteboard.generalPasteboard];
 	}
+}
+
+/* copyTableSelection
+ */
+- (BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
+{
+    NSInteger count = rowIndexes.count;
+    NSMutableArray *pbItems = [NSMutableArray arrayWithCapacity:count];
+
+    // Set up the pasteboard
+    [pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
+
+    NSInteger countOfItems = 0;
+    // Get all the articles that are being copied
+    NSUInteger msgIndex = rowIndexes.firstIndex;
+    while (msgIndex != NSNotFound) {
+        NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self.delegate pasteboardWriterForIndex:msgIndex];
+        if (pboardItem.types) {
+            [pbItems addObject:pboardItem];
+            ++countOfItems;
+        }
+
+        msgIndex = [rowIndexes indexGreaterThanIndex:msgIndex];
+    }
+
+    [pboard writeObjects:pbItems];
+    return countOfItems > 0;
 }
 
 /* validateMenuItem

--- a/Vienna/Sources/Main window/UnifiedDisplayView.h
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.h
@@ -19,6 +19,7 @@
 //
 
 #import "ArticleBaseView.h"
+#import "MessageListView.h"
 
 @class AppController;
 @class ArticleController;
@@ -27,7 +28,7 @@
                                         NSMenuDelegate,
                                         NSMenuItemValidation,
                                         NSTableViewDataSource,
-                                        NSTableViewDelegate>
+                                        MessageListViewDelegate>
 
 - (/*nullable*/ instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
 

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -630,6 +630,13 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 	return [articleArray copy];
 }
 
+/* itemsForMarkedRange
+ */
+-(NSArray *)itemsForMarkedRange
+{
+    return [articleList sharingItems];
+}
+
 #pragma mark -
 #pragma mark Keyboard (NSResponder)
 

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -538,6 +538,58 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
      }
 }
 
+// This is the common pasteboard code for an article item
+- (id<NSPasteboardWriting>)pasteboardWriterForIndex:(NSUInteger)msgIndex
+{
+    NSPasteboardItem *pboardItem = [[NSPasteboardItem alloc] init];
+
+    Article *thisArticle = self.articleController.allArticles[msgIndex];
+    NSString *msgTitle = thisArticle.title;
+    NSString *msgLink = thisArticle.link;
+
+    if (msgLink) {
+        [pboardItem setString:thisArticle.link forType:NSPasteboardTypeURL];
+    }
+    if (msgTitle) {
+        [pboardItem setString:msgTitle forType:VNAPasteboardTypeURLName];
+    }
+    // Plain text
+    NSString *fullPlainText = [NSString stringWithFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
+    [pboardItem setString:fullPlainText forType:NSPasteboardTypeString];
+
+    // For HTML, this hack is needed for multiple selections
+    // because some apps will only recognize the first HTML element
+    // while others will require that the numbers match
+    if (msgIndex == articleList.selectedRowIndexes.firstIndex) {
+        [self addHTMLRecapToPasteboardItem:pboardItem];
+    } else {
+        [pboardItem setString:@"" forType:NSPasteboardTypeHTML];
+    }
+
+    return pboardItem;
+}
+
+// This creates recapitulative type attached to the first item of the selection
+- (void)addHTMLRecapToPasteboardItem:(NSPasteboardItem *)pboardItem
+{
+    NSIndexSet *rowIndexes = articleList.selectedRowIndexes;
+    NSMutableString *fullHTMLText = [NSMutableString stringWithFormat:@"<!DOCTYPE html><html><head>"
+                                                                      @"<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\"></head><body>"];
+
+    NSUInteger rowIndex = rowIndexes.firstIndex;
+    while (rowIndex != NSNotFound) {
+        Article *article = self.articleController.allArticles[rowIndex];
+
+        [fullHTMLText appendFormat:@"<header><div class=\"info\"><a href=\"%@\">%@</a></div></header>"
+                                    "<div class=\"articleBodyStyle\">%@</div><br>",
+                                   article.link, article.title, article.body];
+        rowIndex = [rowIndexes indexGreaterThanIndex:rowIndex];
+    }
+
+    [fullHTMLText appendString:@"</body></html>"];
+    [pboardItem setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];
+}
+
 /* copyTableSelection
  */
 -(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -55,7 +55,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 @end
 
 @implementation UnifiedDisplayView {
-    IBOutlet NSTableView *articleList;
+    IBOutlet MessageListView *articleList;
 
     NSTimer *markReadTimer;
 

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -539,22 +539,17 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 }
 
 /* copyTableSelection
- * This is the common copy selection code. We build an array of dictionary entries each of
- * which include details of each selected article in the standard RSS item format defined by
- * Ranchero NetNewsWire. See http://ranchero.com/netnewswire/rssclipboard.php for more details.
  */
 -(BOOL)copyIndexesSelection:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-	NSMutableArray * arrayOfArticles = [[NSMutableArray alloc] init];
 	NSMutableArray * arrayOfURLs = [[NSMutableArray alloc] init];
 	NSMutableArray * arrayOfTitles = [[NSMutableArray alloc] init];
 	NSMutableString * fullHTMLText = [[NSMutableString alloc] init];
 	NSMutableString * fullPlainText = [[NSMutableString alloc] init];
-	Database * db = [Database sharedManager];
 	NSInteger count = rowIndexes.count;
 
 	// Set up the pasteboard
-	[pboard declareTypes:@[VNAPasteboardTypeRSSItem, VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML] owner:self];
+	[pboard declareTypes:@[VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML] owner:self];
     if (count == 1) {
         [pboard addTypes:@[NSPasteboardTypeURL, VNAPasteboardTypeURLName]
                    owner:self];
@@ -568,22 +563,12 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound) {
 		Article * thisArticle = self.articleController.allArticles[msgIndex];
-		Folder * folder = [db folderFromID:thisArticle.folderId];
 		NSString * msgText = thisArticle.body;
 		NSString * msgTitle = thisArticle.title;
 		NSString * msgLink = thisArticle.link;
 
 		[arrayOfURLs addObject:msgLink];
 		[arrayOfTitles addObject:msgTitle];
-
-		NSMutableDictionary * articleDict = [NSMutableDictionary dictionary];
-		[articleDict setValue:msgTitle forKey:@"rssItemTitle"];
-		[articleDict setValue:msgLink forKey:@"rssItemLink"];
-		[articleDict setValue:msgText forKey:@"rssItemDescription"];
-		[articleDict setValue:folder.name forKey:@"sourceName"];
-		[articleDict setValue:folder.homePage forKey:@"sourceHomeURL"];
-		[articleDict setValue:folder.feedURL forKey:@"sourceRSSURL"];
-		[arrayOfArticles addObject:articleDict];
 
 		// Plain text
         [fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
@@ -608,7 +593,6 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 	[fullHTMLText appendString:@"</body></html>"];
 
 	// Put string on the pasteboard for external drops.
-	[pboard setPropertyList:arrayOfArticles forType:VNAPasteboardTypeRSSItem];
 	[pboard setPropertyList:@[arrayOfURLs, arrayOfTitles] forType:VNAPasteboardTypeWebURLsWithTitles];
 	[pboard setString:fullPlainText forType:NSPasteboardTypeString];
 	[pboard setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -594,71 +594,33 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-	NSMutableArray * arrayOfURLs = [[NSMutableArray alloc] init];
-	NSMutableArray * arrayOfTitles = [[NSMutableArray alloc] init];
-	NSMutableString * fullHTMLText = [[NSMutableString alloc] init];
-	NSMutableString * fullPlainText = [[NSMutableString alloc] init];
 	NSInteger count = rowIndexes.count;
+	NSMutableArray * pbItems = [NSMutableArray arrayWithCapacity:count];
 
 	// Set up the pasteboard
-	[pboard declareTypes:@[VNAPasteboardTypeWebURLsWithTitles, NSPasteboardTypeString, NSPasteboardTypeHTML] owner:self];
-    if (count == 1) {
-        [pboard addTypes:@[NSPasteboardTypeURL, VNAPasteboardTypeURLName]
-                   owner:self];
-    }
+	[pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
 
-	// Open the HTML string
-	[fullHTMLText appendString:@"<html style=\"font-family:sans-serif;\">"
-                                "<head><meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\"></head><body>"];
-
+	NSInteger countOfItems = 0;
 	// Get all the articles that are being dragged
 	NSUInteger msgIndex = rowIndexes.firstIndex;
 	while (msgIndex != NSNotFound) {
-		Article * thisArticle = self.articleController.allArticles[msgIndex];
-		NSString * msgText = thisArticle.body;
-		NSString * msgTitle = thisArticle.title;
-		NSString * msgLink = thisArticle.link;
-
-		[arrayOfURLs addObject:msgLink];
-		[arrayOfTitles addObject:msgTitle];
-
-		// Plain text
-        [fullPlainText appendFormat:@"%@\n%@\n\n", msgTitle, thisArticle.summary];
-
-		// Add HTML version too.
-		[fullHTMLText appendFormat:@"<div class=\"info\"><a href=\"%@\">%@</a><div>"
-                                    "<div class=\"articleBodyStyle\">%@</div><br>", msgLink, msgTitle, msgText];
-
-		if (count == 1) {
-			[pboard setString:msgLink forType:NSPasteboardTypeURL];
-			[pboard setString:msgTitle forType:VNAPasteboardTypeURLName];
-
-			// Write the link to the pastboard.
-			[[NSURL URLWithString:msgLink] writeToPasteboard:pboard];
+		NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self pasteboardWriterForIndex:msgIndex];
+		if (pboardItem.types) {
+			[pbItems addObject:pboardItem];
+		    ++countOfItems;
 		}
 
-		//increment
-    	msgIndex = [rowIndexes indexGreaterThanIndex: msgIndex];
+		msgIndex = [rowIndexes indexGreaterThanIndex:msgIndex];
 	}
 
-	// Close the HTML string
-	[fullHTMLText appendString:@"</body></html>"];
-
-	// Put string on the pasteboard for external drops.
-	[pboard setPropertyList:@[arrayOfURLs, arrayOfTitles] forType:VNAPasteboardTypeWebURLsWithTitles];
-	[pboard setString:fullPlainText forType:NSPasteboardTypeString];
-	[pboard setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];
-
-	return YES;
+	[pboard writeObjects:pbItems];
+	return countOfItems > 0;
 }
 
-/* writeRowsWithIndexes
- * Use the common copy selection code to copy to
- * the pasteboard.
- */
--(BOOL)tableView:(NSTableView*)aListView writeRowsWithIndexes:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard *)pboard
+// Provides a pasteboard writer for dragging article items
+- (id<NSPasteboardWriting>)tableView:(NSTableView *)tableView pasteboardWriterForRow:(NSInteger)row
 {
-	return [self copyTableSelection:rowIndexes toPasteboard:pboard];
+    return [self pasteboardWriterForIndex:row];
 }
 
 /* copy

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -590,45 +590,10 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
     [pboardItem setString:fullHTMLText.vna_stringByEscapingExtendedCharacters forType:NSPasteboardTypeHTML];
 }
 
-/* copyTableSelection
- */
--(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
-{
-	NSInteger count = rowIndexes.count;
-	NSMutableArray * pbItems = [NSMutableArray arrayWithCapacity:count];
-
-	// Set up the pasteboard
-	[pboard prepareForNewContentsWithOptions:NSPasteboardContentsCurrentHostOnly];
-
-	NSInteger countOfItems = 0;
-	// Get all the articles that are being dragged
-	NSUInteger msgIndex = rowIndexes.firstIndex;
-	while (msgIndex != NSNotFound) {
-		NSPasteboardItem *pboardItem = (NSPasteboardItem *)[self pasteboardWriterForIndex:msgIndex];
-		if (pboardItem.types) {
-			[pbItems addObject:pboardItem];
-		    ++countOfItems;
-		}
-
-		msgIndex = [rowIndexes indexGreaterThanIndex:msgIndex];
-	}
-
-	[pboard writeObjects:pbItems];
-	return countOfItems > 0;
-}
-
 // Provides a pasteboard writer for dragging article items
 - (id<NSPasteboardWriting>)tableView:(NSTableView *)tableView pasteboardWriterForRow:(NSInteger)row
 {
     return [self pasteboardWriterForIndex:row];
-}
-
-/* copy
- * Handle the Copy action when the article list has focus.
- */
--(IBAction)copy:(id)sender
-{
-	[self copyTableSelection:articleList.selectedRowIndexes toPasteboard:[NSPasteboard generalPasteboard]];
 }
 
 /* validateMenuItem

--- a/Vienna/Sources/Main window/UnifiedDisplayView.m
+++ b/Vienna/Sources/Main window/UnifiedDisplayView.m
@@ -540,7 +540,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
 
 /* copyTableSelection
  */
--(BOOL)copyIndexesSelection:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard *)pboard
+-(BOOL)copyTableSelection:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
 	NSMutableArray * arrayOfURLs = [[NSMutableArray alloc] init];
 	NSMutableArray * arrayOfTitles = [[NSMutableArray alloc] init];
@@ -606,7 +606,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(BOOL)tableView:(NSTableView*)aListView writeRowsWithIndexes:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-	return [self copyIndexesSelection:rowIndexes toPasteboard:pboard];
+	return [self copyTableSelection:rowIndexes toPasteboard:pboard];
 }
 
 /* copy
@@ -614,7 +614,7 @@ static void *VNAUnifiedDisplayViewObserverContext = &VNAUnifiedDisplayViewObserv
  */
 -(IBAction)copy:(id)sender
 {
-	[self copyIndexesSelection:articleList.selectedRowIndexes toPasteboard:[NSPasteboard generalPasteboard]];
+	[self copyTableSelection:articleList.selectedRowIndexes toPasteboard:[NSPasteboard generalPasteboard]];
 }
 
 /* validateMenuItem

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -120,7 +120,6 @@ extern NSInteger const MA_Default_AutoExpireDuration;
 extern NSInteger const MA_Default_Check_Frequency;
 extern NSInteger const MA_Default_ConcurrentDownloads;
 
-extern NSPasteboardType const VNAPasteboardTypeRSSItem;
 extern NSPasteboardType const VNAPasteboardTypeFolderList;
 extern NSPasteboardType const VNAPasteboardTypeURLName;
 extern NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles;

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -122,7 +122,6 @@ extern NSInteger const MA_Default_ConcurrentDownloads;
 
 extern NSPasteboardType const VNAPasteboardTypeRSSItem;
 extern NSPasteboardType const VNAPasteboardTypeFolderList;
-extern NSPasteboardType const VNAPasteboardTypeRSSSource;
 extern NSPasteboardType const VNAPasteboardTypeURLName;
 extern NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles;
 

--- a/Vienna/Sources/Shared/Constants.h
+++ b/Vienna/Sources/Shared/Constants.h
@@ -121,7 +121,7 @@ extern NSInteger const MA_Default_Check_Frequency;
 extern NSInteger const MA_Default_ConcurrentDownloads;
 
 extern NSPasteboardType const VNAPasteboardTypeFolderList;
-extern NSPasteboardType const VNAPasteboardTypeURLName;
+extern NSPasteboardType const VNAPasteboardTypeURLName NS_SWIFT_NAME(urlName);
 extern NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles;
 
 extern AEKeyword const EditDataItemAppleEventClass;

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -136,7 +136,6 @@ AEKeyword const DataItemSourceFeedURL = 'furl';
 
 // Custom pasteboard types
 NSPasteboardType const VNAPasteboardTypeFolderList = @"uk.co.opencommunity.vienna2.feed.internal";
-NSPasteboardType const VNAPasteboardTypeRSSSource = @"CorePasteboardFlavorType 0x52535373";
 NSPasteboardType const VNAPasteboardTypeRSSItem = @"CorePasteboardFlavorType 0x52535369";
 NSPasteboardType const VNAPasteboardTypeURLName = @"public.url-name";
 NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles = @"WebURLsWithTitlesPboardType";

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -135,7 +135,7 @@ AEKeyword const DataItemSourceHomeURL = 'hurl';
 AEKeyword const DataItemSourceFeedURL = 'furl';
 
 // Custom pasteboard types
-NSPasteboardType const VNAPasteboardTypeFolderList = @"ViennaFolderType";
+NSPasteboardType const VNAPasteboardTypeFolderList = @"uk.co.opencommunity.vienna2.feed.internal";
 NSPasteboardType const VNAPasteboardTypeRSSSource = @"CorePasteboardFlavorType 0x52535373";
 NSPasteboardType const VNAPasteboardTypeRSSItem = @"CorePasteboardFlavorType 0x52535369";
 NSPasteboardType const VNAPasteboardTypeURLName = @"public.url-name";

--- a/Vienna/Sources/Shared/Constants.m
+++ b/Vienna/Sources/Shared/Constants.m
@@ -136,7 +136,6 @@ AEKeyword const DataItemSourceFeedURL = 'furl';
 
 // Custom pasteboard types
 NSPasteboardType const VNAPasteboardTypeFolderList = @"uk.co.opencommunity.vienna2.feed.internal";
-NSPasteboardType const VNAPasteboardTypeRSSItem = @"CorePasteboardFlavorType 0x52535369";
 NSPasteboardType const VNAPasteboardTypeURLName = @"public.url-name";
 NSPasteboardType const VNAPasteboardTypeWebURLsWithTitles = @"WebURLsWithTitlesPboardType";
 


### PR DESCRIPTION
This started as a need to suppress warnings regarding implementation of deprecated methods.

However, significant changes had to be made because: 
- modern methods require pasteboard type names to have a Uniform Type Identifier (UTI) form
- the [list of types which are likely to be interoperable with other applications](https://developer.apple.com/documentation/appkit/nspasteboard/pasteboardtype) is relatively limited
- confronted to multiple items, applications might behave differently according to proposed types
- inside an application, support will vary between copy & paste, drag n'drop and use of sharing services sheet. In general copy & paste will be the most flexible solution, and sharing services the least.

Vienna's supported types for **exporting feeds**:
- public.utf8-plain-text : feed URL
- public.url : feed URL
- public.url-name : feed name
- public.rtf : feed name with a link to feed URL
- public.utf16-external-plain-text : feed name

Vienna's supported types for **importing feeds (via drag and drop)**:
- public.utf8-plain-text : feed URL
- public.url : feed URL
- WebURLsWithTitlesPboardType : legacy Safari type passing feed name and feed URL

Vienna's supported  types for **exporting articles**:
- public.url : article link
- public.url-name : article title
- public.utf8-plain-text : article title plus summary
- public.html : HTML content
